### PR TITLE
Prompt A/B comparison harness and benchmark_concurrency fix

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -162,6 +162,11 @@ def generate(
         "--exemplar-retries",
         help="Retry attempts for external exemplar retrieval on transient errors",
     ),
+    prompt_dir: Optional[str] = typer.Option(
+        None,
+        "--prompt-dir",
+        help="Path to alternative prompt templates directory (for A/B testing)",
+    ),
     seed: Optional[int] = typer.Option(
         None,
         "--seed",
@@ -239,6 +244,8 @@ def generate(
         overrides["exemplar_retrieval_max_retries"] = exemplar_retries
     if seed is not None:
         overrides["seed"] = seed
+    if prompt_dir:
+        overrides["prompt_dir"] = prompt_dir
 
     if config:
         settings = Settings.from_yaml(config, **overrides)
@@ -1241,6 +1248,145 @@ def ablate_retrieval(
     )
 
 
+@app.command("ablate-prompts")
+def ablate_prompts(
+    variant_prompt_dir: str = typer.Option(
+        ..., "--variant-dir", help="Path to the variant prompt templates directory"
+    ),
+    baseline_prompt_dir: Optional[str] = typer.Option(
+        None, "--baseline-dir", help="Path to baseline prompt templates (default: built-in prompts)"
+    ),
+    variant_name: str = typer.Option("variant", "--variant-name", help="Label for the variant"),
+    baseline_name: str = typer.Option("baseline", "--baseline-name", help="Label for the baseline"),
+    category: Optional[str] = typer.Option(
+        None, "--category", help="Only run entries in this category"
+    ),
+    ids: Optional[str] = typer.Option(None, "--ids", help="Comma-separated entry IDs to compare"),
+    limit: Optional[int] = typer.Option(None, "--limit", help="Max entries to compare"),
+    seed: Optional[int] = typer.Option(None, "--seed", help="Random seed for reproducibility"),
+    output_report: Optional[str] = typer.Option(
+        None, "--output-report", "-o", help="Output JSON report path"
+    ),
+    config: Optional[str] = typer.Option(None, "--config", help="Path to config YAML file"),
+    vlm_provider: Optional[str] = typer.Option(None, "--vlm-provider", help="VLM provider"),
+    image_provider: Optional[str] = typer.Option(
+        None, "--image-provider", help="Image generation provider"
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed progress"),
+):
+    """Run A/B comparison of two prompt configurations and produce a scored report."""
+    configure_logging(verbose=verbose)
+
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    overrides: dict = {}
+    if vlm_provider:
+        overrides["vlm_provider"] = vlm_provider
+    if image_provider:
+        overrides["image_provider"] = image_provider
+    if seed is not None:
+        overrides["seed"] = seed
+
+    if config:
+        settings = Settings.from_yaml(config, **overrides)
+    else:
+        settings = Settings(**overrides)
+
+    from paperbanana.evaluation.benchmark import filter_examples
+    from paperbanana.evaluation.prompt_ablation import (
+        PromptAblationRunner,
+        validate_prompt_dir,
+    )
+    from paperbanana.reference.store import ReferenceStore
+
+    try:
+        validate_prompt_dir(variant_prompt_dir)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    if baseline_prompt_dir:
+        try:
+            validate_prompt_dir(baseline_prompt_dir)
+        except ValueError as e:
+            console.print(f"[red]Error: {e}[/red]")
+            raise typer.Exit(1)
+
+    runner = PromptAblationRunner(
+        settings,
+        baseline_prompt_dir=baseline_prompt_dir,
+        variant_prompt_dir=variant_prompt_dir,
+        baseline_name=baseline_name,
+        variant_name=variant_name,
+    )
+
+    id_list = [s.strip() for s in ids.split(",") if s.strip()] if ids else None
+    try:
+        store = ReferenceStore.from_settings(settings)
+        examples = store.get_all()
+        if not examples:
+            raise ValueError("No benchmark entries found. Run 'paperbanana data download' first.")
+        entries = filter_examples(examples, category=category, ids=id_list, limit=limit)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    if not entries:
+        console.print("[red]Error: No entries match the given filters.[/red]")
+        raise typer.Exit(1)
+
+    console.print(
+        Panel.fit(
+            f"[bold]PaperBanana[/bold] — Prompt A/B Comparison\n\n"
+            f"Baseline: {runner.baseline_prompt_dir} ({baseline_name})\n"
+            f"Variant:  {variant_prompt_dir} ({variant_name})\n"
+            f"Entries:  {len(entries)}\n"
+            f"Seed:     {settings.seed or 'none'}",
+            border_style="magenta",
+        )
+    )
+
+    report = asyncio.run(runner.run(entries))
+
+    default_path = Path(settings.output_dir) / f"prompt_ablation_{generate_run_id()}.json"
+    report_path = Path(output_report) if output_report else default_path
+    saved_path = PromptAblationRunner.save_report(report, report_path)
+
+    summary = report.summary
+    if not summary:
+        console.print("[yellow]No entries were successfully scored.[/yellow]")
+        console.print(f"\nReport: [bold]{saved_path}[/bold]")
+        return
+
+    # Display results
+    deltas = summary.get("mean_dimension_deltas", {})
+    delta_lines = []
+    for dim, delta in deltas.items():
+        sign = "+" if delta > 0 else ""
+        delta_lines.append(f"  {dim.capitalize():14s} {sign}{delta}")
+
+    console.print(
+        Panel.fit(
+            "[bold]Prompt Ablation Summary[/bold]\n\n"
+            f"Scored:           {summary.get('scored', 0)}\n"
+            f"Variant wins:     {summary.get('variant_wins', 0)}  "
+            f"({summary.get('variant_win_rate', 0)}%)\n"
+            f"Baseline wins:    {summary.get('baseline_wins', 0)}  "
+            f"({summary.get('baseline_win_rate', 0)}%)\n"
+            f"Ties:             {summary.get('ties', 0)}\n\n"
+            f"Mean baseline:    {summary.get('mean_baseline_score', 0)}/100\n"
+            f"Mean variant:     {summary.get('mean_variant_score', 0)}/100\n"
+            f"Mean delta:       {summary.get('mean_overall_delta', 0):+.1f}\n\n"
+            "[bold]Per-dimension deltas (variant - baseline):[/bold]\n" + "\n".join(delta_lines),
+            border_style="cyan",
+        )
+    )
+
+    console.print(f"\nReport: [bold]{saved_path}[/bold]")
+
+
 @app.command()
 def benchmark(
     config: Optional[str] = typer.Option(None, "--config", help="Path to config YAML file"),
@@ -1274,6 +1420,11 @@ def benchmark(
         "png", "--format", "-f", help="Output image format (png, jpeg, webp)"
     ),
     seed: Optional[int] = typer.Option(None, "--seed", help="Random seed for reproducibility"),
+    prompt_dir: Optional[str] = typer.Option(
+        None,
+        "--prompt-dir",
+        help="Path to alternative prompt templates directory",
+    ),
     concurrency: int = typer.Option(
         1,
         "--concurrency",
@@ -1315,6 +1466,8 @@ def benchmark(
         overrides["output_dir"] = output_dir
     if seed is not None:
         overrides["seed"] = seed
+    if prompt_dir:
+        overrides["prompt_dir"] = prompt_dir
 
     if config:
         settings = Settings.from_yaml(config, **overrides)

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -90,6 +90,12 @@ class Settings(BaseSettings):
     save_iterations: bool = True
     save_prompts: bool = True
 
+    # Prompt settings
+    prompt_dir: Optional[str] = None
+
+    # Benchmark settings
+    benchmark_concurrency: int = 1
+
     # API Keys (loaded from environment)
     google_api_key: Optional[str] = Field(default=None, alias="GOOGLE_API_KEY")
     openrouter_api_key: Optional[str] = Field(default=None, alias="OPENROUTER_API_KEY")
@@ -217,6 +223,7 @@ def _flatten_yaml(config: dict, prefix: str = "") -> dict:
         "output.format": "output_format",
         "output.save_iterations": "save_iterations",
         "output.save_prompts": "save_prompts",
+        "pipeline.prompt_dir": "prompt_dir",
     }
 
     def _recurse(d: dict, prefix: str = "") -> None:

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -222,7 +222,9 @@ class PaperBananaPipeline:
         return ensure_dir(Path(self.settings.output_dir) / self.run_id)
 
     def _find_prompt_dir(self) -> str:
-        """Find the prompts directory relative to the package."""
+        """Find the prompts directory, preferring settings.prompt_dir if set."""
+        if self.settings.prompt_dir:
+            return self.settings.prompt_dir
         return find_prompt_dir()
 
     async def _resolve_retrieval_candidates(

--- a/paperbanana/evaluation/prompt_ablation.py
+++ b/paperbanana/evaluation/prompt_ablation.py
@@ -1,0 +1,350 @@
+"""A/B comparison runner for prompt variant evaluation.
+
+Runs the same inputs through two prompt configurations (baseline vs variant),
+scores both with VLMJudge, and produces a side-by-side report with
+per-dimension deltas and win rates.
+"""
+
+from __future__ import annotations
+
+import datetime
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+import structlog
+from pydantic import BaseModel, Field
+
+from paperbanana.core.config import Settings
+from paperbanana.core.pipeline import PaperBananaPipeline
+from paperbanana.core.types import (
+    EvaluationScore,
+    GenerationInput,
+    ReferenceExample,
+)
+from paperbanana.core.utils import find_prompt_dir
+from paperbanana.evaluation.judge import DIMENSIONS, VLMJudge
+from paperbanana.evaluation.metrics import scores_to_dict
+from paperbanana.providers.registry import ProviderRegistry
+
+logger = structlog.get_logger()
+
+
+# ── Report models ────────────────────────────────────────────────
+
+
+class PromptVariantConfig(BaseModel):
+    """Identifies a prompt variant by name and directory."""
+
+    name: str
+    prompt_dir: str
+
+
+class PromptVariantResult(BaseModel):
+    """Generation + evaluation result for a single (entry, variant) pair."""
+
+    entry_id: str
+    variant_name: str
+    run_id: str = ""
+    image_path: str = ""
+    iteration_count: int = 0
+    generation_seconds: float = 0.0
+    evaluation: Optional[dict] = None
+    error: Optional[str] = None
+
+
+class PromptComparisonEntry(BaseModel):
+    """Side-by-side comparison for a single benchmark entry."""
+
+    entry_id: str
+    category: str = ""
+    baseline: Optional[PromptVariantResult] = None
+    variant: Optional[PromptVariantResult] = None
+    dimension_deltas: dict[str, float] = Field(default_factory=dict)
+    overall_delta: float = 0.0
+    winner: str = ""
+
+
+class PromptAblationReport(BaseModel):
+    """Full A/B prompt comparison report."""
+
+    created_at: str
+    baseline: PromptVariantConfig
+    variant: PromptVariantConfig
+    seed: Optional[int] = None
+    total_entries: int = 0
+    compared: int = 0
+    failed: int = 0
+    total_seconds: float = 0.0
+    entries: list[PromptComparisonEntry] = Field(default_factory=list)
+    summary: dict = Field(default_factory=dict)
+
+
+# ── Comparison logic ─────────────────────────────────────────────
+
+
+def compute_dimension_deltas(
+    baseline_eval: dict, variant_eval: dict
+) -> tuple[dict[str, float], float]:
+    """Compute per-dimension score deltas (variant - baseline).
+
+    Positive deltas mean the variant scored higher.
+    """
+    deltas: dict[str, float] = {}
+    for dim in DIMENSIONS:
+        key = f"{dim}_score"
+        b_score = float(baseline_eval.get(key, 0.0))
+        v_score = float(variant_eval.get(key, 0.0))
+        deltas[dim] = round(v_score - b_score, 1)
+
+    b_overall = float(baseline_eval.get("overall_score", 0.0))
+    v_overall = float(variant_eval.get("overall_score", 0.0))
+    overall_delta = round(v_overall - b_overall, 1)
+
+    return deltas, overall_delta
+
+
+def build_summary(entries: list[PromptComparisonEntry]) -> dict:
+    """Aggregate comparison results into win rates and mean deltas."""
+    scored = [
+        e
+        for e in entries
+        if e.baseline
+        and e.variant
+        and e.baseline.evaluation is not None
+        and e.variant.evaluation is not None
+    ]
+    if not scored:
+        return {}
+
+    variant_wins = sum(1 for e in scored if e.winner == "variant")
+    baseline_wins = sum(1 for e in scored if e.winner == "baseline")
+    ties = len(scored) - variant_wins - baseline_wins
+
+    mean_deltas: dict[str, float] = {}
+    for dim in DIMENSIONS:
+        values = [e.dimension_deltas.get(dim, 0.0) for e in scored]
+        mean_deltas[dim] = round(sum(values) / len(values), 1)
+
+    overall_deltas = [e.overall_delta for e in scored]
+    mean_overall_delta = round(sum(overall_deltas) / len(overall_deltas), 1)
+
+    baseline_scores = [float(e.baseline.evaluation.get("overall_score", 0.0)) for e in scored]
+    variant_scores = [float(e.variant.evaluation.get("overall_score", 0.0)) for e in scored]
+
+    return {
+        "scored": len(scored),
+        "variant_wins": variant_wins,
+        "baseline_wins": baseline_wins,
+        "ties": ties,
+        "variant_win_rate": round(variant_wins / len(scored) * 100, 1),
+        "baseline_win_rate": round(baseline_wins / len(scored) * 100, 1),
+        "mean_dimension_deltas": mean_deltas,
+        "mean_overall_delta": mean_overall_delta,
+        "mean_baseline_score": round(sum(baseline_scores) / len(baseline_scores), 1),
+        "mean_variant_score": round(sum(variant_scores) / len(variant_scores), 1),
+    }
+
+
+# ── Runner ───────────────────────────────────────────────────────
+
+
+def validate_prompt_dir(prompt_dir: str) -> None:
+    """Check that a prompt directory looks valid before running."""
+    p = Path(prompt_dir)
+    if not p.is_dir():
+        raise ValueError(f"Prompt directory does not exist: {prompt_dir}")
+    if not (p / "diagram").is_dir() and not (p / "plot").is_dir():
+        raise ValueError(
+            f"Prompt directory missing expected subdirectory (diagram/ or plot/): {prompt_dir}"
+        )
+
+
+class PromptAblationRunner:
+    """Runs A/B comparisons between two prompt configurations."""
+
+    def __init__(
+        self,
+        base_settings: Settings,
+        *,
+        baseline_prompt_dir: Optional[str] = None,
+        variant_prompt_dir: str,
+        baseline_name: str = "baseline",
+        variant_name: str = "variant",
+        pipeline_factory: Callable[[Settings], PaperBananaPipeline] = PaperBananaPipeline,
+        judge_factory: Optional[Callable[[Settings], VLMJudge]] = None,
+    ):
+        self.base_settings = base_settings
+        self.baseline_prompt_dir = baseline_prompt_dir or find_prompt_dir()
+        self.variant_prompt_dir = variant_prompt_dir
+        self.baseline_name = baseline_name
+        self.variant_name = variant_name
+        self.pipeline_factory = pipeline_factory
+        self.judge_factory = judge_factory or self._default_judge_factory
+
+    def _default_judge_factory(self, settings: Settings) -> VLMJudge:
+        vlm = ProviderRegistry.create_vlm(settings)
+        return VLMJudge(vlm, prompt_dir=find_prompt_dir())
+
+    def _settings_for_variant(self, prompt_dir: str) -> Settings:
+        """Create a settings copy pointing to the given prompt directory."""
+        return self.base_settings.model_copy(update={"prompt_dir": prompt_dir})
+
+    async def _run_variant(
+        self,
+        variant_name: str,
+        prompt_dir: str,
+        input_data: GenerationInput,
+        entry_id: str,
+    ) -> PromptVariantResult:
+        """Generate a single entry with a specific prompt configuration."""
+        result = PromptVariantResult(entry_id=entry_id, variant_name=variant_name)
+        try:
+            settings = self._settings_for_variant(prompt_dir)
+            pipeline = self.pipeline_factory(settings)
+            gen_start = time.perf_counter()
+            output = await pipeline.generate(input_data)
+            result.generation_seconds = round(time.perf_counter() - gen_start, 1)
+            result.run_id = str(output.metadata.get("run_id", ""))
+            result.image_path = output.image_path
+            result.iteration_count = len(output.iterations)
+        except Exception as e:
+            result.error = str(e)
+            logger.error(
+                "Prompt ablation generation failed",
+                entry=entry_id,
+                variant=variant_name,
+                error=str(e),
+            )
+        return result
+
+    async def _evaluate_result(
+        self,
+        result: PromptVariantResult,
+        entry: ReferenceExample,
+        judge: VLMJudge,
+    ) -> None:
+        """Score a generation result against the entry's reference image."""
+        if result.error or not result.image_path:
+            return
+        if not entry.image_path or not Path(entry.image_path).exists():
+            result.error = "reference image not found"
+            return
+        try:
+            scores: EvaluationScore = await judge.evaluate(
+                image_path=result.image_path,
+                source_context=entry.source_context,
+                caption=entry.caption,
+                reference_path=entry.image_path,
+            )
+            result.evaluation = scores_to_dict(scores)
+        except Exception as e:
+            result.error = f"evaluation failed: {e}"
+            logger.error("Evaluation failed", entry=entry.id, error=str(e))
+
+    async def _process_entry(
+        self,
+        entry: ReferenceExample,
+        judge: VLMJudge,
+    ) -> PromptComparisonEntry:
+        """Run both variants for a single entry and compute deltas."""
+        input_data = GenerationInput(
+            source_context=entry.source_context,
+            communicative_intent=entry.caption,
+        )
+
+        comparison = PromptComparisonEntry(
+            entry_id=entry.id,
+            category=entry.category or "",
+        )
+
+        baseline_result = await self._run_variant(
+            self.baseline_name,
+            self.baseline_prompt_dir,
+            input_data,
+            entry.id,
+        )
+        variant_result = await self._run_variant(
+            self.variant_name,
+            self.variant_prompt_dir,
+            input_data,
+            entry.id,
+        )
+
+        await self._evaluate_result(baseline_result, entry, judge)
+        await self._evaluate_result(variant_result, entry, judge)
+
+        comparison.baseline = baseline_result
+        comparison.variant = variant_result
+
+        if baseline_result.evaluation and variant_result.evaluation:
+            deltas, overall_delta = compute_dimension_deltas(
+                baseline_result.evaluation, variant_result.evaluation
+            )
+            comparison.dimension_deltas = deltas
+            comparison.overall_delta = overall_delta
+
+            if overall_delta > 0:
+                comparison.winner = "variant"
+            elif overall_delta < 0:
+                comparison.winner = "baseline"
+            else:
+                comparison.winner = "tie"
+
+        return comparison
+
+    async def run(
+        self,
+        entries: list[ReferenceExample],
+    ) -> PromptAblationReport:
+        """Run the A/B comparison across all entries."""
+        validate_prompt_dir(self.baseline_prompt_dir)
+        validate_prompt_dir(self.variant_prompt_dir)
+
+        judge = self.judge_factory(self.base_settings)
+        results: list[PromptComparisonEntry] = []
+        total_start = time.perf_counter()
+
+        for idx, entry in enumerate(entries):
+            logger.info(
+                f"Prompt ablation {idx + 1}/{len(entries)}",
+                entry=entry.id,
+                category=entry.category,
+            )
+            comparison = await self._process_entry(entry, judge)
+            results.append(comparison)
+
+        total_seconds = time.perf_counter() - total_start
+        compared = sum(1 for e in results if e.baseline and e.variant)
+        failed = sum(
+            1
+            for e in results
+            if (e.baseline and e.baseline.error) or (e.variant and e.variant.error)
+        )
+
+        return PromptAblationReport(
+            created_at=datetime.datetime.now().isoformat(),
+            baseline=PromptVariantConfig(
+                name=self.baseline_name,
+                prompt_dir=self.baseline_prompt_dir,
+            ),
+            variant=PromptVariantConfig(
+                name=self.variant_name,
+                prompt_dir=self.variant_prompt_dir,
+            ),
+            seed=self.base_settings.seed,
+            total_entries=len(entries),
+            compared=compared,
+            failed=failed,
+            total_seconds=round(total_seconds, 1),
+            entries=results,
+            summary=build_summary(results),
+        )
+
+    @staticmethod
+    def save_report(report: PromptAblationReport, path: str | Path) -> Path:
+        """Write the report to a JSON file."""
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+        return output_path

--- a/tests/test_evaluation/test_prompt_ablation.py
+++ b/tests/test_evaluation/test_prompt_ablation.py
@@ -1,0 +1,364 @@
+"""Tests for the prompt A/B comparison runner."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from paperbanana.core.config import Settings
+from paperbanana.core.types import (
+    CritiqueResult,
+    DimensionResult,
+    EvaluationScore,
+    GenerationInput,
+    GenerationOutput,
+    IterationRecord,
+    ReferenceExample,
+)
+from paperbanana.evaluation.prompt_ablation import (
+    PromptAblationRunner,
+    PromptComparisonEntry,
+    PromptVariantResult,
+    build_summary,
+    compute_dimension_deltas,
+    validate_prompt_dir,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+def _make_eval_dict(overall_score: float) -> dict:
+    """Build a minimal evaluation dict matching scores_to_dict output."""
+    d = {"overall_winner": "Model", "overall_score": overall_score}
+    for dim in ["faithfulness", "conciseness", "readability", "aesthetics"]:
+        d[f"{dim}_winner"] = "Model"
+        d[f"{dim}_score"] = overall_score
+        d[f"{dim}_reasoning"] = ""
+    return d
+
+
+class _FakePipeline:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+    async def generate(self, input_data: GenerationInput) -> GenerationOutput:
+        prompt_dir = self.settings.prompt_dir or "default"
+        return GenerationOutput(
+            image_path="/tmp/fake.png",
+            description="desc",
+            iterations=[
+                IterationRecord(
+                    iteration=1,
+                    description="desc",
+                    image_path="/tmp/fake.png",
+                    critique=CritiqueResult(
+                        critic_suggestions=[],
+                        revised_description=None,
+                    ),
+                )
+            ],
+            metadata={"run_id": f"run_{prompt_dir}", "timing": {"total_seconds": 3.0}},
+        )
+
+
+class _FakeJudge:
+    def __init__(self, score: float = 75.0):
+        self._score = score
+
+    async def evaluate(self, **kwargs) -> EvaluationScore:
+        return EvaluationScore(
+            faithfulness=DimensionResult(winner="Model", score=self._score, reasoning=""),
+            conciseness=DimensionResult(winner="Model", score=self._score, reasoning=""),
+            readability=DimensionResult(winner="Model", score=self._score, reasoning=""),
+            aesthetics=DimensionResult(winner="Model", score=self._score, reasoning=""),
+            overall_winner="Model",
+            overall_score=self._score,
+        )
+
+
+def _make_prompt_dir(tmp_path, name: str = "prompts") -> str:
+    """Create a minimal prompt directory structure for validation."""
+    d = tmp_path / name / "diagram"
+    d.mkdir(parents=True)
+    (d / "planner.txt").write_text("test prompt")
+    return str(tmp_path / name)
+
+
+# ── compute_dimension_deltas ─────────────────────────────────────
+
+
+def test_compute_deltas_positive():
+    deltas, overall = compute_dimension_deltas(_make_eval_dict(60.0), _make_eval_dict(80.0))
+    assert overall == 20.0
+    assert deltas["faithfulness"] == 20.0
+
+
+def test_compute_deltas_negative():
+    deltas, overall = compute_dimension_deltas(_make_eval_dict(90.0), _make_eval_dict(70.0))
+    assert overall == -20.0
+
+
+def test_compute_deltas_zero():
+    same = _make_eval_dict(50.0)
+    deltas, overall = compute_dimension_deltas(same, same)
+    assert overall == 0.0
+    assert all(v == 0.0 for v in deltas.values())
+
+
+# ── build_summary ────────────────────────────────────────────────
+
+
+def _make_comparison(entry_id: str, baseline_score: float, variant_score: float):
+    b = PromptVariantResult(
+        entry_id=entry_id,
+        variant_name="baseline",
+        evaluation=_make_eval_dict(baseline_score),
+    )
+    v = PromptVariantResult(
+        entry_id=entry_id,
+        variant_name="variant",
+        evaluation=_make_eval_dict(variant_score),
+    )
+    deltas, overall_delta = compute_dimension_deltas(b.evaluation, v.evaluation)
+    winner = "variant" if overall_delta > 0 else ("baseline" if overall_delta < 0 else "tie")
+    return PromptComparisonEntry(
+        entry_id=entry_id,
+        baseline=b,
+        variant=v,
+        dimension_deltas=deltas,
+        overall_delta=overall_delta,
+        winner=winner,
+    )
+
+
+def test_build_summary_basic():
+    entries = [
+        _make_comparison("a", 60.0, 80.0),
+        _make_comparison("b", 90.0, 70.0),
+        _make_comparison("c", 50.0, 50.0),
+    ]
+    summary = build_summary(entries)
+    assert summary["scored"] == 3
+    assert summary["variant_wins"] == 1
+    assert summary["baseline_wins"] == 1
+    assert summary["ties"] == 1
+    assert summary["variant_win_rate"] == pytest.approx(33.3, abs=0.1)
+
+
+def test_build_summary_empty():
+    assert build_summary([]) == {}
+
+
+def test_build_summary_no_evaluations():
+    entry = PromptComparisonEntry(
+        entry_id="x",
+        baseline=PromptVariantResult(entry_id="x", variant_name="baseline"),
+        variant=PromptVariantResult(entry_id="x", variant_name="variant"),
+    )
+    assert build_summary([entry]) == {}
+
+
+# ── validate_prompt_dir ──────────────────────────────────────────
+
+
+def test_validate_prompt_dir_valid(tmp_path):
+    validate_prompt_dir(_make_prompt_dir(tmp_path))
+
+
+def test_validate_prompt_dir_missing():
+    with pytest.raises(ValueError, match="does not exist"):
+        validate_prompt_dir("/nonexistent/prompts_v99")
+
+
+def test_validate_prompt_dir_no_subdirectory(tmp_path):
+    empty_dir = tmp_path / "empty_prompts"
+    empty_dir.mkdir()
+    with pytest.raises(ValueError, match="missing expected subdirectory"):
+        validate_prompt_dir(str(empty_dir))
+
+
+# ── PromptAblationRunner ────────────────────────────────────────
+
+
+def _setup_runner(tmp_path, pipeline_factory=None, judge_factory=None, **settings_kw):
+    """Shared setup: creates prompt dirs, reference image, entries, and runner."""
+    baseline_dir = _make_prompt_dir(tmp_path, "baseline_prompts")
+    variant_dir = _make_prompt_dir(tmp_path, "variant_prompts")
+
+    from PIL import Image
+
+    ref_img = tmp_path / "ref.png"
+    Image.new("RGB", (64, 64)).save(ref_img)
+
+    entries = [
+        ReferenceExample(
+            id="test_001",
+            source_context="ctx",
+            caption="cap",
+            image_path=str(ref_img),
+            category="vision",
+        ),
+    ]
+
+    settings = Settings(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "refs"),
+        **settings_kw,
+    )
+
+    runner = PromptAblationRunner(
+        settings,
+        baseline_prompt_dir=baseline_dir,
+        variant_prompt_dir=variant_dir,
+        pipeline_factory=pipeline_factory or (lambda s: _FakePipeline(s)),
+        judge_factory=judge_factory or (lambda s: _FakeJudge()),
+    )
+    return runner, entries, baseline_dir, variant_dir
+
+
+@pytest.mark.asyncio
+async def test_runner_compares_two_variants(tmp_path):
+    seen_prompt_dirs: list[str] = []
+
+    class _TrackingPipeline(_FakePipeline):
+        def __init__(self, settings):
+            super().__init__(settings)
+            seen_prompt_dirs.append(settings.prompt_dir or "default")
+
+    runner, entries, baseline_dir, variant_dir = _setup_runner(
+        tmp_path,
+        pipeline_factory=lambda s: _TrackingPipeline(s),
+    )
+    report = await runner.run(entries)
+
+    assert len(seen_prompt_dirs) == 2
+    assert baseline_dir in seen_prompt_dirs
+    assert variant_dir in seen_prompt_dirs
+    assert report.total_entries == 1
+    assert report.compared == 1
+    assert report.entries[0].winner == "tie"
+
+
+@pytest.mark.asyncio
+async def test_runner_detects_variant_winning(tmp_path):
+    class _DifferentialJudge:
+        def __init__(self):
+            self._call_count = 0
+
+        async def evaluate(self, **kwargs) -> EvaluationScore:
+            self._call_count += 1
+            score = 90.0 if self._call_count == 2 else 60.0
+            return EvaluationScore(
+                faithfulness=DimensionResult(winner="Model", score=score, reasoning=""),
+                conciseness=DimensionResult(winner="Model", score=score, reasoning=""),
+                readability=DimensionResult(winner="Model", score=score, reasoning=""),
+                aesthetics=DimensionResult(winner="Model", score=score, reasoning=""),
+                overall_winner="Model",
+                overall_score=score,
+            )
+
+    judge = _DifferentialJudge()
+    runner, entries, _, _ = _setup_runner(
+        tmp_path,
+        judge_factory=lambda s: judge,
+    )
+    report = await runner.run(entries)
+
+    assert report.entries[0].winner == "variant"
+    assert report.entries[0].overall_delta == 30.0
+    assert report.summary["variant_wins"] == 1
+
+
+@pytest.mark.asyncio
+async def test_runner_uses_configured_seed(tmp_path):
+    seen_seeds: list = []
+
+    class _SeedTracker(_FakePipeline):
+        def __init__(self, settings):
+            super().__init__(settings)
+            seen_seeds.append(settings.seed)
+
+    runner, entries, _, _ = _setup_runner(
+        tmp_path,
+        pipeline_factory=lambda s: _SeedTracker(s),
+        seed=42,
+    )
+    report = await runner.run(entries)
+
+    assert report.seed == 42
+    assert seen_seeds == [42, 42]
+
+
+@pytest.mark.asyncio
+async def test_runner_handles_generation_failure(tmp_path):
+    class _FailingPipeline:
+        def __init__(self, settings):
+            pass
+
+        async def generate(self, input_data):
+            raise RuntimeError("API error")
+
+    runner, entries, _, _ = _setup_runner(
+        tmp_path,
+        pipeline_factory=lambda s: _FailingPipeline(s),
+    )
+    report = await runner.run(entries)
+
+    assert report.failed == 1
+    assert report.entries[0].baseline.error == "API error"
+    assert report.entries[0].winner == ""
+
+
+@pytest.mark.asyncio
+async def test_runner_rejects_invalid_prompt_dir(tmp_path):
+    baseline_dir = _make_prompt_dir(tmp_path, "baseline_prompts")
+    settings = Settings(output_dir=str(tmp_path), reference_set_path=str(tmp_path))
+    entries = [
+        ReferenceExample(id="x", source_context="ctx", caption="cap", image_path="/tmp/x.png"),
+    ]
+
+    runner = PromptAblationRunner(
+        settings,
+        baseline_prompt_dir=baseline_dir,
+        variant_prompt_dir="/nonexistent/prompts",
+        pipeline_factory=lambda s: _FakePipeline(s),
+    )
+    with pytest.raises(ValueError, match="does not exist"):
+        await runner.run(entries)
+
+
+@pytest.mark.asyncio
+async def test_save_report(tmp_path):
+    runner, entries, _, _ = _setup_runner(tmp_path)
+    report = await runner.run(entries)
+
+    report_path = tmp_path / "report.json"
+    saved = PromptAblationRunner.save_report(report, report_path)
+
+    assert saved.exists()
+    data = json.loads(saved.read_text())
+    assert data["baseline"]["name"] == "baseline"
+    assert data["variant"]["name"] == "variant"
+    assert data["total_entries"] == 1
+
+
+# ── Settings integration ─────────────────────────────────────────
+
+
+def test_benchmark_concurrency_field():
+    """benchmark_concurrency should be accepted by Settings (not silently dropped)."""
+    settings = Settings(benchmark_concurrency=4)
+    assert settings.benchmark_concurrency == 4
+
+
+def test_benchmark_concurrency_default():
+    assert Settings().benchmark_concurrency == 1
+
+
+def test_prompt_dir_field():
+    assert Settings(prompt_dir="/custom/prompts").prompt_dir == "/custom/prompts"
+
+
+def test_prompt_dir_default_is_none():
+    assert Settings().prompt_dir is None


### PR DESCRIPTION
## Summary

We had no way to compare two prompt versions against the same test cases. You'd edit a `.txt` template, run a few examples, look at the image, and guess whether it got better. If a change helped faithfulness but hurt aesthetics, you'd never know.

This adds a prompt A/B comparison harness and fixes a bug where `--concurrency` on the benchmark command did nothing.

## Changes

`Settings` gets a `prompt_dir` field. When set, the pipeline uses it instead of the hardcoded `find_prompt_dir()`. Available via `--prompt-dir` on the `generate` and `benchmark` commands, or `pipeline.prompt_dir` in YAML config.

New `ablate-prompts` command runs the same benchmark entries through two prompt configs, scores both with VLMJudge, and writes a JSON report with per-dimension deltas and win rates:

```
paperbanana ablate-prompts --variant-dir prompts_v2/ --limit 5
```

`PromptAblationRunner` is the runner behind it. Same shape as `RetrievalAblationRunner` - factory-injected pipeline/judge, Pydantic report models, `save_report()`. Validates prompt dirs before making API calls.

Bug fix: the CLI passed `benchmark_concurrency` to `Settings`, but the field didn't exist and `extra = "ignore"` silently dropped it. Added the field so `--concurrency` actually works.

No existing prompt templates, agents, or pipeline logic were touched. All 256 existing tests still pass.

## Test plan

- [x] Delta computation (positive, negative, zero)
- [x] Summary aggregation (win rates, empty inputs, missing evals)
- [x] Prompt dir validation (valid, missing, bad structure)
- [x] Runner end-to-end (variant comparison, winner detection, seed propagation, failure handling, report save)
- [x] Settings fields (`benchmark_concurrency` not dropped, `prompt_dir` defaults to `None`)
- [x] Full suite: 256 passed, 5 skipped, 0 failures

Closes #113
