### PR TITLE
Fix UnicodeEncodeError on Windows CLI

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -100,7 +100,7 @@ def generate(
         return await pipeline.generate(gen_input)
 
     with Progress(
-        SpinnerColumn(),
+        SpinnerColumn(spinner_name="line"),  # ASCII-safe spinner for Windows compatibility
         TextColumn("[progress.description]{task.description}"),
         console=console,
     ) as progress:


### PR DESCRIPTION
## Summary

- Fixes the `UnicodeEncodeError: 'charmap' codec can't encode character '\u280b'` error on Windows
- Changed the Rich spinner from default (Braille characters) to `line` spinner (ASCII: `- \ | /`)
- Braille characters like `⠋` (`\u280b`) are not supported by Windows console's default code page (cp1252)

## Root Cause

The default `SpinnerColumn()` in Rich uses Braille pattern characters for animation. Windows Command Prompt uses code page 1252 (or similar locale-specific encoding) which cannot encode these Unicode characters, causing Python to raise `UnicodeEncodeError`.

## Solution

Use `SpinnerColumn(spinner_name="line")` which uses ASCII characters (`- \ | /`) that work on all terminal encodings.

## Test Plan

- [ ] Verify CLI works on Windows 11 with Python 3.13
- [ ] Verify CLI still works on macOS/Linux

Fixes #14