### PR TITLE
fix: resolve MIME type mismatch in MCP `generate_diagram` response

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -27,7 +27,7 @@ from PIL import Image as PILImage
 from paperbanana.core.config import Settings
 from paperbanana.core.pipeline import PaperBananaPipeline
 from paperbanana.core.types import DiagramType, GenerationInput
-from paperbanana.core.utils import detect_image_mime_type, find_prompt_dir
+from paperbanana.core.utils import detect_format_from_bytes, find_prompt_dir
 from paperbanana.evaluation.judge import VLMJudge
 from paperbanana.providers.registry import ProviderRegistry
 
@@ -39,47 +39,47 @@ logger = structlog.get_logger()
 _MAX_IMAGE_BYTES = int(os.environ.get("PAPERBANANA_MAX_IMAGE_BYTES", 3_750_000))
 
 
-def _compress_for_api(image_path: str) -> tuple[str, str]:
-    """Return *(effective_path, format)* for an image that fits the API limit.
+def _compress_for_api(image_path: str) -> tuple[bytes, str]:
+    """Return *(image_bytes, format)* for an image that fits the API limit.
 
-    If the file at *image_path* already fits, returns it as-is.  Otherwise the
-    image is re-saved as optimised JPEG (which is dramatically smaller for the
-    photographic output typical of AI image generators) next to the original.
+    Reads the file, detects its true format from magic bytes, and returns
+    the raw bytes paired with the matching format string.  This guarantees
+    that the declared MIME type always matches the actual image encoding.
+
+    If the file exceeds the API size limit the image is re-encoded as
+    optimised JPEG (dramatically smaller for photographic AI output).
 
     Raises ``ValueError`` if the image cannot be compressed below the limit
     after all quality and resize attempts.
     """
-    raw_size = Path(image_path).stat().st_size
-    mime = detect_image_mime_type(image_path)
-    fmt = mime.split("/")[1]  # e.g. "png", "jpeg"
+    raw_data = Path(image_path).read_bytes()
+    fmt = detect_format_from_bytes(raw_data)
 
-    if raw_size <= _MAX_IMAGE_BYTES:
-        return image_path, fmt
+    if len(raw_data) <= _MAX_IMAGE_BYTES:
+        return raw_data, fmt
 
     logger.info(
         "Image exceeds API size limit, compressing to JPEG",
-        original_bytes=raw_size,
+        original_bytes=len(raw_data),
         limit=_MAX_IMAGE_BYTES,
     )
 
-    img = PILImage.open(image_path)
+    img = PILImage.open(BytesIO(raw_data))
     if img.mode in ("RGBA", "LA", "P"):
         img = img.convert("RGB")
-
-    compressed_path = str(Path(image_path).with_suffix(".mcp.jpg"))
 
     # Try quality 85 first; fall back to progressively lower quality.
     for quality in (85, 70, 50):
         buf = BytesIO()
         img.save(buf, format="JPEG", quality=quality, optimize=True)
         if buf.tell() <= _MAX_IMAGE_BYTES:
-            Path(compressed_path).write_bytes(buf.getvalue())
+            compressed = buf.getvalue()
             logger.info(
-                "Compressed image saved",
+                "Compressed image",
                 quality=quality,
-                compressed_bytes=buf.tell(),
+                compressed_bytes=len(compressed),
             )
-            return compressed_path, "jpeg"
+            return compressed, "jpeg"
 
     # Last resort: scale down.
     for scale in (0.75, 0.5, 0.25):
@@ -90,16 +90,16 @@ def _compress_for_api(image_path: str) -> tuple[str, str]:
         buf = BytesIO()
         resized.save(buf, format="JPEG", quality=70, optimize=True)
         if buf.tell() <= _MAX_IMAGE_BYTES:
-            Path(compressed_path).write_bytes(buf.getvalue())
+            compressed = buf.getvalue()
             logger.info(
-                "Resized and compressed image saved",
+                "Resized and compressed image",
                 scale=scale,
-                compressed_bytes=buf.tell(),
+                compressed_bytes=len(compressed),
             )
-            return compressed_path, "jpeg"
+            return compressed, "jpeg"
 
     raise ValueError(
-        f"Image at {image_path} ({raw_size} bytes) could not be "
+        f"Image at {image_path} ({len(raw_data)} bytes) could not be "
         f"compressed below the {_MAX_IMAGE_BYTES} byte API limit."
     )
 
@@ -133,8 +133,8 @@ async def generate_diagram(
     )
 
     result = await pipeline.generate(gen_input)
-    effective_path, fmt = _compress_for_api(result.image_path)
-    return Image(path=effective_path, format=fmt)
+    data, fmt = _compress_for_api(result.image_path)
+    return Image(data=data, format=fmt)
 
 
 @mcp.tool
@@ -167,8 +167,8 @@ async def generate_plot(
     )
 
     result = await pipeline.generate(gen_input)
-    effective_path, fmt = _compress_for_api(result.image_path)
-    return Image(path=effective_path, format=fmt)
+    data, fmt = _compress_for_api(result.image_path)
+    return Image(data=data, format=fmt)
 
 
 @mcp.tool

--- a/paperbanana/core/utils.py
+++ b/paperbanana/core/utils.py
@@ -162,6 +162,27 @@ def find_prompt_dir() -> str:
     return "prompts"
 
 
+def detect_format_from_bytes(data: bytes) -> str:
+    """Detect short image format name from raw bytes using magic-byte signatures.
+
+    Returns a short format string such as ``"png"``, ``"jpeg"``, ``"webp"``,
+    or ``"gif"``.
+
+    Raises ``ValueError`` when the magic bytes do not match any known format.
+    """
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png"
+    if data[:2] == b"\xff\xd8":
+        return "jpeg"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "webp"
+    if data[:4] == b"GIF8":
+        return "gif"
+    raise ValueError(
+        f"Unrecognised image format (header bytes: {data[:12]!r})"
+    )
+
+
 def detect_image_mime_type(path: str | Path) -> str:
     """Detect the actual image MIME type from file header bytes.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -223,26 +223,38 @@ class TestCompressForApi:
 
         p = tmp_path / "small.png"
         _write_png(p)
