### PR TITLE
feat: add --dry-run flag to generate command

### DIFF
--- a/tests/test_cli_dry_run.py
+++ b/tests/test_cli_dry_run.py
@@ -1,0 +1,63 @@
+"""Tests for the --dry-run CLI flag."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from paperbanana.cli import app
+
+runner = CliRunner()
+
+
+def test_dry_run_with_valid_input():
+    """Dry run with valid input file should succeed."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("This is a methodology description for testing purposes.")
+        f.flush()
+
+        result = runner.invoke(
+            app,
+            ["generate", "--input", f.name, "--caption", "Test caption", "--dry-run"],
+        )
+
+    assert result.exit_code == 0
+    assert "Dry Run" in result.output
+    assert "All checks passed" in result.output
+
+
+def test_dry_run_missing_input_file():
+    """Dry run with nonexistent input file should report the issue."""
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            "--input",
+            "/nonexistent/path.txt",
+            "--caption",
+            "Test",
+            "--dry-run",
+        ],
+    )
+
+    assert "not found" in result.output
+
+
+def test_dry_run_no_input():
+    """Dry run without --input should still show config and warn."""
+    result = runner.invoke(app, ["generate", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "Dry Run" in result.output
+    assert "No --input provided" in result.output
+
+
+def test_dry_run_shows_config():
+    """Dry run should display provider and model configuration."""
+    result = runner.invoke(app, ["generate", "--dry-run"])
+
+    assert "VLM provider" in result.output
+    assert "VLM model" in result.output
+    assert "Image provider" in result.output


### PR DESCRIPTION
## Summary

Adds a `--dry-run` flag to the `paperbanana generate` command that validates inputs and shows configuration without making any API calls.

## Motivation

Users should be able to verify their setup (API keys, input files, config) before spending API credits. Also useful for CI/CD pipelines and debugging.

Closes #20

## Changes

- **`paperbanana/cli.py`**: Added `--dry-run` option to `generate` command. When enabled, displays provider config, validates input file, caption, API keys, and reference set, then exits without calling the pipeline.
- **`tests/test_cli_dry_run.py`**: 4 test cases covering valid input, missing file, no input, and config display.

## Usage

```bash
# Check setup without API calls
paperbanana generate --input method.txt --caption 'Test' --dry-run

# Verify config only (no input needed)
paperbanana generate --dry-run
```

## Example Output

```
╭─ PaperBanana — Dry Run ───────────────────╮
│ VLM provider:   gemini                     │
│ VLM model:      gemini-2.5-flash           │
│ Image provider: google_imagen              │
│ ...                                        │
╰────────────────────────────────────────────╯

✓ Input file: method.txt (1234 chars)
✓ Caption: Overview of our framework
✓ GOOGLE_API_KEY: configured
✓ Reference set: 42 examples

✓ All checks passed — ready to generate
```