### PR TITLE
feat: Add SVG and PDF vector export for statistical plots

### DIFF
--- a/paperbanana/agents/visualizer.py
+++ b/paperbanana/agents/visualizer.py
@@ -38,6 +38,7 @@ class VisualizerAgent(BaseAgent):
         super().__init__(vlm_provider, prompt_dir, prompt_recorder=prompt_recorder)
         self.image_gen = image_gen
         self.output_dir = Path(output_dir)
+        self._last_vector_paths: dict[str, str] = {}
 
     @property
     def agent_name(self) -> str:
@@ -52,6 +53,7 @@ class VisualizerAgent(BaseAgent):
         iteration: int = 0,
         seed: Optional[int] = None,
         aspect_ratio: Optional[str] = None,
+        vector_formats: Optional[list[str]] = None,
     ) -> str:
         """Generate an image from a description.
 
@@ -63,13 +65,16 @@ class VisualizerAgent(BaseAgent):
             iteration: Current iteration number (for naming).
             seed: Random seed for reproducibility.
             aspect_ratio: Target aspect ratio (e.g., '16:9', '1:1').
+            vector_formats: Vector formats to export alongside raster (e.g., ['svg', 'pdf']).
+                Only applies to statistical plots; ignored for methodology diagrams.
 
         Returns:
-            Path to the generated image.
+            Path to the generated raster image.
         """
+        self._last_vector_paths = {}
         if diagram_type == DiagramType.STATISTICAL_PLOT:
             return await self._generate_plot(
-                description, raw_data, output_path, iteration, aspect_ratio
+                description, raw_data, output_path, iteration, aspect_ratio, vector_formats
             )
         else:
             return await self._generate_diagram(
@@ -138,6 +143,7 @@ class VisualizerAgent(BaseAgent):
         output_path: Optional[str],
         iteration: int,
         aspect_ratio: Optional[str] = None,
+        vector_formats: Optional[list[str]] = None,
     ) -> str:
         """Generate a statistical plot by generating and executing matplotlib code."""
         # Build the description with raw data appended
@@ -176,12 +182,15 @@ class VisualizerAgent(BaseAgent):
         logger.info("Plot code saved", path=str(code_path))
 
         # Execute the code
-        success = self._execute_plot_code(code, output_path, aspect_ratio)
+        success = self._execute_plot_code(code, output_path, aspect_ratio, vector_formats)
         if not success:
             logger.error("Plot code execution failed, using placeholder")
             # Create a placeholder image
             placeholder = Image.new("RGB", (1024, 768), color=(255, 255, 255))
             save_image(placeholder, output_path)
+
+        if self._last_vector_paths:
+            logger.info("Vector outputs saved", paths=self._last_vector_paths)
 
         return output_path
 
@@ -205,24 +214,54 @@ class VisualizerAgent(BaseAgent):
         return response.strip()
 
     def _execute_plot_code(
-        self, code: str, output_path: str, aspect_ratio: Optional[str] = None
+        self,
+        code: str,
+        output_path: str,
+        aspect_ratio: Optional[str] = None,
+        vector_formats: Optional[list[str]] = None,
     ) -> bool:
-        """Execute matplotlib code in a subprocess to generate a plot."""
+        """Execute matplotlib code in a subprocess to generate a plot.
+
+        When *vector_formats* is provided (e.g. ``['svg', 'pdf']``), additional
+        vector files are saved alongside the raster output using ``plt.savefig``.
+        Paths are stored in ``self._last_vector_paths`` after a successful run.
+        """
         # Strip any OUTPUT_PATH assignments from VLM-generated code so the
         # injected value below is authoritative (the VLM is prompted to set
         # OUTPUT_PATH itself, which would override the injected line).
         code = re.sub(r'^OUTPUT_PATH\s*=\s*["\'].*["\']\s*$', "", code, flags=re.MULTILINE)
+        # Strip any VECTOR_PATH_* assignments the VLM may have generated.
+        code = re.sub(r'^VECTOR_PATH_\w+\s*=\s*["\'].*["\']\s*$', "", code, flags=re.MULTILINE)
 
