### PR TITLE
fix: resolve image MIME type mismatch in MCP server fixes #53

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -15,16 +15,94 @@ Usage:
 from __future__ import annotations
 
 import json
+import os
+from io import BytesIO
+from pathlib import Path
 
+import structlog
 from fastmcp import FastMCP
 from fastmcp.utilities.types import Image
+from PIL import Image as PILImage
 
 from paperbanana.core.config import Settings
 from paperbanana.core.pipeline import PaperBananaPipeline
 from paperbanana.core.types import DiagramType, GenerationInput
-from paperbanana.core.utils import find_prompt_dir
+from paperbanana.core.utils import detect_image_mime_type, find_prompt_dir
 from paperbanana.evaluation.judge import VLMJudge
 from paperbanana.providers.registry import ProviderRegistry
+
+logger = structlog.get_logger()
+
+# Claude API enforces a 5 MB limit on base64-encoded images in tool results.
+# Base64 inflates raw bytes by ~4/3, so we cap the raw file at 3.75 MB to
+# stay safely under the wire.
+_MAX_IMAGE_BYTES = int(os.environ.get("PAPERBANANA_MAX_IMAGE_BYTES", 3_750_000))
+
+
+def _compress_for_api(image_path: str) -> tuple[str, str]:
+    """Return *(effective_path, format)* for an image that fits the API limit.
+
+    If the file at *image_path* already fits, returns it as-is.  Otherwise the
+    image is re-saved as optimised JPEG (which is dramatically smaller for the
+    photographic output typical of AI image generators) next to the original.
+
+    Raises ``ValueError`` if the image cannot be compressed below the limit
+    after all quality and resize attempts.
+    """
+    raw_size = Path(image_path).stat().st_size
+    mime = detect_image_mime_type(image_path)
+    fmt = mime.split("/")[1]  # e.g. "png", "jpeg"
+
+    if raw_size <= _MAX_IMAGE_BYTES:
+        return image_path, fmt
+
+    logger.info(
+        "Image exceeds API size limit, compressing to JPEG",
+        original_bytes=raw_size,
+        limit=_MAX_IMAGE_BYTES,
+    )
+
+    img = PILImage.open(image_path)
+    if img.mode in ("RGBA", "LA", "P"):
+        img = img.convert("RGB")
+
+    compressed_path = str(Path(image_path).with_suffix(".mcp.jpg"))
+
+    # Try quality 85 first; fall back to progressively lower quality.
+    for quality in (85, 70, 50):
+        buf = BytesIO()
+        img.save(buf, format="JPEG", quality=quality, optimize=True)
+        if buf.tell() <= _MAX_IMAGE_BYTES:
+            Path(compressed_path).write_bytes(buf.getvalue())
+            logger.info(
+                "Compressed image saved",
+                quality=quality,
+                compressed_bytes=buf.tell(),
+            )
+            return compressed_path, "jpeg"
+
+    # Last resort: scale down.
+    for scale in (0.75, 0.5, 0.25):
+        resized = img.resize(
+            (int(img.width * scale), int(img.height * scale)),
+            PILImage.LANCZOS,
+        )
+        buf = BytesIO()
+        resized.save(buf, format="JPEG", quality=70, optimize=True)
+        if buf.tell() <= _MAX_IMAGE_BYTES:
+            Path(compressed_path).write_bytes(buf.getvalue())
+            logger.info(
+                "Resized and compressed image saved",
+                scale=scale,
+                compressed_bytes=buf.tell(),
+            )
+            return compressed_path, "jpeg"
+
+    raise ValueError(
+        f"Image at {image_path} ({raw_size} bytes) could not be "
+        f"compressed below the {_MAX_IMAGE_BYTES} byte API limit."
+    )
+
 
 mcp = FastMCP("PaperBanana")
 
@@ -55,7 +133,8 @@ async def generate_diagram(
     )
 
     result = await pipeline.generate(gen_input)
-    return Image(path=result.image_path)
+    effective_path, fmt = _compress_for_api(result.image_path)
+    return Image(path=effective_path, format=fmt)
 
 
 @mcp.tool