-        path, fmt = _compress_for_api(str(p))
-        assert path == str(p)
+        data, fmt = _compress_for_api(str(p))
         assert fmt == "png"
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_jpeg_in_png_detected(self, tmp_path: Path):
+        """A .png file containing JPEG data must be returned as format=jpeg."""
+        from mcp_server.server import _compress_for_api
+
+        # Write JPEG bytes into a .png file (the exact scenario from #58).
+        p = tmp_path / "misleading.png"
+        buf = BytesIO()
+        Image.new("RGB", (10, 10), "red").save(buf, format="JPEG")
+        p.write_bytes(buf.getvalue())
+
+        data, fmt = _compress_for_api(str(p))
+        assert fmt == "jpeg"
+        assert data[:2] == b"\xff\xd8"
 
     def test_large_image_compressed(self, tmp_path: Path, monkeypatch):
         from mcp_server import server
         from mcp_server.server import _compress_for_api
 
-        # Set a very low limit so our test image exceeds it.
-        monkeypatch.setattr(server, "_MAX_IMAGE_BYTES", 100)
+        # Use a limit that the PNG will exceed but JPEG can satisfy.
+        monkeypatch.setattr(server, "_MAX_IMAGE_BYTES", 500)
 
         p = tmp_path / "big.png"
         Image.new("RGB", (200, 200), color=(128, 64, 32)).save(p, format="PNG")
-        assert p.stat().st_size > 100
+        assert p.stat().st_size > 500
 
-        path, fmt = _compress_for_api(str(p))
+        data, fmt = _compress_for_api(str(p))
         assert fmt == "jpeg"
-        assert path.endswith(".mcp.jpg")
-        # Compressed file should actually exist
-        assert Path(path).exists()
+        assert data[:2] == b"\xff\xd8"
 
     def test_uncompressible_raises(self, tmp_path: Path, monkeypatch):
         from mcp_server import server


### PR DESCRIPTION
## What does this PR do?

Fixes the image MIME type mismatch that causes the Anthropic API to reject MCP tool results from `generate_diagram` and `generate_plot`. The API error was:

> The image was specified using the image/png media type, but the image appears to be a image/jpeg image

Fixes #58

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Reference dataset addition
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] New provider support

## Changes made

- `_compress_for_api()` now returns `(bytes, format)` instead of `(path, format)`. The file is read once, the format is detected from those exact bytes via magic-byte signatures, and both are returned together — guaranteeing the declared MIME type always matches the actual image encoding.
- MCP tools (`generate_diagram`, `generate_plot`) use `Image(data=..., format=...)` instead of `Image(path=..., format=...)`, eliminating the indirection that allowed format and data to diverge.
- Added `detect_format_from_bytes()` to `paperbanana/core/utils.py` for reusable magic-byte format detection from raw bytes. Raises `ValueError` on unrecognised formats rather than silently falling back.
- Updated and added tests: `test_jpeg_in_png_detected` covers the exact scenario from #58; fixed `test_large_image_compressed` which was previously failing due to an unrealistically low byte limit.

## How to test

1. `pytest tests/test_utils.py -v` — all 23 tests pass, including the new `test_jpeg_in_png_detected` case
2. `ruff check paperbanana/ mcp_server/ tests/ scripts/` — no lint errors
3. To verify end-to-end: configure PaperBanana as an MCP server and call `generate_diagram` — the tool result should no longer trigger `image/png` vs `image/jpeg` validation errors from the Anthropic API

## Checklist

- [x] `pytest tests/ -v` passes
- [x] `ruff check paperbanana/ mcp_server/ tests/ scripts/` passes
- [x] I've added/updated tests for new functionality (if applicable)
- [ ] I've updated documentation (if applicable)
- [ ] For reference dataset additions: verified methodology text matches diagram, aspect ratio is within [1.5, 2.5], metadata.json is complete