### PR TITLE
fix: plot generation returns blank image due to OUTPUT_PATH override

### DIFF
--- a/paperbanana/agents/visualizer.py
+++ b/paperbanana/agents/visualizer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import tempfile
@@ -153,6 +154,11 @@ class VisualizerAgent(BaseAgent):
 
     def _execute_plot_code(self, code: str, output_path: str) -> bool:
         """Execute matplotlib code in a subprocess to generate a plot."""
+        # Strip any OUTPUT_PATH assignments from VLM-generated code so the
+        # injected value below is authoritative (the VLM is prompted to set
+        # OUTPUT_PATH itself, which would override the injected line).
+        code = re.sub(r'^OUTPUT_PATH\s*=\s*["\'].*["\']\s*$', '', code, flags=re.MULTILINE)
+
         # Inject the output path
         full_code = f'OUTPUT_PATH = "{output_path}"\n{code}'
 


### PR DESCRIPTION
## Summary

- `generate_plot` returns a blank white 1024x768 placeholder instead of the actual matplotlib plot
- Root cause: the VLM-generated code sets its own `OUTPUT_PATH` variable (as instructed by the prompt template), which overrides the value injected by `_execute_plot_code` on line 1 of the script
- The `savefig()` call writes to the VLM's arbitrary relative path (e.g. `revenue_by_quarter.png`), and the existence check on the intended path fails, triggering the placeholder fallback
- Fix: strip `OUTPUT_PATH` assignments from VLM-generated code before prepending the authoritative value

## Reproduction

1. Call `generate_plot` with any valid data/intent
2. Observe: tool returns a 4KB blank white PNG (the placeholder at `visualizer.py:136`)
3. The actual plot is saved to a relative path in the working directory (e.g. `revenue_by_quarter.png`)

## Test plan

- [ ] Call `generate_plot` via MCP tool or CLI and verify the returned image contains visible plot content
- [ ] Verify the output file is saved to the pipeline's expected output directory, not a relative path

🤖 Generated with [Claude Code](https://claude.com/claude-code)