### PR TITLE
Fix UnicodeEncodeError on Windows for non-ASCII VLM output

### DIFF
--- a/paperbanana/__init__.py
+++ b/paperbanana/__init__.py
@@ -1,5 +1,12 @@
 """PaperBanana: Agentic framework for automated academic illustration generation."""
 
+import sys
+
+if sys.platform == "win32":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+
 __version__ = "0.1.0"
 
 from paperbanana.core.pipeline import PaperBananaPipeline


### PR DESCRIPTION
## Summary

- Fixes `UnicodeEncodeError: 'charmap' codec can't encode character '\u03b2'` on Windows when the critic agent returns text containing Greek letters (β, α, etc.)
- Reconfigures `stdout`/`stderr` to UTF-8 with `errors="replace"` at package import time, but only on Windows (`sys.platform == "win32"`)
- Covers all entry points: CLI commands, MCP server, and direct library usage — not just the CLI path

## Root Cause

On Windows, the default console encoding is `cp1252`. When the critic agent's suggestions contain Unicode characters (common for LaTeX/math-heavy papers), structlog's log output crashes at write time. The images are generated successfully but the process exits with code 1, breaking CI/automation pipelines.

## What Changed

**`paperbanana/__init__.py`** — Added a 4-line guard that runs on import:
- Checks `sys.platform == "win32"`
- Reconfigures `sys.stdout` and `sys.stderr` to `encoding="utf-8"` with `errors="replace"`
- `hasattr` guard handles edge cases where streams are redirected (e.g., pytest capture)

## Test Plan

- [x] All 47 existing tests pass
- [x] Package imports cleanly after the change
- [ ] Verify on Windows with cp1252 console encoding and a LaTeX source containing Greek symbols

Fixes #33