### PR TITLE
Add --verbose flag for detailed logging during generation

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -13,6 +13,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.prompt import Prompt
 
 from paperbanana.core.config import Settings
+from paperbanana.core.logging import configure_logging
 from paperbanana.core.types import DiagramType, GenerationInput
 
 app = typer.Typer(
@@ -42,8 +43,12 @@ def generate(
         None, "--iterations", "-n", help="Refinement iterations"
     ),
     config: Optional[str] = typer.Option(None, "--config", help="Path to config YAML file"),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show detailed agent progress and timing"
+    ),
 ):
     """Generate a methodology diagram from a text description."""
+    configure_logging(verbose=verbose)
     # Load source text
     input_path = Path(input)
     if not input_path.exists():
@@ -119,8 +124,12 @@ def plot(
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Output image path"),
     vlm_provider: str = typer.Option("gemini", "--vlm-provider", help="VLM provider"),
     iterations: int = typer.Option(3, "--iterations", "-n", help="Number of refinement iterations"),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show detailed agent progress and timing"
+    ),
 ):
     """Generate a statistical plot from data."""
+    configure_logging(verbose=verbose)
     data_path = Path(data)
     if not data_path.exists():
         console.print(f"[red]Error: Data file not found: {data}[/red]")
@@ -228,8 +237,12 @@ def evaluate(
     vlm_provider: str = typer.Option(
         "gemini", "--vlm-provider", help="VLM provider for evaluation"
     ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show detailed agent progress and timing"
+    ),
 ):
     """Evaluate a generated diagram vs human reference (comparative)."""
+    configure_logging(verbose=verbose)
     from paperbanana.evaluation.judge import VLMJudge
 
     generated_path = Path(generated)

--- a/paperbanana/core/logging.py
+++ b/paperbanana/core/logging.py
@@ -1,0 +1,21 @@
+"""Logging configuration for PaperBanana."""
+
+from __future__ import annotations
+
+import logging
+
+import structlog
+
+
+def configure_logging(*, verbose: bool = False) -> None:
+    """Configure structlog output level.
+
+    Args:
+        verbose: If True, show detailed agent progress and timing at DEBUG level.
+                 If False (default), suppress logs below WARNING for clean output.
+    """
+    level = logging.DEBUG if verbose else logging.WARNING
+
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+    )

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -201,6 +201,11 @@ class PaperBananaPipeline:
             diagram_type=input.diagram_type,
         )
         retrieval_seconds = time.perf_counter() - retrieval_start
+        logger.info(
+            "[Retriever] done",
+            seconds=round(retrieval_seconds, 1),
+            examples_found=len(examples),
+        )
 
         # Step 2: Planner — generate textual description
         logger.info("Phase 1: Planning")
@@ -212,6 +217,10 @@ class PaperBananaPipeline:
             diagram_type=input.diagram_type,
         )
         planning_seconds = time.perf_counter() - planning_start
+        logger.info(
+            "[Planner] done",
+            seconds=round(planning_seconds, 1),
+        )
 
         # Step 3: Stylist — optimize description aesthetics
         logger.info("Phase 1: Styling")
@@ -224,6 +233,10 @@ class PaperBananaPipeline:
             diagram_type=input.diagram_type,
         )
         styling_seconds = time.perf_counter() - styling_start
+        logger.info(
+            "[Stylist] done",
+            seconds=round(styling_seconds, 1),
+        )
 
         # Save planning outputs
         if self.settings.save_iterations:
@@ -254,6 +267,10 @@ class PaperBananaPipeline:
                 iteration=i + 1,
             )
             visualizer_seconds = time.perf_counter() - visualizer_start
+            logger.info(
+                f"[Visualizer] Iteration {i + 1}/{self.settings.refinement_iterations} done",
+                seconds=round(visualizer_seconds, 1),
+            )
 
             # Step 5: Critic — evaluate and provide feedback
             critic_start = time.perf_counter()
@@ -265,6 +282,11 @@ class PaperBananaPipeline:
                 diagram_type=input.diagram_type,
             )
             critic_seconds = time.perf_counter() - critic_start
+            logger.info(
+                "[Critic] done",
+                seconds=round(critic_seconds, 1),
+                needs_revision=critique.needs_revision,
+            )
 
             iteration_record = IterationRecord(
                 iteration=i + 1,

--- a/tests/test_pipeline/test_logging.py
+++ b/tests/test_pipeline/test_logging.py
@@ -1,0 +1,32 @@
+"""Tests for logging configuration."""
+
+from __future__ import annotations
+
+import structlog
+
+from paperbanana.core.logging import configure_logging
+
+
+def test_configure_logging_default_suppresses_info():
+    """Test that default logging sets filtering at WARNING level."""
+    configure_logging(verbose=False)
+    logger = structlog.get_logger().bind()
+    assert "FilteringAtWarning" in type(logger).__name__
+
+
+def test_configure_logging_verbose_enables_debug():
+    """Test that verbose logging sets filtering at DEBUG level."""
+    configure_logging(verbose=True)
+    logger = structlog.get_logger().bind()
+    assert "FilteringAtDebug" in type(logger).__name__
+
+
+def test_configure_logging_verbose_false_then_true():
+    """Test that logging can be reconfigured from quiet to verbose."""
+    configure_logging(verbose=False)
+    logger = structlog.get_logger().bind()
+    assert "FilteringAtWarning" in type(logger).__name__
+
+    configure_logging(verbose=True)
+    logger = structlog.get_logger().bind()
+    assert "FilteringAtDebug" in type(logger).__name__


### PR DESCRIPTION
Fixes #23

Adds `--verbose` / `-v` to `generate`, `plot`, and `evaluate` CLI commands.

**Changes:**
- `paperbanana/core/logging.py` — new `configure_logging()` that sets structlog level (WARNING default, DEBUG when verbose)
- `paperbanana/cli.py` — added `--verbose` flag to all three commands
- `paperbanana/core/pipeline.py` — added `[Retriever]`, `[Planner]`, `[Stylist]`, `[Visualizer]`, `[Critic]` logging hooks with timing
- 3 new tests for logging configuration

Default output unchanged. With `--verbose`, shows agent names and per-step timing.

All 37 tests pass. Ruff passes.