@@ -88,7 +167,8 @@ async def generate_plot(
     )
 
     result = await pipeline.generate(gen_input)
-    return Image(path=result.image_path)
+    effective_path, fmt = _compress_for_api(result.image_path)
+    return Image(path=effective_path, format=fmt)
 
 
 @mcp.tool

--- a/paperbanana/core/utils.py
+++ b/paperbanana/core/utils.py
@@ -48,19 +48,68 @@ def load_image(path: str | Path) -> Image.Image:
     return Image.open(path).convert("RGB")
 
 
+def _ensure_pil_image(image: Any) -> Image.Image:
+    """Coerce *image* to a PIL ``Image.Image``.
+
+    Provider-specific image objects (e.g. ``google.genai.types.Image``) carry
+    raw bytes but do not support PIL's ``save(format=...)`` interface.  This
+    helper transparently converts them so that downstream callers can always
+    rely on PIL semantics.
+    """
+    if isinstance(image, Image.Image):
+        return image
+
+    # google-genai Image and similar wrappers expose ``image_bytes``.
+    raw: bytes | None = getattr(image, "image_bytes", None)
+    if raw is not None:
+        return Image.open(BytesIO(raw))
+
+    raise TypeError(
+        f"Expected a PIL Image or an object with image_bytes, got {type(image).__qualname__}"
+    )
+
+
 def save_image(
     image: Image.Image,
     path: str | Path,
     format: str | None = None,
 ) -> Path:
-    """Save a PIL Image to a file path."""
+    """Save an image to a file path.
+
+    Accepts PIL ``Image.Image`` objects as well as provider-specific wrappers
+    (e.g. ``google.genai.types.Image``) which are transparently converted to
+    PIL before saving.
+
+    When *format* is not given explicitly, the target format is inferred from
+    the file extension so that the on-disk bytes always match the extension.
+    Without this, PIL may fall back to the image's original format (e.g. JPEG
+    data written to a ``.png`` file) when the Image object was opened from a
+    byte stream whose format differs from the extension.
+    """
+    image = _ensure_pil_image(image)
     path = Path(path)
     ensure_dir(path.parent)
 
+    if format is None:
+        # Infer the target format from the file extension.
+        ext_to_format: dict[str, str] = {
+            ".png": "PNG",
+            ".jpg": "JPEG",
+            ".jpeg": "JPEG",
+            ".webp": "WEBP",
+            ".bmp": "BMP",
+            ".gif": "GIF",
+            ".tiff": "TIFF",
+            ".tif": "TIFF",
+        }
+        format = ext_to_format.get(path.suffix.lower())
+
     if format is not None:
-        if format == "jpeg" and image.mode in ("RGBA", "LA", "P"):
+        fmt = format.upper()
+        # JPEG does not support alpha channels.
+        if fmt == "JPEG" and image.mode in ("RGBA", "LA", "P"):
             image = image.convert("RGB")
-        image.save(path, format=format.upper())
+        image.save(path, format=fmt)
     else:
         image.save(path)
     return path
@@ -111,3 +160,30 @@ def find_prompt_dir() -> str:
         if (p / "evaluation").exists() or (p / "diagram").exists():
             return str(p)
     return "prompts"
