### PR TITLE
fix: update default VLM model from gemini-2.0-flash to gemini-2.5-flash

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -4,7 +4,7 @@
 # Provider settings
 vlm:
   provider: gemini
-  model: gemini-2.0-flash
+  model: gemini-2.5-flash
 
 image:
   provider: google_imagen

--- a/configs/provider/vlm/gemini.yaml
+++ b/configs/provider/vlm/gemini.yaml
@@ -7,7 +7,7 @@ capabilities:
   - vision_input
   - json_mode
 config:
-  model: gemini-2.0-flash
+  model: gemini-2.5-flash
   api_key: ${GOOGLE_API_KEY}
   temperature: 1.0
   max_tokens: 4096

--- a/examples/generate_diagram.py
+++ b/examples/generate_diagram.py
@@ -39,7 +39,7 @@ async def main():
 
     settings = Settings(
         vlm_provider="gemini",
-        vlm_model="gemini-2.0-flash",
+        vlm_model="gemini-2.5-flash",
         image_provider="google_imagen",
         image_model="gemini-3-pro-image-preview",
         refinement_iterations=2,

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -16,7 +16,7 @@ class VLMConfig(BaseSettings):
     """VLM provider configuration."""
 
     provider: str = "gemini"
-    model: str = "gemini-2.0-flash"
+    model: str = "gemini-2.5-flash"
 
 
 class ImageConfig(BaseSettings):
@@ -57,7 +57,7 @@ class Settings(BaseSettings):
 
     # Provider settings
     vlm_provider: str = Field(default="gemini", alias="VLM_PROVIDER")
-    vlm_model: str = Field(default="gemini-2.0-flash", alias="VLM_MODEL")
+    vlm_model: str = Field(default="gemini-2.5-flash", alias="VLM_MODEL")
     image_provider: str = Field(default="google_imagen", alias="IMAGE_PROVIDER")
     image_model: str = Field(default="gemini-3-pro-image-preview", alias="IMAGE_MODEL")
 

--- a/paperbanana/providers/vlm/gemini.py
+++ b/paperbanana/providers/vlm/gemini.py
@@ -20,7 +20,7 @@ class GeminiVLM(VLMProvider):
     Free tier: https://makersuite.google.com/app/apikey
     """
 
-    def __init__(self, api_key: Optional[str] = None, model: str = "gemini-2.0-flash"):
+    def __init__(self, api_key: Optional[str] = None, model: str = "gemini-2.5-flash"):
         self._api_key = api_key
         self._model = model
         self._client = None

--- a/tests/test_providers/test_registry.py
+++ b/tests/test_providers/test_registry.py
@@ -12,12 +12,12 @@ def test_create_gemini_vlm():
     """Test creating a Gemini VLM provider."""
     settings = Settings(
         vlm_provider="gemini",
-        vlm_model="gemini-2.0-flash",
+        vlm_model="gemini-2.5-flash",
         google_api_key="test-key",
     )
     vlm = ProviderRegistry.create_vlm(settings)
     assert vlm.name == "gemini"
-    assert vlm.model_name == "gemini-2.0-flash"
+    assert vlm.model_name == "gemini-2.5-flash"
 
 
 def test_create_google_imagen_gen():


### PR DESCRIPTION
gemini-2.0-flash has been discontinued by Google and returns 404 NOT_FOUND for new users. Update all default references to gemini-2.5-flash so that `paperbanana generate` works out of the box.

## fix: update default VLM model from gemini-2.0-flash to gemini-2.5-flash

## Summary
- `gemini-2.0-flash` has been discontinued by Google and returns `404 NOT_FOUND` for new users
- Updated all default VLM model references to `gemini-2.5-flash` so that `paperbanana generate` works out of the box

## Changes
| File | What changed |
|---|---|
| `paperbanana/core/config.py` | Default in `VLMConfig.model` and `Settings.vlm_model` |
| `paperbanana/providers/vlm/gemini.py` | Default argument in `GeminiVLM.__init__` |
| `configs/config.yaml` | Default config |
| `configs/provider/vlm/gemini.yaml` | Gemini provider config |
| `examples/generate_diagram.py` | Example script |
| `tests/test_providers/test_registry.py` | Test assertions |

## Reproduction
```bash
paperbanana generate --input method.txt --caption 'Overview of our framework'
# Before: RetryError → 404 NOT_FOUND "models/gemini-2.0-flash is no longer available to new users"
# After:  Completes successfully (3 iterations, ~212s)
```

## Test plan
- [x] `paperbanana generate --input method.txt --caption 'Overview of our framework'` completes with 3 iterations
- [ ] `pytest tests/` passes (53/54 pass; 1 pre-existing failure unrelated to this change)
- [ ] Verify with `--vlm-model` CLI override still works for users who explicitly specify a model


