### PR TITLE
fix: increase retry attempts and waiting time

### DIFF
--- a/paperbanana/providers/vlm/gemini.py
+++ b/paperbanana/providers/vlm/gemini.py
@@ -49,7 +49,7 @@ class GeminiVLM(VLMProvider):
     def is_available(self) -> bool:
         return self._api_key is not None
 
-    @retry(stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=10))
+    @retry(stop=stop_after_attempt(8), wait=wait_exponential(min=2, max=120))
     async def generate(
         self,
         prompt: str,


### PR DESCRIPTION
This PR aims to resolve #10, which is caused by HTTP 429 (Too Many Requests) errors encountered by free-tier users. To better handle rate limiting, we:

- Increase retry attempts from 3 to 8
- Increase exponential backoff from 1-10s to 2-120s