-        # Inject the output path and figure size from aspect ratio
-        figsize_line = ""
+        # Build header: inject authoritative path variables
+        header = f'OUTPUT_PATH = "{output_path}"\n'
+
+        # Map each requested vector format to its output path
+        fmt_to_path: dict[str, str] = {}
+        if vector_formats:
+            for fmt in vector_formats:
+                vec_path = str(Path(output_path).with_suffix(f".{fmt}"))
+                fmt_to_path[fmt] = vec_path
+                header += f'VECTOR_PATH_{fmt.upper()} = "{vec_path}"\n'
+
+        # Inject figure size from aspect ratio
         if aspect_ratio:
             w, h = self._ratio_to_dimensions(aspect_ratio)
             # Scale to reasonable matplotlib inches (assume 150 dpi)
             fig_w, fig_h = round(w / 150, 1), round(h / 150, 1)
-            figsize_line = (
+            header += (
                 f"import matplotlib\nmatplotlib.rcParams['figure.figsize'] = [{fig_w}, {fig_h}]\n"
             )
-        full_code = f'OUTPUT_PATH = "{output_path}"\n{figsize_line}{code}'
+
+        # Append vector savefig calls after the user code
+        vector_suffix = ""
+        if fmt_to_path:
+            vector_suffix = "\nimport matplotlib.pyplot as _pb_plt\n"
+            for fmt, var_path in fmt_to_path.items():
+                var = f"VECTOR_PATH_{fmt.upper()}"
+                vector_suffix += f"_pb_plt.savefig({var}, format='{fmt}', bbox_inches='tight')\n"
+
+        full_code = header + code + vector_suffix
 
         # Ensure output directory exists
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
@@ -240,10 +279,17 @@ class VisualizerAgent(BaseAgent):
             )
             if result.returncode != 0:
                 logger.error("Plot code error", stderr=result.stderr[:500])
+                self._last_vector_paths = {}
                 return False
+
+            # Collect successfully written vector outputs
+            self._last_vector_paths = {
+                fmt: path for fmt, path in fmt_to_path.items() if Path(path).exists()
+            }
             return Path(output_path).exists()
         except subprocess.TimeoutExpired:
             logger.error("Plot code timed out")
+            self._last_vector_paths = {}
             return False
         finally:
             Path(temp_path).unlink(missing_ok=True)

--- a/paperbanana/agents/visualizer.py
+++ b/paperbanana/agents/visualizer.py
@@ -233,8 +233,11 @@ class VisualizerAgent(BaseAgent):
         # Strip any VECTOR_PATH_* assignments the VLM may have generated.
         code = re.sub(r'^VECTOR_PATH_\w+\s*=\s*["\'].*["\']\s*$', "", code, flags=re.MULTILINE)
 
-        # Build header: inject authoritative path variables
-        header = f'OUTPUT_PATH = "{output_path}"\n'
+        # Build header: inject authoritative path variables.
+        # Use forward slashes to avoid invalid unicode escapes on Windows
+        # (e.g. C:\Users → \U is an invalid escape sequence in Python strings).
+        safe_output = output_path.replace("\\", "/")
+        header = f'OUTPUT_PATH = "{safe_output}"\n'
 
         # Map each requested vector format to its output path
         fmt_to_path: dict[str, str] = {}
@@ -242,7 +245,8 @@ class VisualizerAgent(BaseAgent):
             for fmt in vector_formats:
                 vec_path = str(Path(output_path).with_suffix(f".{fmt}"))
                 fmt_to_path[fmt] = vec_path
-                header += f'VECTOR_PATH_{fmt.upper()} = "{vec_path}"\n'
+                safe_vec = vec_path.replace("\\", "/")
+                header += f'VECTOR_PATH_{fmt.upper()} = "{safe_vec}"\n'
 
         # Inject figure size from aspect ratio
         if aspect_ratio:
@@ -257,7 +261,7 @@ class VisualizerAgent(BaseAgent):
         vector_suffix = ""
         if fmt_to_path:
             vector_suffix = "\nimport matplotlib.pyplot as _pb_plt\n"
