### PR TITLE
fix: update default VLM model from deprecated gemini-2.0-flash to gemini-2.5-flash

### DIFF
--- a/examples/generate_diagram.py
+++ b/examples/generate_diagram.py
@@ -39,7 +39,7 @@ async def main():
 
     settings = Settings(
         vlm_provider="gemini",
-        vlm_model="gemini-2.0-flash",
+        vlm_model="gemini-2.5-flash",
         image_provider="google_imagen",
         image_model="gemini-3-pro-image-preview",
         refinement_iterations=2,

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -16,7 +16,7 @@ class VLMConfig(BaseSettings):
     """VLM provider configuration."""
 
     provider: str = "gemini"
-    model: str = "gemini-2.0-flash"
+    model: str = "gemini-2.5-flash"
 
 
 class ImageConfig(BaseSettings):
@@ -57,7 +57,7 @@ class Settings(BaseSettings):
 
     # Provider settings
     vlm_provider: str = Field(default="gemini", alias="VLM_PROVIDER")
-    vlm_model: str = Field(default="gemini-2.0-flash", alias="VLM_MODEL")
+    vlm_model: str = Field(default="gemini-2.5-flash", alias="VLM_MODEL")
     image_provider: str = Field(default="google_imagen", alias="IMAGE_PROVIDER")
     image_model: str = Field(default="gemini-3-pro-image-preview", alias="IMAGE_MODEL")
 

--- a/paperbanana/providers/vlm/gemini.py
+++ b/paperbanana/providers/vlm/gemini.py
@@ -20,7 +20,7 @@ class GeminiVLM(VLMProvider):
     Free tier: https://makersuite.google.com/app/apikey
     """
 
-    def __init__(self, api_key: Optional[str] = None, model: str = "gemini-2.0-flash"):
+    def __init__(self, api_key: Optional[str] = None, model: str = "gemini-2.5-flash"):
         self._api_key = api_key
         self._model = model
         self._client = None

--- a/tests/test_providers/test_registry.py
+++ b/tests/test_providers/test_registry.py
@@ -12,12 +12,12 @@ def test_create_gemini_vlm():
     """Test creating a Gemini VLM provider."""
     settings = Settings(
         vlm_provider="gemini",
-        vlm_model="gemini-2.0-flash",
+        vlm_model="gemini-2.5-flash",
         google_api_key="test-key",
     )
     vlm = ProviderRegistry.create_vlm(settings)
     assert vlm.name == "gemini"
-    assert vlm.model_name == "gemini-2.0-flash"
+    assert vlm.model_name == "gemini-2.5-flash"
 
 
 def test_create_google_imagen_gen():


### PR DESCRIPTION
## Summary

Updates the default VLM model from `gemini-2.0-flash` to `gemini-2.5-flash` across the entire codebase.

## Problem

`gemini-2.0-flash` has been deprecated by Google and returns `404 NOT_FOUND` for new users, breaking the pipeline out of the box.

## Changes

- `paperbanana/core/config.py`: Updated default model in `VLMConfig` and `Settings`
- `paperbanana/providers/vlm/gemini.py`: Updated default parameter
- `configs/config.yaml` and `configs/provider/vlm/gemini.yaml`: Updated defaults
- `tests/test_providers/test_registry.py`: Updated test expectations
- `examples/generate_diagram.py`: Updated example
- `README.md`: Updated model reference in provider table

Existing users with `VLM_MODEL` env var or custom config are unaffected.

Fixes #44