### PR TITLE
feat: add get_version() helper function

### DIFF
--- a/paperbanana/__init__.py
+++ b/paperbanana/__init__.py
@@ -18,3 +18,8 @@ __all__ = [
     "GenerationInput",
     "GenerationOutput",
 ]
+
+
+def get_version() -> str:
+    """Return the current PaperBanana version."""
+    return __version__


### PR DESCRIPTION
## Summary

Add get_version() helper function to retrieve package version.

## Changes

- Add get_version() function to return __version__
- Useful for CLI and programmatic version checks

## Testing

- Function returns correct version string
- No breaking changes