-            for fmt, var_path in fmt_to_path.items():
+            for fmt in fmt_to_path:
                 var = f"VECTOR_PATH_{fmt.upper()}"
                 vector_suffix += f"_pb_plt.savefig({var}, format='{fmt}', bbox_inches='tight')\n"
 

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -119,7 +119,7 @@ def generate(
     vector: bool = typer.Option(
         False,
         "--vector/--no-vector",
-        help="Also export SVG and PDF vector formats for statistical plots.",
+        help="Export SVG and PDF vector formats for statistical plots.",
     ),
     config: Optional[str] = typer.Option(None, "--config", help="Path to config YAML file"),
     save_prompts: Optional[bool] = typer.Option(

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -116,6 +116,11 @@ def generate(
         "-f",
         help="Output image format (png, jpeg, or webp)",
     ),
+    vector: bool = typer.Option(
+        False,
+        "--vector/--no-vector",
+        help="Also export SVG and PDF vector formats for statistical plots.",
+    ),
     config: Optional[str] = typer.Option(None, "--config", help="Path to config YAML file"),
     save_prompts: Optional[bool] = typer.Option(
         None,
@@ -250,6 +255,8 @@ def generate(
     if output:
         overrides["output_dir"] = str(Path(output).parent)
     overrides["output_format"] = format
+    if vector:
+        overrides["vector_export"] = True
     if exemplar_retrieval:
         overrides["exemplar_retrieval_enabled"] = True
     if exemplar_endpoint:
@@ -1458,6 +1465,11 @@ def plot(
         "--budget",
         help="Budget cap in USD; pipeline aborts gracefully when exceeded",
     ),
+    vector: bool = typer.Option(
+        False,
+        "--vector/--no-vector",
+        help="Also export SVG and PDF vector formats alongside the raster output.",
+    ),
 ):
     """Generate a statistical plot from data."""
     if format not in ("png", "jpeg", "webp"):
@@ -1496,6 +1508,7 @@ def plot(
         save_prompts=True if save_prompts is None else save_prompts,
         venue=venue,
         budget_usd=budget,
+        vector_export=vector,
     )
 
     gen_input = GenerationInput(
@@ -1545,6 +1558,9 @@ def plot(
 
     result = asyncio.run(_run())
     console.print(f"\n[green]Done![/green] Plot saved to: [bold]{result.image_path}[/bold]")
+    vector_paths = result.metadata.get("vector_output_paths", {})
+    for fmt, path in vector_paths.items():
+        console.print(f"[green]Vector ({fmt.upper()}):[/green] [bold]{path}[/bold]")
 
     cost_data = result.metadata.get("cost")
     if cost_data:

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -10,7 +10,6 @@ from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 OutputFormat = Literal["png", "jpeg", "webp"]
-VectorFormat = Literal["svg", "pdf"]
 ExemplarRetrievalMode = Literal["external_only", "external_then_rerank"]
 Venue = Literal["neurips", "icml", "acl", "ieee", "custom"]
 

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -10,6 +10,7 @@ from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 OutputFormat = Literal["png", "jpeg", "webp"]
+VectorFormat = Literal["svg", "pdf"]
 ExemplarRetrievalMode = Literal["external_only", "external_then_rerank"]
 Venue = Literal["neurips", "icml", "acl", "ieee", "custom"]
 
@@ -94,6 +95,7 @@ class Settings(BaseSettings):
     # Output settings
     output_dir: str = "outputs"
     output_format: OutputFormat = "png"
+    vector_export: bool = False
     save_iterations: bool = True
     save_prompts: bool = True
 
@@ -240,6 +242,7 @@ def _flatten_yaml(config: dict, prefix: str = "") -> dict:
         "pipeline.venue": "venue",
         "output.dir": "output_dir",
         "output.format": "output_format",
+        "output.vector_export": "vector_export",
         "output.save_iterations": "save_iterations",
         "output.save_prompts": "save_prompts",
         "cost.budget": "budget_usd",

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -539,6 +539,7 @@ class PaperBananaPipeline:
         current_description = optimized_description
         iterations: list[IterationRecord] = []
         iteration_timings = []
+        vector_formats = ["svg", "pdf"] if self.settings.vector_export else None
 
         if self.settings.auto_refine:
             total_iters = self.settings.max_iterations
@@ -588,6 +589,7 @@ class PaperBananaPipeline:
                 iteration=iter_index,
                 seed=self.settings.seed,
                 aspect_ratio=effective_ratio,
+                vector_formats=vector_formats,
             )
             visualizer_seconds = time.perf_counter() - visualizer_start
             _emit_progress(
@@ -783,6 +785,10 @@ class PaperBananaPipeline:
                 cost_summary["budget_usd"] = self.settings.budget_usd
             metadata_dict["cost"] = cost_summary
 
+        # Include vector output paths when vector export was requested
+        if self.settings.vector_export and self.visualizer._last_vector_paths:
+            metadata_dict["vector_output_paths"] = self.visualizer._last_vector_paths
+
         # Always write metadata (including cost) to disk for every run
         save_json(metadata_dict, self._run_dir / "metadata.json")
 
@@ -852,6 +858,7 @@ class PaperBananaPipeline:
         iterations: list[IterationRecord] = []
         iteration_timings = []
         budget_exceeded = False
+        vector_formats = ["svg", "pdf"] if self.settings.vector_export else None
 
         for i in range(total_iters):
             if budget_exceeded:
@@ -889,6 +896,7 @@ class PaperBananaPipeline:
                 iteration=iter_num,
                 seed=self.settings.seed,
                 aspect_ratio=resume_state.aspect_ratio,
+                vector_formats=vector_formats,
             )
             visualizer_seconds = time.perf_counter() - visualizer_start
             _emit_progress(
@@ -1078,6 +1086,9 @@ class PaperBananaPipeline:
             if self.settings.budget_usd is not None:
                 cost_summary["budget_usd"] = self.settings.budget_usd
             metadata_dict["cost"] = cost_summary
+
+        if self.settings.vector_export and self.visualizer._last_vector_paths:
+            metadata_dict["vector_output_paths"] = self.visualizer._last_vector_paths
 
         # Always write metadata (including cost) to disk for every run
         save_json(metadata_dict, run_dir / "metadata_continued.json")

--- a/tests/test_agents/test_visualizer.py
+++ b/tests/test_agents/test_visualizer.py
@@ -1,6 +1,8 @@
-"""Tests for VisualizerAgent code extraction edge cases."""
+"""Tests for VisualizerAgent code extraction edge cases and vector export."""
 
 from __future__ import annotations
+
+from pathlib import Path
 
 from paperbanana.agents.visualizer import VisualizerAgent
 
@@ -50,3 +52,78 @@ def test_extract_code_handles_plain_code_response(tmp_path):
     response = "import matplotlib.pyplot as plt\nplt.figure()"
     code = agent._extract_code(response)
     assert code == response
+
+
+# ── Vector export tests ───────────────────────────────────────────────────────
+
+_SIMPLE_PLOT_CODE = """\
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+fig, ax = plt.subplots()
+ax.plot([1, 2, 3], [4, 5, 6])
+plt.savefig(OUTPUT_PATH, bbox_inches='tight')
+"""
+
+
+def test_execute_plot_code_produces_raster_only_by_default(tmp_path):
+    agent = _make_agent(tmp_path)
+    output_path = str(tmp_path / "plot.png")
+    success = agent._execute_plot_code(_SIMPLE_PLOT_CODE, output_path)
+    assert success
+    assert Path(output_path).exists()
+    assert agent._last_vector_paths == {}
+
+
+def test_execute_plot_code_produces_svg_and_pdf_when_requested(tmp_path):
+    agent = _make_agent(tmp_path)
+    output_path = str(tmp_path / "plot.png")
+    success = agent._execute_plot_code(
+        _SIMPLE_PLOT_CODE, output_path, vector_formats=["svg", "pdf"]
+    )
+    assert success
+    assert Path(output_path).exists()
+    assert "svg" in agent._last_vector_paths
+    assert "pdf" in agent._last_vector_paths
+    assert Path(agent._last_vector_paths["svg"]).exists()
+    assert Path(agent._last_vector_paths["pdf"]).exists()
+
+
+def test_execute_plot_code_svg_path_has_correct_suffix(tmp_path):
+    agent = _make_agent(tmp_path)
+    output_path = str(tmp_path / "my_plot.png")
+    agent._execute_plot_code(_SIMPLE_PLOT_CODE, output_path, vector_formats=["svg"])
+    assert agent._last_vector_paths["svg"] == str(tmp_path / "my_plot.svg")
+
+
+def test_execute_plot_code_strips_vlm_vector_path_assignments(tmp_path):
+    """VLM-injected VECTOR_PATH_* assignments must be overridden by our header."""
+    agent = _make_agent(tmp_path)
+    output_path = str(tmp_path / "plot.png")
+    code_with_stale_path = 'VECTOR_PATH_SVG = "/stale/path.svg"\n' + _SIMPLE_PLOT_CODE
+    success = agent._execute_plot_code(code_with_stale_path, output_path, vector_formats=["svg"])
+    assert success
+    # Our injected path, not the stale one, should be used
+    assert agent._last_vector_paths.get("svg") == str(tmp_path / "plot.svg")
+
+
+def test_execute_plot_code_sets_empty_vector_paths_on_failure(tmp_path):
+    agent = _make_agent(tmp_path)
+    output_path = str(tmp_path / "plot.png")
+    bad_code = "raise RuntimeError('intentional failure')"
+    success = agent._execute_plot_code(bad_code, output_path, vector_formats=["svg", "pdf"])
+    assert not success
+    assert agent._last_vector_paths == {}
+
+
+def test_last_vector_paths_reset_on_each_run_call(tmp_path):
+    """_last_vector_paths from a previous run must not bleed into the next."""
+    agent = _make_agent(tmp_path)
+    output_path = str(tmp_path / "plot.png")
+    # First call with vector export
+    agent._execute_plot_code(_SIMPLE_PLOT_CODE, output_path, vector_formats=["svg"])
+    assert "svg" in agent._last_vector_paths
+    # Second call without vector export
+    output_path2 = str(tmp_path / "plot2.png")
+    agent._execute_plot_code(_SIMPLE_PLOT_CODE, output_path2)
+    assert agent._last_vector_paths == {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -221,6 +221,38 @@ def test_sweep_writes_report_with_mocked_pipeline(tmp_path, monkeypatch):
     assert ranked[0]["quality_proxy_score"] > ranked[1]["quality_proxy_score"]
 
 
+def test_generate_accepts_vector_flag():
+    """--vector flag is accepted by the CLI in dry-run mode."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("Sample methodology text for testing.")
+        input_path = f.name
+
+    try:
+        result = runner.invoke(
+            app,
+            ["generate", "--input", input_path, "--caption", "test", "--dry-run", "--vector"],
+        )
+        assert result.exit_code == 0
+    finally:
+        Path(input_path).unlink(missing_ok=True)
+
+
+def test_generate_no_vector_flag_accepted():
+    """--no-vector flag (explicit opt-out) is accepted by the CLI in dry-run mode."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("Sample methodology text for testing.")
+        input_path = f.name
+
+    try:
+        result = runner.invoke(
+            app,
+            ["generate", "--input", input_path, "--caption", "test", "--dry-run", "--no-vector"],
+        )
+        assert result.exit_code == 0
+    finally:
+        Path(input_path).unlink(missing_ok=True)
+
+
 def test_ablate_retrieval_writes_report(monkeypatch):
     """ablate-retrieval writes a JSON report and exits cleanly."""
     from paperbanana.evaluation.retrieval_ablation import AblationReport, AblationVariantResult

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -232,6 +232,46 @@ def test_optimizer_from_yaml():
         Path(path).unlink(missing_ok=True)
 
 
+# ── Vector export settings tests ─────────────────────────────────
+
+
+def test_vector_export_defaults_false():
+    """vector_export defaults to False."""
+    settings = Settings()
+    assert settings.vector_export is False
+
+
+def test_vector_export_can_be_enabled():
+    """vector_export can be enabled via constructor."""
+    settings = Settings(vector_export=True)
+    assert settings.vector_export is True
+
+
+def test_vector_export_from_yaml():
+    """output.vector_export loads from YAML config."""
+    import yaml
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.safe_dump({"output": {"vector_export": True}}, f)
+        path = f.name
+    try:
+        settings = Settings.from_yaml(path)
+        assert settings.vector_export is True
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_visualizer_run_signature_has_vector_formats():
+    """VisualizerAgent.run() exposes a vector_formats parameter."""
+    import inspect
+
+    from paperbanana.agents.visualizer import VisualizerAgent
+
+    sig = inspect.signature(VisualizerAgent.run)
+    assert "vector_formats" in sig.parameters
+    assert sig.parameters["vector_formats"].default is None
+
+
 def test_run_input_json_structure():
     """run_input.json has the expected structure."""
     data = {

--- a/tests/test_pipeline/test_output_format.py
+++ b/tests/test_pipeline/test_output_format.py
@@ -120,6 +120,142 @@ async def test_pipeline_webp_output_extension(empty_reference_dir):
     assert Path(result.image_path).exists()
 
 
+# ── Vector export integration tests ──────────────────────────────
+
+# Minimal matplotlib code the mock VLM returns for statistical plot generation.
+# Uses Agg backend to avoid display issues in CI; saves to the injected OUTPUT_PATH.
+_MOCK_PLOT_VLM_RESPONSE = """\
+```python
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+fig, ax = plt.subplots()
+ax.plot([1, 2, 3], [4, 5, 6])
+plt.savefig(OUTPUT_PATH, bbox_inches='tight')
+```"""
+
+
+class FakeVLMSequenced:
+    """Returns pre-configured responses in order, cycling on the last one."""
+
+    name = "fake-vlm"
+    model_name = "fake-model"
+
+    def __init__(self, responses: list[str]):
+        self._responses = responses
+        self._idx = 0
+
+    async def generate(self, *args, **kwargs):
+        idx = min(self._idx, len(self._responses) - 1)
+        self._idx += 1
+        return self._responses[idx]
+
+
+@pytest.mark.asyncio
+async def test_vector_export_produces_svg_and_pdf_for_statistical_plot(empty_reference_dir):
+    """vector_export=True generates SVG and PDF alongside raster for statistical plots."""
+    import json as json_mod
+
+    critic_response = json_mod.dumps({"critic_suggestions": [], "revised_description": None})
+
+    # VLM call order: planner → stylist → visualizer (matplotlib code) → critic
+    vlm = FakeVLMSequenced(
+        [
+            "A bar chart comparing model accuracy across datasets",
+            "A clean bar chart with publication-quality styling",
+            _MOCK_PLOT_VLM_RESPONSE,
+            critic_response,
+        ]
+    )
+
+    settings = Settings(
+        reference_set_path=str(empty_reference_dir),
+        output_dir=str(empty_reference_dir / "out"),
+        refinement_iterations=1,
+        save_iterations=True,
+        vector_export=True,
+    )
+    pipeline = PaperBananaPipeline(
+        settings=settings,
+        vlm_client=vlm,
+        image_gen_fn=FakeImageGen(),
+    )
+
+    result = await pipeline.generate(
+        GenerationInput(
+            source_context="Comparison of accuracy across five benchmark datasets.",
+            communicative_intent="Accuracy comparison bar chart",
+            diagram_type=DiagramType.STATISTICAL_PLOT,
+        )
+    )
+
+    # Raster output must exist
+    assert Path(result.image_path).exists()
+
+    # Vector paths must be recorded in metadata
+    assert "vector_output_paths" in result.metadata
+    vector_paths = result.metadata["vector_output_paths"]
+    assert "svg" in vector_paths
+    assert "pdf" in vector_paths
+    assert Path(vector_paths["svg"]).exists()
+    assert Path(vector_paths["pdf"]).exists()
+
+
+@pytest.mark.asyncio
+async def test_vector_export_not_in_metadata_when_disabled(empty_reference_dir):
+    """Without vector_export, vector_output_paths is absent from metadata."""
+    settings = Settings(
+        reference_set_path=str(empty_reference_dir),
+        output_dir=str(empty_reference_dir / "out"),
+        refinement_iterations=1,
+        save_iterations=False,
+        vector_export=False,
+    )
+    pipeline = PaperBananaPipeline(
+        settings=settings,
+        vlm_client=FakeVLM(),
+        image_gen_fn=FakeImageGen(),
+    )
+
+    result = await pipeline.generate(
+        GenerationInput(
+            source_context="Test methodology.",
+            communicative_intent="Test caption",
+            diagram_type=DiagramType.METHODOLOGY,
+        )
+    )
+
+    assert "vector_output_paths" not in result.metadata
+
+
+@pytest.mark.asyncio
+async def test_vector_export_not_in_metadata_for_methodology_diagram(empty_reference_dir):
+    """vector_export=True has no effect on methodology diagrams — no vector paths in metadata."""
+    settings = Settings(
+        reference_set_path=str(empty_reference_dir),
+        output_dir=str(empty_reference_dir / "out"),
+        refinement_iterations=1,
+        save_iterations=False,
+        vector_export=True,
+    )
+    pipeline = PaperBananaPipeline(
+        settings=settings,
+        vlm_client=FakeVLM(),
+        image_gen_fn=FakeImageGen(),
+    )
+
+    result = await pipeline.generate(
+        GenerationInput(
+            source_context="Test methodology.",
+            communicative_intent="Test caption",
+            diagram_type=DiagramType.METHODOLOGY,
+        )
+    )
+
+    # Methodology diagrams use image gen, not matplotlib — no vector output
+    assert "vector_output_paths" not in result.metadata
+
+
 def test_cli_invalid_format_rejected():
     """Invalid format via CLI is rejected cleanly."""
     from typer.testing import CliRunner


### PR DESCRIPTION
## PR Description

This pull request adds vector format export (SVG and PDF) for statistical plots, enabling publication-ready figures for academic venues such as NeurIPS, ICML, and ICLR with no new dependencies.

**Related Issue:** Closes #97

---

## Key Changes

**New CLI Flag (`paperbanana generate`):**
- `--vector / --no-vector` — exports SVG and PDF alongside the raster output for statistical plots
- Non-breaking; defaults to `False`, leaving MCP server and batch runner unaffected

**`VisualizerAgent` (`paperbanana/agents/visualizer.py`):**
- `_execute_plot_code()` — strips any VLM-injected `VECTOR_PATH_*` assignments, injects authoritative `VECTOR_PATH_SVG` / `VECTOR_PATH_PDF` variables into the script header, and appends `plt.savefig()` calls for each requested format after user code
- `run()` / `_generate_plot()` — accept `vector_formats` parameter; results stored in `self._last_vector_paths` after each execution
- State is reset to `{}` at the start of every `run()` call to prevent bleed between iterations

**Settings (`paperbanana/core/config.py`):**
- `vector_export: bool = False` — new field on `Settings`
- `VectorFormat = Literal["svg", "pdf"]` — type alias for valid vector formats
- YAML key `output.vector_export` supported via `_flatten_yaml`

**Pipeline (`paperbanana/core/pipeline.py`):**
- Derives `vector_formats` from `settings.vector_export` in both `generate()` and `continue_run()`
- Writes `vector_output_paths` dict to `metadata.json` when vector files are produced
- Vector export is silently skipped for methodology diagrams (image-gen path, not matplotlib)

## Usage
```
# JSON
paperbanana plot --data results.json --intent "..." --vector

# CSV
paperbanana plot --data results.csv --intent "..." --vector



Output when --vector is used:

Done! Plot saved to: outputs/run_.../final_output.png
Vector (SVG): outputs/run_.../plot_iter_1.svg
Vector (PDF): outputs/run_.../plot_iter_1.pdf
```