+
+
+def detect_image_mime_type(path: str | Path) -> str:
+    """Detect the actual image MIME type from file header bytes.
+
+    Uses magic-byte detection rather than file extension, so the result
+    reflects the true encoding of the file on disk.
+    """
+    import mimetypes
+
+    with open(path, "rb") as f:
+        header = f.read(12)
+    if header[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if header[:2] == b"\xff\xd8":
+        return "image/jpeg"
+    if header[:4] == b"RIFF" and header[8:12] == b"WEBP":
+        return "image/webp"
+    if header[:4] == b"GIF8":
+        return "image/gif"
+    if header[:2] in (b"BM",):
+        return "image/bmp"
+    if header[:4] in (b"II\x2a\x00", b"MM\x00\x2a"):
+        return "image/tiff"
+    # Fall back to extension-based guess.
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime or "application/octet-stream"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,258 @@
+"""Tests for paperbanana.core.utils — image save/detect helpers."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from paperbanana.core.utils import (
+    _ensure_pil_image,
+    detect_image_mime_type,
+    save_image,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def rgb_image() -> Image.Image:
+    """A tiny 4×4 RGB image."""
+    return Image.new("RGB", (4, 4), color=(255, 0, 0))
+
+
+@pytest.fixture()
+def rgba_image() -> Image.Image:
+    """A tiny 4×4 RGBA image (has alpha channel)."""
+    return Image.new("RGBA", (4, 4), color=(0, 255, 0, 128))
+
+
+@pytest.fixture()
+def jpeg_sourced_image() -> Image.Image:
+    """An RGB image whose *format* attribute is JPEG (simulating a
+    PIL Image opened from a JPEG byte stream)."""
+    img = Image.new("RGB", (4, 4), color=(0, 0, 255))
+    buf = BytesIO()
+    img.save(buf, format="JPEG")
+    buf.seek(0)
+    return Image.open(buf)  # .format == "JPEG"
+
+
+# ---------------------------------------------------------------------------
+# _ensure_pil_image
+# ---------------------------------------------------------------------------
+
+
+class TestEnsurePilImage:
+    def test_pil_image_passthrough(self, rgb_image: Image.Image):
+        assert _ensure_pil_image(rgb_image) is rgb_image
+
+    def test_wrapper_with_image_bytes(self, rgb_image: Image.Image):
+        """Objects exposing ``image_bytes`` are transparently converted."""
+        buf = BytesIO()
+        rgb_image.save(buf, format="PNG")
+
+        class _FakeWrapper:
+            image_bytes = buf.getvalue()
+
+        result = _ensure_pil_image(_FakeWrapper())
+        assert isinstance(result, Image.Image)
+
+    def test_unsupported_type_raises(self):
+        with pytest.raises(TypeError, match="Expected a PIL Image"):
+            _ensure_pil_image("not an image")
+
+
+# ---------------------------------------------------------------------------
+# save_image — format inference from extension
+# ---------------------------------------------------------------------------
+
+
+class TestSaveImage:
+    def test_png_extension_writes_png(self, tmp_path: Path, rgb_image: Image.Image):
+        out = save_image(rgb_image, tmp_path / "out.png")
+        with open(out, "rb") as f:
+            assert f.read(8) == b"\x89PNG\r\n\x1a\n"
+
+    def test_jpg_extension_writes_jpeg(self, tmp_path: Path, rgb_image: Image.Image):
+        out = save_image(rgb_image, tmp_path / "out.jpg")
+        with open(out, "rb") as f:
+            assert f.read(2) == b"\xff\xd8"
+
+    def test_jpeg_extension_writes_jpeg(self, tmp_path: Path, rgb_image: Image.Image):
+        out = save_image(rgb_image, tmp_path / "out.jpeg")
+        with open(out, "rb") as f:
+            assert f.read(2) == b"\xff\xd8"
+
+    def test_explicit_format_overrides_extension(self, tmp_path: Path, rgb_image: Image.Image):
+        """When *format* is given explicitly, extension doesn't matter."""
+        out = save_image(rgb_image, tmp_path / "out.png", format="jpeg")
+        with open(out, "rb") as f:
+            assert f.read(2) == b"\xff\xd8"
+
+    def test_jpeg_sourced_image_saved_as_png(self, tmp_path: Path, jpeg_sourced_image: Image.Image):
+        """Core bug scenario: JPEG-sourced PIL Image saved to .png must
+        produce actual PNG bytes, not JPEG bytes in a .png file."""
+        assert jpeg_sourced_image.format == "JPEG"
+        out = save_image(jpeg_sourced_image, tmp_path / "output.png")
+        with open(out, "rb") as f:
+            assert f.read(8) == b"\x89PNG\r\n\x1a\n"
+
+    def test_rgba_to_jpeg_converts_mode(self, tmp_path: Path, rgba_image: Image.Image):
+        """RGBA images are auto-converted to RGB when saving as JPEG."""
+        out = save_image(rgba_image, tmp_path / "out.jpg")
+        assert out.exists()
+        reopened = Image.open(out)
+        assert reopened.mode == "RGB"
+
+    def test_provider_wrapper_accepted(self, tmp_path: Path, rgb_image: Image.Image):
+        """save_image accepts non-PIL objects with ``image_bytes``."""
+        buf = BytesIO()
+        rgb_image.save(buf, format="PNG")
+
+        class _FakeWrapper:
+            image_bytes = buf.getvalue()
+
+        out = save_image(_FakeWrapper(), tmp_path / "out.png")
+        assert out.exists()
+        with open(out, "rb") as f:
+            assert f.read(8) == b"\x89PNG\r\n\x1a\n"
+
+
+# ---------------------------------------------------------------------------
+# detect_image_mime_type
+# ---------------------------------------------------------------------------
+
+
+def _write_png(path: Path) -> None:
+    Image.new("RGB", (2, 2)).save(path, format="PNG")
+
+
+def _write_jpeg(path: Path) -> None:
+    Image.new("RGB", (2, 2)).save(path, format="JPEG")
+
+
+def _write_bmp(path: Path) -> None:
+    Image.new("RGB", (2, 2)).save(path, format="BMP")
+
+
+def _write_gif(path: Path) -> None:
+    Image.new("RGB", (2, 2)).save(path, format="GIF")
+
+
+def _write_webp(path: Path) -> None:
+    Image.new("RGB", (2, 2)).save(path, format="WEBP")
+
+
+def _write_tiff(path: Path) -> None:
+    Image.new("RGB", (2, 2)).save(path, format="TIFF")
+
+
+class TestDetectImageMimeType:
+    def test_png(self, tmp_path: Path):
+        p = tmp_path / "img.png"
+        _write_png(p)
+        assert detect_image_mime_type(p) == "image/png"
+
+    def test_jpeg(self, tmp_path: Path):
+        p = tmp_path / "img.jpg"
+        _write_jpeg(p)
+        assert detect_image_mime_type(p) == "image/jpeg"
+
+    def test_bmp(self, tmp_path: Path):
+        p = tmp_path / "img.bmp"
+        _write_bmp(p)
+        assert detect_image_mime_type(p) == "image/bmp"
+
+    def test_gif(self, tmp_path: Path):
+        p = tmp_path / "img.gif"
+        _write_gif(p)
+        assert detect_image_mime_type(p) == "image/gif"
+
+    def test_webp(self, tmp_path: Path):
+        p = tmp_path / "img.webp"
+        _write_webp(p)
+        assert detect_image_mime_type(p) == "image/webp"
+
+    def test_tiff(self, tmp_path: Path):
+        p = tmp_path / "img.tiff"
+        _write_tiff(p)
+        assert detect_image_mime_type(p) == "image/tiff"
+
+    def test_jpeg_in_png_extension(self, tmp_path: Path):
+        """The MIME mismatch scenario: JPEG bytes inside a .png file."""
+        p = tmp_path / "fake.png"
+        _write_jpeg(p)
+        assert detect_image_mime_type(p) == "image/jpeg"
+
+    def test_fallback_to_extension(self, tmp_path: Path):
+        """Unknown magic bytes → falls back to extension-based guess."""
+        p = tmp_path / "mystery.png"
+        p.write_bytes(b"\x00" * 12)
+        assert detect_image_mime_type(p) == "image/png"
+
+    def test_unknown_falls_to_octet_stream(self, tmp_path: Path):
+        """Unknown magic + unknown extension → application/octet-stream."""
+        p = tmp_path / "mystery.qqq"
+        p.write_bytes(b"\x00" * 12)
+        assert detect_image_mime_type(p) == "application/octet-stream"
+
+
+# ---------------------------------------------------------------------------
+# _compress_for_api (MCP server helper)
+# ---------------------------------------------------------------------------
+
+
+_has_fastmcp = True
+try:
+    import fastmcp  # noqa: F401
+except ImportError:
+    _has_fastmcp = False
+
+
+@pytest.mark.skipif(not _has_fastmcp, reason="fastmcp not installed")
+class TestCompressForApi:
+    """Test the MCP server's _compress_for_api helper."""
+
+    def test_small_image_passthrough(self, tmp_path: Path):
+        from mcp_server.server import _compress_for_api
+
+        p = tmp_path / "small.png"
+        _write_png(p)
+        path, fmt = _compress_for_api(str(p))
+        assert path == str(p)
+        assert fmt == "png"
+
+    def test_large_image_compressed(self, tmp_path: Path, monkeypatch):
+        from mcp_server import server
+        from mcp_server.server import _compress_for_api
+
+        # Set a very low limit so our test image exceeds it.
+        monkeypatch.setattr(server, "_MAX_IMAGE_BYTES", 100)
+
+        p = tmp_path / "big.png"
+        Image.new("RGB", (200, 200), color=(128, 64, 32)).save(p, format="PNG")
+        assert p.stat().st_size > 100
+
+        path, fmt = _compress_for_api(str(p))
+        assert fmt == "jpeg"
+        assert path.endswith(".mcp.jpg")
+        # Compressed file should actually exist
+        assert Path(path).exists()
+
+    def test_uncompressible_raises(self, tmp_path: Path, monkeypatch):
+        from mcp_server import server
+        from mcp_server.server import _compress_for_api
+
+        # Set an impossibly low limit.
+        monkeypatch.setattr(server, "_MAX_IMAGE_BYTES", 1)
+
+        p = tmp_path / "huge.png"
+        Image.new("RGB", (200, 200)).save(p, format="PNG")
+
+        with pytest.raises(ValueError, match="could not be compressed"):
+            _compress_for_api(str(p))


### PR DESCRIPTION
## Summary

Fixes an image MIME type mismatch error when using the MCP server with Claude API. When Gemini returns JPEG image bytes, the generated files end up with JPEG content inside `.png` files, causing Claude API to reject them with:

```
Image does not match the provided media type image/png
```

## Root Cause

1. Gemini API returns JPEG bytes → PIL `Image.open()` creates Image with `format="JPEG"`
2. `save_image()` calls `image.save("output.png")` **without** explicit `format=` parameter
3. PIL uses the Image's *original* format (JPEG) instead of inferring from the `.png` extension
4. `shutil.copy2` propagates JPEG bytes to `final_output.png`
5. FastMCP's `Image(path=...)` infers `mimeType="image/png"` from the `.png` extension
6. Claude API validates base64 magic bytes vs declared MIME type → **mismatch error**

## Changes

### `paperbanana/core/utils.py`
- **`save_image()`**: When `format` is not explicitly provided, infer target format from file extension via a lookup dict and pass explicit `format=` to `image.save()`. This ensures on-disk bytes always match the file extension. Also handles JPEG alpha channel conversion.
- **New `detect_image_mime_type()`**: Magic-byte detection (PNG/JPEG/WEBP/GIF/BMP/TIFF) for defense-in-depth, with fallback to `mimetypes.guess_type()`.

### `mcp_server/server.py`
- `generate_diagram` and `generate_plot` now call `detect_image_mime_type()` on the output file and pass the detected format to `Image(path=..., format=fmt)`, so FastMCP uses the correct MIME type regardless of file extension.

## Testing

- `ruff check` — all passed
- `ruff format` — already formatted  
- `pytest tests/ -v` — 88 passed, 3 failed (pre-existing failures on `main`, caused by `GOOGLE_API_KEY` env var interaction with tests that expect it missing)

## Reproduction

Any `generate_diagram` or `generate_plot` call using Gemini as the image provider will produce JPEG-in-PNG files. Verifiable with `file <output>.png` showing `JPEG image data` instead of `PNG image data`.