### PR TITLE
feat: auto-generate figure captions from final pipeline output

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -23,7 +23,6 @@ from pathlib import Path
 import structlog
 from fastmcp import FastMCP
 from fastmcp.utilities.types import Image
-from mcp.types import TextContent
 from PIL import Image as PILImage
 
 from paperbanana.core.config import Settings
@@ -106,6 +105,31 @@ def _compress_for_api(image_path: str) -> tuple[str, str]:
     )
 
 
+def _embed_caption(image_path: str, caption: str) -> None:
+    """Embed a caption into a PNG image's tEXt metadata chunk.
+
+    This preserves the MCP return type (always ``Image``) while making
+    the caption accessible to any client that reads PNG metadata.
+    Non-PNG files or write errors are silently ignored.
+    """
+    try:
+        from PIL.PngImagePlugin import PngInfo
+
+        img = PILImage.open(image_path)
+        if img.format != "PNG":
+            return
+        meta = PngInfo()
+        # Carry over existing text chunks
+        existing = img.info or {}
+        for k, v in existing.items():
+            if isinstance(v, str):
+                meta.add_text(k, v)
+        meta.add_text("Caption", caption)
+        img.save(image_path, pnginfo=meta)
+    except Exception:
+        logger.debug("Failed to embed caption in image metadata")
+
+
 mcp = FastMCP("PaperBanana")
 
 
@@ -118,7 +142,7 @@ async def generate_diagram(
     optimize: bool = False,
     auto_refine: bool = False,
     generate_caption: bool = False,
-) -> Image | list:
+) -> Image:
     """Generate a publication-quality methodology diagram from text.
 
     Args:
@@ -131,12 +155,12 @@ async def generate_diagram(
             Set False to skip preprocessing for faster results.
         auto_refine: Let critic loop until satisfied (default True, max 30 iterations).
             Set False to use fixed iteration count for faster results.
-        generate_caption: Auto-generate a publication-ready figure caption after generation.
-            Returns a list [caption_text, image] instead of just the image (default False).
+        generate_caption: Auto-generate a publication-ready figure caption
+            after generation. When True, the caption is embedded in the
+            image metadata (PNG tEXt chunk, key "Caption") and logged.
 
     Returns:
-        The generated diagram as a PNG image, or a list of [caption text, image] when
-        generate_caption=True.
+        The generated diagram as a PNG image.
     """
     settings = Settings(
         refinement_iterations=iterations,
@@ -146,8 +170,12 @@ async def generate_diagram(
     )
 
     def _on_progress(event: str, payload: dict) -> None:
-        # Surface coarse progress to MCP logs; IDEs can display this in tool output.
-        logger.info("mcp_progress", tool="generate_diagram", progress_event=event, **payload)
+        logger.info(
+            "mcp_progress",
+            tool="generate_diagram",
+            progress_event=event,
+            **payload,
+        )
 
     pipeline = PaperBananaPipeline(settings=settings, progress_callback=_on_progress)
 
@@ -160,11 +188,16 @@ async def generate_diagram(
 
     result = await pipeline.generate(gen_input)
     effective_path, fmt = _compress_for_api(result.image_path)
-    image = Image(path=effective_path, format=fmt)
 
     if result.generated_caption:
-        return [TextContent(type="text", text=result.generated_caption), image]
-    return image
+        _embed_caption(effective_path, result.generated_caption)
+        logger.info(
+            "generated_caption",
+            tool="generate_diagram",
+            caption=result.generated_caption,
+        )
+
+    return Image(path=effective_path, format=fmt)
 
 
 @mcp.tool
@@ -176,7 +209,7 @@ async def generate_plot(
     optimize: bool = False,
     auto_refine: bool = False,
     generate_caption: bool = False,
-) -> Image | list:
+) -> Image:
     """Generate a publication-quality statistical plot from JSON data.
 
     Args:
@@ -190,12 +223,12 @@ async def generate_plot(
             Set False to skip preprocessing for faster results.
         auto_refine: Let critic loop until satisfied (default True, max 30 iterations).
             Set False to use fixed iteration count for faster results.
-        generate_caption: Auto-generate a publication-ready figure caption after generation.
-            Returns a list [caption_text, image] instead of just the image (default False).
+        generate_caption: Auto-generate a publication-ready figure caption
+            after generation. When True, the caption is embedded in the
+            image metadata (PNG tEXt chunk, key "Caption") and logged.
 
     Returns:
-        The generated plot as a PNG image, or a list of [caption text, image] when
-        generate_caption=True.
+        The generated plot as a PNG image.
     """
     raw_data = json.loads(data_json)
 
@@ -207,7 +240,12 @@ async def generate_plot(
     )
 
     def _on_progress(event: str, payload: dict) -> None:
-        logger.info("mcp_progress", tool="generate_plot", progress_event=event, **payload)
+        logger.info(
+            "mcp_progress",
+            tool="generate_plot",
+            progress_event=event,
+            **payload,
+        )
 
     pipeline = PaperBananaPipeline(settings=settings, progress_callback=_on_progress)
 
@@ -221,11 +259,16 @@ async def generate_plot(
 
     result = await pipeline.generate(gen_input)
     effective_path, fmt = _compress_for_api(result.image_path)
-    image = Image(path=effective_path, format=fmt)
 
     if result.generated_caption:
-        return [TextContent(type="text", text=result.generated_caption), image]
-    return image
+        _embed_caption(effective_path, result.generated_caption)
+        logger.info(
+            "generated_caption",
+            tool="generate_plot",
+            caption=result.generated_caption,
+        )
+
+    return Image(path=effective_path, format=fmt)
 
 
 @mcp.tool

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import structlog
 from fastmcp import FastMCP
 from fastmcp.utilities.types import Image
+from mcp.types import TextContent
 from PIL import Image as PILImage
 
 from paperbanana.core.config import Settings
@@ -116,7 +117,8 @@ async def generate_diagram(
     aspect_ratio: str | None = None,
     optimize: bool = False,
     auto_refine: bool = False,
-) -> Image:
+    generate_caption: bool = False,
+) -> Image | list:
     """Generate a publication-quality methodology diagram from text.
 
     Args:
@@ -129,14 +131,18 @@ async def generate_diagram(
             Set False to skip preprocessing for faster results.
         auto_refine: Let critic loop until satisfied (default True, max 30 iterations).
             Set False to use fixed iteration count for faster results.
+        generate_caption: Auto-generate a publication-ready figure caption after generation.
+            Returns a list [caption_text, image] instead of just the image (default False).
 
     Returns:
-        The generated diagram as a PNG image.
+        The generated diagram as a PNG image, or a list of [caption text, image] when
+        generate_caption=True.
     """
     settings = Settings(
         refinement_iterations=iterations,
         optimize_inputs=optimize,
         auto_refine=auto_refine,
+        generate_caption=generate_caption,
     )
 
     def _on_progress(event: str, payload: dict) -> None:
@@ -154,7 +160,11 @@ async def generate_diagram(
 
     result = await pipeline.generate(gen_input)
     effective_path, fmt = _compress_for_api(result.image_path)
-    return Image(path=effective_path, format=fmt)
+    image = Image(path=effective_path, format=fmt)
+
+    if result.generated_caption:
+        return [TextContent(type="text", text=result.generated_caption), image]
+    return image
 
 
 @mcp.tool
@@ -165,7 +175,8 @@ async def generate_plot(
     aspect_ratio: str | None = None,
     optimize: bool = False,
     auto_refine: bool = False,
-) -> Image:
+    generate_caption: bool = False,
+) -> Image | list:
     """Generate a publication-quality statistical plot from JSON data.
 
     Args:
@@ -179,9 +190,12 @@ async def generate_plot(
             Set False to skip preprocessing for faster results.
         auto_refine: Let critic loop until satisfied (default True, max 30 iterations).
             Set False to use fixed iteration count for faster results.
+        generate_caption: Auto-generate a publication-ready figure caption after generation.
+            Returns a list [caption_text, image] instead of just the image (default False).
 
     Returns:
-        The generated plot as a PNG image.
+        The generated plot as a PNG image, or a list of [caption text, image] when
+        generate_caption=True.
     """
     raw_data = json.loads(data_json)
 
@@ -189,6 +203,7 @@ async def generate_plot(
         refinement_iterations=iterations,
         optimize_inputs=optimize,
         auto_refine=auto_refine,
+        generate_caption=generate_caption,
     )
 
     def _on_progress(event: str, payload: dict) -> None:
@@ -206,7 +221,11 @@ async def generate_plot(
 
     result = await pipeline.generate(gen_input)
     effective_path, fmt = _compress_for_api(result.image_path)
-    return Image(path=effective_path, format=fmt)
+    image = Image(path=effective_path, format=fmt)
+
+    if result.generated_caption:
+        return [TextContent(type="text", text=result.generated_caption), image]
+    return image
 
 
 @mcp.tool

--- a/paperbanana/agents/caption.py
+++ b/paperbanana/agents/caption.py
@@ -1,0 +1,80 @@
+"""Caption Agent: Generates publication-ready figure captions from the final pipeline output."""
+
+from __future__ import annotations
+
+import structlog
+
+from paperbanana.agents.base import BaseAgent
+from paperbanana.core.types import DiagramType
+from paperbanana.core.utils import load_image
+from paperbanana.providers.base import VLMProvider
+
+logger = structlog.get_logger()
+
+
+class CaptionAgent(BaseAgent):
+    """Generates a publication-ready figure caption after the final iteration.
+
+    Makes a single vision-language model call using the final image together
+    with the source context, communicative intent, and styled description to
+    produce a 1-3 sentence academic caption — the kind that appears beneath
+    figures in conference and journal papers.
+    """
+
+    def __init__(
+        self, vlm_provider: VLMProvider, prompt_dir: str = "prompts", prompt_recorder=None
+    ):
+        super().__init__(vlm_provider, prompt_dir, prompt_recorder=prompt_recorder)
+
+    @property
+    def agent_name(self) -> str:
+        return "caption"
+
+    async def run(
+        self,
+        image_path: str,
+        source_context: str,
+        intent: str,
+        description: str,
+        diagram_type: DiagramType = DiagramType.METHODOLOGY,
+    ) -> str:
+        """Generate a publication-ready caption for the final figure.
+
+        Args:
+            image_path: Path to the final generated image.
+            source_context: Original methodology text or data context.
+            intent: User-supplied communicative intent (raw caption input).
+            description: Final styled description used to produce the image.
+            diagram_type: Type of diagram (methodology or statistical_plot).
+
+        Returns:
+            A 1-3 sentence publication-ready figure caption string.
+        """
+        image = load_image(image_path)
+
+        prompt_type = "diagram" if diagram_type == DiagramType.METHODOLOGY else "plot"
+        template = self.load_prompt(prompt_type)
+        prompt = self.format_prompt(
+            template,
+            source_context=source_context,
+            intent=intent,
+            description=description,
+            prompt_label="caption",
+        )
+
+        logger.info("Running caption agent", image_path=image_path)
+
+        response = await self.vlm.generate(
+            prompt=prompt,
+            images=[image],
+            temperature=0.3,
+            max_tokens=512,
+        )
+
+        caption = response.strip()
+        # Strip any surrounding quotes the model may add
+        if len(caption) >= 2 and caption[0] in ('"', "'") and caption[-1] == caption[0]:
+            caption = caption[1:-1].strip()
+
+        logger.info("Caption generated", length=len(caption))
+        return caption

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -1682,7 +1682,6 @@ def plot(
         "--venue",
         help="Target venue style (neurips, icml, acl, ieee, custom)",
     ),
-<<<<<<< HEAD
     cost_only: bool = typer.Option(
         False,
         "--cost-only",
@@ -1692,16 +1691,11 @@ def plot(
         None,
         "--budget",
         help="Budget cap in USD; pipeline aborts gracefully when exceeded",
-=======
+    ),
     generate_caption: bool = typer.Option(
         False,
         "--generate-caption",
-<<<<<<< HEAD
-        help="Auto-generate a publication-ready figure caption after generation (one extra VLM call)",
->>>>>>> 43d46a4 (feat: add CaptionAgent for auto-generating publication-ready figure captions)
-=======
         help="Auto-generate a publication-ready figure caption (one extra VLM call)",
->>>>>>> e4ba4dc (fix: address review and CI failures)
     ),
 ):
     """Generate a statistical plot from data."""

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -200,7 +200,7 @@ def generate(
     generate_caption: bool = typer.Option(
         False,
         "--generate-caption",
-        help="Auto-generate a publication-ready figure caption after generation (one extra VLM call)",
+        help="Auto-generate a publication-ready figure caption (one extra VLM call)",
     ),
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Show detailed agent progress and timing"
@@ -613,7 +613,7 @@ def generate(
     console.print(f"  Output: [bold]{result.image_path}[/bold]")
     console.print(f"  Run ID: [dim]{result.metadata.get('run_id', 'unknown')}[/dim]")
     if result.generated_caption:
-        console.print(f"\n  [bold]Generated Caption:[/bold]")
+        console.print("\n  [bold]Generated Caption:[/bold]")
         console.print(f"  {result.generated_caption}")
 
     cost_data = result.metadata.get("cost")
@@ -1481,8 +1481,12 @@ def plot(
     generate_caption: bool = typer.Option(
         False,
         "--generate-caption",
+<<<<<<< HEAD
         help="Auto-generate a publication-ready figure caption after generation (one extra VLM call)",
 >>>>>>> 43d46a4 (feat: add CaptionAgent for auto-generating publication-ready figure captions)
+=======
+        help="Auto-generate a publication-ready figure caption (one extra VLM call)",
+>>>>>>> e4ba4dc (fix: address review and CI failures)
     ),
 ):
     """Generate a statistical plot from data."""
@@ -1573,7 +1577,7 @@ def plot(
     result = asyncio.run(_run())
     console.print(f"\n[green]Done![/green] Plot saved to: [bold]{result.image_path}[/bold]")
     if result.generated_caption:
-        console.print(f"\n  [bold]Generated Caption:[/bold]")
+        console.print("\n  [bold]Generated Caption:[/bold]")
         console.print(f"  {result.generated_caption}")
 
     cost_data = result.metadata.get("cost")

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -197,6 +197,11 @@ def generate(
         "--pdf-pages",
         help=("PDF input only: 1-based pages (e.g. '1-5', '3', '1-3,7,10-12'); default: all pages"),
     ),
+    generate_caption: bool = typer.Option(
+        False,
+        "--generate-caption",
+        help="Auto-generate a publication-ready figure caption after generation (one extra VLM call)",
+    ),
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Show detailed agent progress and timing"
     ),
@@ -270,6 +275,8 @@ def generate(
         overrides["venue"] = venue
     if prompt_dir:
         overrides["prompt_dir"] = prompt_dir
+    if generate_caption:
+        overrides["generate_caption"] = True
 
     if config:
         settings = Settings.from_yaml(config, **overrides)
@@ -581,6 +588,15 @@ def generate(
                         console.print(f"    [yellow]↻[/yellow] [dim]{s}[/dim]")
                 else:
                     console.print("    [green]✓[/green] [bold green]Critic satisfied[/bold green]")
+            elif event.stage == PipelineProgressStage.CAPTION_START:
+                console.print("[bold]Phase 3[/bold] — Caption Generation")
+                console.print("  [dim]●[/dim] Generating figure caption...", end="")
+            elif event.stage == PipelineProgressStage.CAPTION_END:
+                console.print(
+                    f" [green]✓[/green] [dim]{event.seconds:.1f}s[/dim]"
+                    if event.seconds is not None
+                    else " [green]✓[/green]"
+                )
 
         return await pipeline.generate(
             gen_input,
@@ -596,6 +612,9 @@ def generate(
     )
     console.print(f"  Output: [bold]{result.image_path}[/bold]")
     console.print(f"  Run ID: [dim]{result.metadata.get('run_id', 'unknown')}[/dim]")
+    if result.generated_caption:
+        console.print(f"\n  [bold]Generated Caption:[/bold]")
+        console.print(f"  {result.generated_caption}")
 
     cost_data = result.metadata.get("cost")
     if cost_data:
@@ -1448,6 +1467,7 @@ def plot(
         "--venue",
         help="Target venue style (neurips, icml, acl, ieee, custom)",
     ),
+<<<<<<< HEAD
     cost_only: bool = typer.Option(
         False,
         "--cost-only",
@@ -1457,6 +1477,12 @@ def plot(
         None,
         "--budget",
         help="Budget cap in USD; pipeline aborts gracefully when exceeded",
+=======
+    generate_caption: bool = typer.Option(
+        False,
+        "--generate-caption",
+        help="Auto-generate a publication-ready figure caption after generation (one extra VLM call)",
+>>>>>>> 43d46a4 (feat: add CaptionAgent for auto-generating publication-ready figure captions)
     ),
 ):
     """Generate a statistical plot from data."""
@@ -1496,6 +1522,7 @@ def plot(
         save_prompts=True if save_prompts is None else save_prompts,
         venue=venue,
         budget_usd=budget,
+        generate_caption=generate_caption,
     )
 
     gen_input = GenerationInput(
@@ -1545,6 +1572,9 @@ def plot(
 
     result = asyncio.run(_run())
     console.print(f"\n[green]Done![/green] Plot saved to: [bold]{result.image_path}[/bold]")
+    if result.generated_caption:
+        console.print(f"\n  [bold]Generated Caption:[/bold]")
+        console.print(f"  {result.generated_caption}")
 
     cost_data = result.metadata.get("cost")
     if cost_data:

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -100,6 +100,9 @@ class Settings(BaseSettings):
     # Prompt settings
     prompt_dir: Optional[str] = None
 
+    # Caption generation
+    generate_caption: bool = False
+
     # Benchmark settings
     benchmark_concurrency: int = 1
 
@@ -244,6 +247,7 @@ def _flatten_yaml(config: dict, prefix: str = "") -> dict:
         "output.save_prompts": "save_prompts",
         "cost.budget": "budget_usd",
         "pipeline.prompt_dir": "prompt_dir",
+        "pipeline.generate_caption": "generate_caption",
     }
 
     def _recurse(d: dict, prefix: str = "") -> None:

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, Optional
 
 import structlog
 
+from paperbanana.agents.caption import CaptionAgent
 from paperbanana.agents.critic import CriticAgent
 from paperbanana.agents.optimizer import InputOptimizerAgent
 from paperbanana.agents.planner import PlannerAgent
@@ -202,6 +203,9 @@ class PaperBananaPipeline:
             prompt_recorder=self._prompt_recorder,
         )
         self.critic = CriticAgent(
+            self._vlm, prompt_dir=prompt_dir, prompt_recorder=self._prompt_recorder
+        )
+        self.caption_agent = CaptionAgent(
             self._vlm, prompt_dir=prompt_dir, prompt_recorder=self._prompt_recorder
         )
 
@@ -732,6 +736,45 @@ class PaperBananaPipeline:
                 run_id=self.run_id,
             )
 
+        # ── Caption Generation (optional) ─────────────────────────────
+        generated_caption: Optional[str] = None
+        caption_seconds = 0.0
+        if self.settings.generate_caption:
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.CAPTION_START,
+                    message="Generating figure caption",
+                ),
+            )
+            self._emit_progress("caption_started")
+            caption_start = time.perf_counter()
+            try:
+                generated_caption = await self.caption_agent.run(
+                    image_path=final_output_path,
+                    source_context=input.source_context,
+                    intent=input.communicative_intent,
+                    description=current_description,
+                    diagram_type=input.diagram_type,
+                )
+            except Exception as e:
+                logger.warning("Caption generation failed", error=str(e))
+            caption_seconds = time.perf_counter() - caption_start
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.CAPTION_END,
+                    message="Caption generated",
+                    seconds=caption_seconds,
+                    extra={"caption": generated_caption},
+                ),
+            )
+            self._emit_progress(
+                "caption_completed",
+                seconds=round(caption_seconds, 1),
+                caption=generated_caption,
+            )
+
         total_seconds = time.perf_counter() - total_start
         logger.info(
             "Total generation time",
@@ -768,6 +811,7 @@ class PaperBananaPipeline:
             "retrieval_seconds": retrieval_seconds,
             "planning_seconds": planning_seconds,
             "styling_seconds": styling_seconds,
+            "caption_seconds": caption_seconds,
             "iterations": iteration_timings,
         }
         metadata_dict["retrieval"] = {
@@ -775,6 +819,8 @@ class PaperBananaPipeline:
             "external_enabled": self.settings.exemplar_retrieval_enabled,
             "external_candidate_ids": external_candidate_ids,
         }
+        if generated_caption is not None:
+            metadata_dict["generated_caption"] = generated_caption
 
         if self._cost_tracker:
             cost_summary = self._cost_tracker.summary()
@@ -791,6 +837,7 @@ class PaperBananaPipeline:
             description=current_description,
             iterations=iterations,
             metadata=metadata_dict,
+            generated_caption=generated_caption,
         )
 
         logger.info(
@@ -1034,6 +1081,46 @@ class PaperBananaPipeline:
                 run_id=self.run_id,
             )
 
+        # ── Caption Generation (optional) ─────────────────────────────
+        generated_caption: Optional[str] = None
+        caption_seconds = 0.0
+        if self.settings.generate_caption:
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.CAPTION_START,
+                    message="Generating figure caption",
+                ),
+            )
+            self._emit_progress("caption_started", mode="continue")
+            caption_start = time.perf_counter()
+            try:
+                generated_caption = await self.caption_agent.run(
+                    image_path=final_output_path,
+                    source_context=resume_state.source_context,
+                    intent=resume_state.communicative_intent,
+                    description=current_description,
+                    diagram_type=resume_state.diagram_type,
+                )
+            except Exception as e:
+                logger.warning("Caption generation failed", error=str(e))
+            caption_seconds = time.perf_counter() - caption_start
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.CAPTION_END,
+                    message="Caption generated",
+                    seconds=caption_seconds,
+                    extra={"caption": generated_caption},
+                ),
+            )
+            self._emit_progress(
+                "caption_completed",
+                seconds=round(caption_seconds, 1),
+                caption=generated_caption,
+                mode="continue",
+            )
+
         total_seconds = time.perf_counter() - total_start
         logger.info(
             "Continue run complete",
@@ -1066,11 +1153,14 @@ class PaperBananaPipeline:
         metadata_dict = metadata.model_dump()
         metadata_dict["timing"] = {
             "continue_total_seconds": total_seconds,
+            "caption_seconds": caption_seconds,
             "iterations": iteration_timings,
         }
         metadata_dict["continued_from_iteration"] = start_iter
         if user_feedback:
             metadata_dict["user_feedback"] = user_feedback
+        if generated_caption is not None:
+            metadata_dict["generated_caption"] = generated_caption
 
         if self._cost_tracker:
             cost_summary = self._cost_tracker.summary()
@@ -1087,6 +1177,7 @@ class PaperBananaPipeline:
             description=current_description,
             iterations=iterations,
             metadata=metadata_dict,
+            generated_caption=generated_caption,
         )
 
         return output

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -242,6 +242,62 @@ class PaperBananaPipeline:
             return self.settings.prompt_dir
         return find_prompt_dir()
 
+    async def _generate_caption(
+        self,
+        *,
+        image_path: str,
+        source_context: str,
+        intent: str,
+        description: str,
+        diagram_type: DiagramType,
+        progress_callback: Optional[Callable[[PipelineProgressEvent], None]],
+    ) -> tuple[Optional[str], float]:
+        """Run the CaptionAgent if ``generate_caption`` is enabled.
+
+        Returns:
+            (generated_caption, caption_seconds).  Both default to
+            ``(None, 0.0)`` when the setting is off or the agent fails.
+        """
+        if not self.settings.generate_caption:
+            return None, 0.0
+
+        _emit_progress(
+            progress_callback,
+            PipelineProgressEvent(
+                stage=PipelineProgressStage.CAPTION_START,
+                message="Generating figure caption",
+            ),
+        )
+        self._emit_progress("caption_started")
+        generated_caption: Optional[str] = None
+        caption_start = time.perf_counter()
+        try:
+            generated_caption = await self.caption_agent.run(
+                image_path=image_path,
+                source_context=source_context,
+                intent=intent,
+                description=description,
+                diagram_type=diagram_type,
+            )
+        except Exception as e:
+            logger.warning("Caption generation failed", error=str(e))
+        caption_seconds = time.perf_counter() - caption_start
+        _emit_progress(
+            progress_callback,
+            PipelineProgressEvent(
+                stage=PipelineProgressStage.CAPTION_END,
+                message="Caption generated",
+                seconds=caption_seconds,
+                extra={"caption": generated_caption},
+            ),
+        )
+        self._emit_progress(
+            "caption_completed",
+            seconds=round(caption_seconds, 1),
+            caption=generated_caption,
+        )
+        return generated_caption, caption_seconds
+
     async def _resolve_retrieval_candidates(
         self, input: GenerationInput, candidates: list[ReferenceExample]
     ) -> tuple[list[ReferenceExample], str, list[str]]:
@@ -737,43 +793,14 @@ class PaperBananaPipeline:
             )
 
         # ── Caption Generation (optional) ─────────────────────────────
-        generated_caption: Optional[str] = None
-        caption_seconds = 0.0
-        if self.settings.generate_caption:
-            _emit_progress(
-                progress_callback,
-                PipelineProgressEvent(
-                    stage=PipelineProgressStage.CAPTION_START,
-                    message="Generating figure caption",
-                ),
-            )
-            self._emit_progress("caption_started")
-            caption_start = time.perf_counter()
-            try:
-                generated_caption = await self.caption_agent.run(
-                    image_path=final_output_path,
-                    source_context=input.source_context,
-                    intent=input.communicative_intent,
-                    description=current_description,
-                    diagram_type=input.diagram_type,
-                )
-            except Exception as e:
-                logger.warning("Caption generation failed", error=str(e))
-            caption_seconds = time.perf_counter() - caption_start
-            _emit_progress(
-                progress_callback,
-                PipelineProgressEvent(
-                    stage=PipelineProgressStage.CAPTION_END,
-                    message="Caption generated",
-                    seconds=caption_seconds,
-                    extra={"caption": generated_caption},
-                ),
-            )
-            self._emit_progress(
-                "caption_completed",
-                seconds=round(caption_seconds, 1),
-                caption=generated_caption,
-            )
+        generated_caption, caption_seconds = await self._generate_caption(
+            image_path=final_output_path,
+            source_context=input.source_context,
+            intent=input.communicative_intent,
+            description=current_description,
+            diagram_type=input.diagram_type,
+            progress_callback=progress_callback,
+        )
 
         total_seconds = time.perf_counter() - total_start
         logger.info(
@@ -1082,44 +1109,14 @@ class PaperBananaPipeline:
             )
 
         # ── Caption Generation (optional) ─────────────────────────────
-        generated_caption: Optional[str] = None
-        caption_seconds = 0.0
-        if self.settings.generate_caption:
-            _emit_progress(
-                progress_callback,
-                PipelineProgressEvent(
-                    stage=PipelineProgressStage.CAPTION_START,
-                    message="Generating figure caption",
-                ),
-            )
-            self._emit_progress("caption_started", mode="continue")
-            caption_start = time.perf_counter()
-            try:
-                generated_caption = await self.caption_agent.run(
-                    image_path=final_output_path,
-                    source_context=resume_state.source_context,
-                    intent=resume_state.communicative_intent,
-                    description=current_description,
-                    diagram_type=resume_state.diagram_type,
-                )
-            except Exception as e:
-                logger.warning("Caption generation failed", error=str(e))
-            caption_seconds = time.perf_counter() - caption_start
-            _emit_progress(
-                progress_callback,
-                PipelineProgressEvent(
-                    stage=PipelineProgressStage.CAPTION_END,
-                    message="Caption generated",
-                    seconds=caption_seconds,
-                    extra={"caption": generated_caption},
-                ),
-            )
-            self._emit_progress(
-                "caption_completed",
-                seconds=round(caption_seconds, 1),
-                caption=generated_caption,
-                mode="continue",
-            )
+        generated_caption, caption_seconds = await self._generate_caption(
+            image_path=final_output_path,
+            source_context=resume_state.source_context,
+            intent=resume_state.communicative_intent,
+            description=current_description,
+            diagram_type=resume_state.diagram_type,
+            progress_callback=progress_callback,
+        )
 
         total_seconds = time.perf_counter() - total_start
         logger.info(

--- a/paperbanana/core/types.py
+++ b/paperbanana/core/types.py
@@ -35,6 +35,8 @@ class PipelineProgressStage(str, Enum):
     VISUALIZER_END = "visualizer_end"
     CRITIC_START = "critic_start"
     CRITIC_END = "critic_end"
+    CAPTION_START = "caption_start"
+    CAPTION_END = "caption_end"
 
 
 class PipelineProgressEvent(BaseModel):
@@ -133,6 +135,13 @@ class GenerationOutput(BaseModel):
         default_factory=list, description="History of refinement iterations"
     )
     metadata: dict[str, Any] = Field(default_factory=dict)
+    generated_caption: Optional[str] = Field(
+        default=None,
+        description=(
+            "Auto-generated publication-ready figure caption. "
+            "Only present when generate_caption=True was passed to the pipeline."
+        ),
+    )
 
 
 VALID_WINNERS = {"Model", "Human", "Both are good", "Both are bad"}

--- a/prompts/diagram/caption.txt
+++ b/prompts/diagram/caption.txt
@@ -1,0 +1,28 @@
+## ROLE
+
+You are an expert academic writer specializing in writing figure captions for top-tier AI/ML conference papers (NeurIPS, ICML, ICLR, CVPR, ACL).
+
+## TASK
+
+Given the methodology section, the communicative intent, the detailed visual description, and the final generated diagram, write a publication-ready figure caption.
+
+## CAPTION RULES
+
+1. **Length**: 1–3 sentences. No more.
+2. **Structure**: Start with a brief label like "Overview of [method/framework/approach]." or "Illustration of [concept].". Follow with 1–2 sentences that describe what the diagram shows and how it connects to the paper's contribution.
+3. **Standalone**: The caption must be fully understandable without reading the paper body. Introduce any necessary acronyms on first use.
+4. **Precise**: Use the exact method names, module names, and terminology from the methodology section. Do not invent names not present in the source.
+5. **No figure number**: Do not include "Figure 1:" or any numbering — the template handles that.
+6. **Active voice**: Prefer active, concise constructions over passive.
+7. **No meta-language**: Do not say "This figure shows..." — just describe it directly.
+
+## INPUT DATA
+
+- **Methodology Section**: {source_context}
+- **Communicative Intent**: {intent}
+- **Visual Description**: {description}
+- **Final Diagram**: [The generated diagram is provided as an image]
+
+## OUTPUT
+
+Return only the caption text. No JSON, no markdown, no extra commentary. Plain text only.

--- a/prompts/plot/caption.txt
+++ b/prompts/plot/caption.txt
@@ -1,0 +1,29 @@
+## ROLE
+
+You are an expert academic writer specializing in writing figure captions for top-tier AI/ML conference papers (NeurIPS, ICML, ICLR, CVPR, ACL).
+
+## TASK
+
+Given the data context, the communicative intent, the visual description, and the final generated statistical plot, write a publication-ready figure caption.
+
+## CAPTION RULES
+
+1. **Length**: 1–3 sentences. No more.
+2. **Structure**: Start with a brief label that summarizes what the plot shows (e.g., "Comparison of model accuracy across five benchmarks."). Follow with 1–2 sentences highlighting the key takeaway or trend the reader should notice.
+3. **Standalone**: The caption must be fully understandable without reading the paper body. Introduce any necessary acronyms on first use.
+4. **Precise**: Reference the exact metrics, baselines, datasets, or model names present in the data. Do not invent terms not present in the source.
+5. **No figure number**: Do not include "Figure 1:" or any numbering — the template handles that.
+6. **Active voice**: Prefer active, concise constructions over passive.
+7. **No meta-language**: Do not say "This figure shows..." — just describe it directly.
+8. **Highlight insight**: Where appropriate, briefly note the most important result or trend (e.g., "Our method achieves the highest accuracy on 4 out of 5 benchmarks.").
+
+## INPUT DATA
+
+- **Data Context**: {source_context}
+- **Communicative Intent**: {intent}
+- **Visual Description**: {description}
+- **Final Plot**: [The generated plot is provided as an image]
+
+## OUTPUT
+
+Return only the caption text. No JSON, no markdown, no extra commentary. Plain text only.

--- a/tests/test_caption_feature.py
+++ b/tests/test_caption_feature.py
@@ -31,7 +31,6 @@ from paperbanana.core.types import (
     PipelineProgressStage,
 )
 
-
 # ── Shared mock helpers ────────────────────────────────────────────
 
 
@@ -216,9 +215,7 @@ async def test_caption_agent_uses_plot_prompt_for_statistical_type(tmp_path):
 @pytest.mark.asyncio
 async def test_caption_disabled_by_default(tmp_path):
     """generate_caption=False (default) → generated_caption is None."""
-    vlm = _MockVLM(
-        ["Planned description", "Styled description", _critic_satisfied()]
-    )
+    vlm = _MockVLM(["Planned description", "Styled description", _critic_satisfied()])
     pipeline = PaperBananaPipeline(
         settings=_make_settings(tmp_path),
         vlm_client=vlm,
@@ -261,8 +258,8 @@ async def test_caption_generated_when_enabled(tmp_path):
 @pytest.mark.asyncio
 async def test_caption_uses_final_output_image(tmp_path):
     """CaptionAgent receives the final_output image path, not a per-iteration path."""
-    from paperbanana.core.utils import find_prompt_dir
     from paperbanana.agents.caption import CaptionAgent
+    from paperbanana.core.utils import find_prompt_dir
 
     called_with_paths = []
 
@@ -278,9 +275,7 @@ async def test_caption_uses_final_output_image(tmp_path):
         vlm_client=vlm,
         image_gen_fn=_MockImageGen(),
     )
-    pipeline.caption_agent = _TrackingCaptionAgent(
-        vlm_provider=vlm, prompt_dir=find_prompt_dir()
-    )
+    pipeline.caption_agent = _TrackingCaptionAgent(vlm_provider=vlm, prompt_dir=find_prompt_dir())
 
     result = await pipeline.generate(
         GenerationInput(source_context="ctx", communicative_intent="intent")
@@ -309,9 +304,7 @@ async def test_caption_failure_is_graceful(tmp_path):
         vlm_client=vlm,
         image_gen_fn=_MockImageGen(),
     )
-    pipeline.caption_agent = _FailingCaptionAgent(
-        vlm_provider=vlm, prompt_dir=find_prompt_dir()
-    )
+    pipeline.caption_agent = _FailingCaptionAgent(vlm_provider=vlm, prompt_dir=find_prompt_dir())
 
     result = await pipeline.generate(
         GenerationInput(source_context="ctx", communicative_intent="intent")
@@ -358,9 +351,7 @@ async def test_caption_seconds_always_present_in_timing(tmp_path):
     """timing.caption_seconds is always in metadata, even when caption is disabled."""
     vlm = _MockVLM(["Plan", "Style", _critic_satisfied()])
     settings = _make_settings(tmp_path, generate_caption=False)
-    pipeline = PaperBananaPipeline(
-        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
-    )
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
     result = await pipeline.generate(
         GenerationInput(source_context="ctx", communicative_intent="intent")
     )
@@ -371,13 +362,9 @@ async def test_caption_seconds_always_present_in_timing(tmp_path):
 @pytest.mark.asyncio
 async def test_caption_seconds_nonzero_when_enabled(tmp_path):
     """timing.caption_seconds > 0 when caption generation runs."""
-    import time as _time
-
     vlm = _MockVLM(["Plan", "Style", _critic_satisfied(), "A generated caption."])
     settings = _make_settings(tmp_path, generate_caption=True)
-    pipeline = PaperBananaPipeline(
-        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
-    )
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
     result = await pipeline.generate(
         GenerationInput(source_context="ctx", communicative_intent="intent")
     )
@@ -394,9 +381,7 @@ async def test_caption_progress_events_emitted(tmp_path):
     """CAPTION_START and CAPTION_END progress events are emitted when enabled."""
     vlm = _MockVLM(["Plan", "Style", _critic_satisfied(), "A caption."])
     settings = _make_settings(tmp_path, generate_caption=True)
-    pipeline = PaperBananaPipeline(
-        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
-    )
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
 
     received_stages = []
 
@@ -421,9 +406,7 @@ async def test_no_caption_progress_events_when_disabled(tmp_path):
     """No CAPTION_* events are emitted when generate_caption=False."""
     vlm = _MockVLM(["Plan", "Style", _critic_satisfied()])
     settings = _make_settings(tmp_path, generate_caption=False)
-    pipeline = PaperBananaPipeline(
-        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
-    )
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
 
     received_stages = []
 
@@ -445,9 +428,7 @@ async def test_caption_end_event_carries_caption_text(tmp_path):
     expected_caption = "Our method combines diffusion and attention."
     vlm = _MockVLM(["Plan", "Style", _critic_satisfied(), expected_caption])
     settings = _make_settings(tmp_path, generate_caption=True)
-    pipeline = PaperBananaPipeline(
-        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
-    )
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
 
     caption_end_events = []
 
@@ -508,9 +489,7 @@ async def test_caption_in_continue_run(tmp_path):
         save_iterations=False,
         generate_caption=True,
     )
-    pipeline = PaperBananaPipeline(
-        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
-    )
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
 
     result = await pipeline.continue_run(resume_state=state, additional_iterations=1)
 
@@ -554,9 +533,7 @@ async def test_no_caption_in_continue_run_when_disabled(tmp_path):
         save_iterations=False,
         generate_caption=False,
     )
-    pipeline = PaperBananaPipeline(
-        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
-    )
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
 
     result = await pipeline.continue_run(resume_state=state, additional_iterations=1)
     assert result.generated_caption is None

--- a/tests/test_caption_feature.py
+++ b/tests/test_caption_feature.py
@@ -1,0 +1,627 @@
+"""Tests for the auto-generate figure caption feature (issue #98).
+
+Covers:
+- Settings: generate_caption default and override, YAML loading
+- CaptionAgent: signature, prompt loading, quote stripping, diagram/plot types
+- Pipeline: caption disabled (default), caption enabled, caption failure is graceful,
+  metadata written, GenerationOutput.generated_caption populated
+- continue_run: caption also generated in continue flow
+- Progress events: CAPTION_START / CAPTION_END emitted
+- CLI: --generate-caption flag wired into Settings
+- Prompt files exist for both diagram and plot types
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image
+
+from paperbanana.core.config import Settings
+from paperbanana.core.pipeline import PaperBananaPipeline
+from paperbanana.core.resume import load_resume_state
+from paperbanana.core.types import (
+    DiagramType,
+    GenerationInput,
+    PipelineProgressStage,
+)
+
+
+# ── Shared mock helpers ────────────────────────────────────────────
+
+
+class _MockVLM:
+    """Sequenced VLM mock returning pre-configured responses in order."""
+
+    name = "mock-vlm"
+    model_name = "mock-model"
+
+    def __init__(self, responses: list[str]):
+        self._responses = responses
+        self._idx = 0
+        self.calls: list[dict] = []
+
+    async def generate(self, *args, **kwargs):
+        self.calls.append({"args": args, "kwargs": kwargs})
+        idx = min(self._idx, len(self._responses) - 1)
+        self._idx += 1
+        return self._responses[idx]
+
+
+class _MockImageGen:
+    name = "mock-image-gen"
+    model_name = "mock-image-model"
+
+    async def generate(self, *args, **kwargs):
+        return Image.new("RGB", (128, 128), color=(200, 200, 200))
+
+
+def _critic_satisfied() -> str:
+    return json.dumps({"critic_suggestions": [], "revised_description": None})
+
+
+def _make_settings(tmp_path, **extra) -> Settings:
+    return Settings(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "refs"),
+        refinement_iterations=1,
+        save_iterations=False,
+        **extra,
+    )
+
+
+# ── Settings tests ────────────────────────────────────────────────
+
+
+def test_generate_caption_default_false():
+    assert Settings().generate_caption is False
+
+
+def test_generate_caption_override():
+    assert Settings(generate_caption=True).generate_caption is True
+
+
+def test_generate_caption_from_yaml():
+    import yaml
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.safe_dump({"pipeline": {"generate_caption": True}}, f)
+        path = f.name
+    try:
+        settings = Settings.from_yaml(path)
+        assert settings.generate_caption is True
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+# ── CaptionAgent unit tests ────────────────────────────────────────
+
+
+def test_caption_agent_has_correct_name():
+    from paperbanana.agents.caption import CaptionAgent
+
+    assert CaptionAgent.__name__ == "CaptionAgent"
+    mock_vlm = MagicMock()
+    agent = CaptionAgent(vlm_provider=mock_vlm)
+    assert agent.agent_name == "caption"
+
+
+def test_caption_agent_run_signature():
+    from paperbanana.agents.caption import CaptionAgent
+
+    sig = inspect.signature(CaptionAgent.run)
+    params = list(sig.parameters.keys())
+    assert "image_path" in params
+    assert "source_context" in params
+    assert "intent" in params
+    assert "description" in params
+    assert "diagram_type" in params
+    # diagram_type defaults to METHODOLOGY
+    assert sig.parameters["diagram_type"].default == DiagramType.METHODOLOGY
+
+
+def test_caption_prompts_exist_for_both_types():
+    prompts_root = Path(__file__).parent.parent / "prompts"
+    assert (prompts_root / "diagram" / "caption.txt").exists(), "diagram/caption.txt missing"
+    assert (prompts_root / "plot" / "caption.txt").exists(), "plot/caption.txt missing"
+
+
+def test_caption_prompt_has_required_placeholders():
+    prompts_root = Path(__file__).parent.parent / "prompts"
+    for subdir in ("diagram", "plot"):
+        text = (prompts_root / subdir / "caption.txt").read_text()
+        assert "{source_context}" in text, f"{subdir}/caption.txt missing {{source_context}}"
+        assert "{intent}" in text, f"{subdir}/caption.txt missing {{intent}}"
+        assert "{description}" in text, f"{subdir}/caption.txt missing {{description}}"
+
+
+@pytest.mark.asyncio
+async def test_caption_agent_strips_surrounding_quotes(tmp_path):
+    """CaptionAgent strips surrounding double/single quotes from model output."""
+    from paperbanana.agents.caption import CaptionAgent
+    from paperbanana.core.utils import find_prompt_dir
+
+    # Create a tiny test image
+    img_path = str(tmp_path / "test.png")
+    Image.new("RGB", (64, 64), color=(0, 0, 0)).save(img_path)
+
+    mock_vlm = MagicMock()
+    mock_vlm.generate = AsyncMock(return_value='"This is a quoted caption."')
+
+    agent = CaptionAgent(vlm_provider=mock_vlm, prompt_dir=find_prompt_dir())
+    result = await agent.run(
+        image_path=img_path,
+        source_context="Source context here",
+        intent="Show framework overview",
+        description="Detailed visual description",
+    )
+    assert result == "This is a quoted caption."
+    assert not result.startswith('"')
+
+
+@pytest.mark.asyncio
+async def test_caption_agent_no_strip_when_no_quotes(tmp_path):
+    """CaptionAgent returns the response unchanged when no surrounding quotes."""
+    from paperbanana.agents.caption import CaptionAgent
+    from paperbanana.core.utils import find_prompt_dir
+
+    img_path = str(tmp_path / "test.png")
+    Image.new("RGB", (64, 64)).save(img_path)
+
+    mock_vlm = MagicMock()
+    expected = "Overview of our encoder-decoder framework."
+    mock_vlm.generate = AsyncMock(return_value=expected)
+
+    agent = CaptionAgent(vlm_provider=mock_vlm, prompt_dir=find_prompt_dir())
+    result = await agent.run(
+        image_path=img_path,
+        source_context="ctx",
+        intent="intent",
+        description="desc",
+    )
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_caption_agent_uses_plot_prompt_for_statistical_type(tmp_path):
+    """CaptionAgent loads the 'plot' prompt when diagram_type is STATISTICAL_PLOT."""
+    from paperbanana.agents.caption import CaptionAgent
+    from paperbanana.core.utils import find_prompt_dir
+
+    img_path = str(tmp_path / "test.png")
+    Image.new("RGB", (64, 64)).save(img_path)
+
+    mock_vlm = MagicMock()
+    mock_vlm.generate = AsyncMock(return_value="A plot caption.")
+
+    agent = CaptionAgent(vlm_provider=mock_vlm, prompt_dir=find_prompt_dir())
+    result = await agent.run(
+        image_path=img_path,
+        source_context="data context",
+        intent="bar chart intent",
+        description="bar chart description",
+        diagram_type=DiagramType.STATISTICAL_PLOT,
+    )
+    assert result == "A plot caption."
+
+
+# ── Pipeline: caption disabled (default behaviour) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_caption_disabled_by_default(tmp_path):
+    """generate_caption=False (default) → generated_caption is None."""
+    vlm = _MockVLM(
+        ["Planned description", "Styled description", _critic_satisfied()]
+    )
+    pipeline = PaperBananaPipeline(
+        settings=_make_settings(tmp_path),
+        vlm_client=vlm,
+        image_gen_fn=_MockImageGen(),
+    )
+    result = await pipeline.generate(
+        GenerationInput(source_context="ctx", communicative_intent="intent")
+    )
+    assert result.generated_caption is None
+    assert "generated_caption" not in result.metadata
+    # Caption agent should NOT have been called: VLM call count == 3 (plan+style+critic)
+    assert vlm._idx == 3
+
+
+@pytest.mark.asyncio
+async def test_caption_generated_when_enabled(tmp_path):
+    """generate_caption=True → generated_caption is set on output and metadata."""
+    expected_caption = "Overview of our encoder-decoder attention mechanism."
+    vlm = _MockVLM(
+        [
+            "Planned description",
+            "Styled description",
+            _critic_satisfied(),
+            expected_caption,  # caption agent call
+        ]
+    )
+    settings = _make_settings(tmp_path, generate_caption=True)
+    pipeline = PaperBananaPipeline(
+        settings=settings,
+        vlm_client=vlm,
+        image_gen_fn=_MockImageGen(),
+    )
+    result = await pipeline.generate(
+        GenerationInput(source_context="ctx", communicative_intent="intent")
+    )
+    assert result.generated_caption == expected_caption
+    assert result.metadata["generated_caption"] == expected_caption
+
+
+@pytest.mark.asyncio
+async def test_caption_uses_final_output_image(tmp_path):
+    """CaptionAgent receives the final_output image path, not a per-iteration path."""
+    from paperbanana.core.utils import find_prompt_dir
+    from paperbanana.agents.caption import CaptionAgent
+
+    called_with_paths = []
+
+    class _TrackingCaptionAgent(CaptionAgent):
+        async def run(self, image_path, **kwargs):
+            called_with_paths.append(image_path)
+            return "Caption text"
+
+    vlm = _MockVLM(["Plan", "Style", _critic_satisfied()])
+    settings = _make_settings(tmp_path, generate_caption=True)
+    pipeline = PaperBananaPipeline(
+        settings=settings,
+        vlm_client=vlm,
+        image_gen_fn=_MockImageGen(),
+    )
+    pipeline.caption_agent = _TrackingCaptionAgent(
+        vlm_provider=vlm, prompt_dir=find_prompt_dir()
+    )
+
+    result = await pipeline.generate(
+        GenerationInput(source_context="ctx", communicative_intent="intent")
+    )
+
+    assert len(called_with_paths) == 1
+    # Should be the final output file, not an iteration-level image
+    assert "final_output" in called_with_paths[0]
+    assert called_with_paths[0] == result.image_path
+
+
+@pytest.mark.asyncio
+async def test_caption_failure_is_graceful(tmp_path):
+    """If CaptionAgent raises, the pipeline still returns a valid result with None caption."""
+    from paperbanana.agents.caption import CaptionAgent
+    from paperbanana.core.utils import find_prompt_dir
+
+    class _FailingCaptionAgent(CaptionAgent):
+        async def run(self, **kwargs):
+            raise RuntimeError("VLM quota exceeded")
+
+    vlm = _MockVLM(["Plan", "Style", _critic_satisfied()])
+    settings = _make_settings(tmp_path, generate_caption=True)
+    pipeline = PaperBananaPipeline(
+        settings=settings,
+        vlm_client=vlm,
+        image_gen_fn=_MockImageGen(),
+    )
+    pipeline.caption_agent = _FailingCaptionAgent(
+        vlm_provider=vlm, prompt_dir=find_prompt_dir()
+    )
+
+    result = await pipeline.generate(
+        GenerationInput(source_context="ctx", communicative_intent="intent")
+    )
+
+    # Pipeline must still succeed and image must exist
+    assert Path(result.image_path).exists()
+    # Caption is None because agent failed
+    assert result.generated_caption is None
+    assert "generated_caption" not in result.metadata
+
+
+@pytest.mark.asyncio
+async def test_caption_saved_to_metadata_json(tmp_path):
+    """With save_iterations=True, generated_caption appears in metadata.json."""
+    expected_caption = "Illustration of the proposed attention routing mechanism."
+    vlm = _MockVLM(["Plan", "Style", _critic_satisfied(), expected_caption])
+    settings = Settings(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "refs"),
+        refinement_iterations=1,
+        save_iterations=True,
+        generate_caption=True,
+    )
+    pipeline = PaperBananaPipeline(
+        settings=settings,
+        vlm_client=vlm,
+        image_gen_fn=_MockImageGen(),
+    )
+    result = await pipeline.generate(
+        GenerationInput(source_context="ctx", communicative_intent="intent")
+    )
+
+    # Read the persisted metadata.json
+    run_id = result.metadata["run_id"]
+    metadata_path = Path(settings.output_dir) / run_id / "metadata.json"
+    assert metadata_path.exists()
+    saved = json.loads(metadata_path.read_text())
+    assert saved["generated_caption"] == expected_caption
+
+
+@pytest.mark.asyncio
+async def test_caption_seconds_always_present_in_timing(tmp_path):
+    """timing.caption_seconds is always in metadata, even when caption is disabled."""
+    vlm = _MockVLM(["Plan", "Style", _critic_satisfied()])
+    settings = _make_settings(tmp_path, generate_caption=False)
+    pipeline = PaperBananaPipeline(
+        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
+    )
+    result = await pipeline.generate(
+        GenerationInput(source_context="ctx", communicative_intent="intent")
+    )
+    assert "caption_seconds" in result.metadata["timing"]
+    assert result.metadata["timing"]["caption_seconds"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_caption_seconds_nonzero_when_enabled(tmp_path):
+    """timing.caption_seconds > 0 when caption generation runs."""
+    import time as _time
+
+    vlm = _MockVLM(["Plan", "Style", _critic_satisfied(), "A generated caption."])
+    settings = _make_settings(tmp_path, generate_caption=True)
+    pipeline = PaperBananaPipeline(
+        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
+    )
+    result = await pipeline.generate(
+        GenerationInput(source_context="ctx", communicative_intent="intent")
+    )
+    # caption_seconds should be a non-negative float (may be 0.0 on very fast machines)
+    assert isinstance(result.metadata["timing"]["caption_seconds"], float)
+    assert result.metadata["timing"]["caption_seconds"] >= 0.0
+
+
+# ── Progress events ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_caption_progress_events_emitted(tmp_path):
+    """CAPTION_START and CAPTION_END progress events are emitted when enabled."""
+    vlm = _MockVLM(["Plan", "Style", _critic_satisfied(), "A caption."])
+    settings = _make_settings(tmp_path, generate_caption=True)
+    pipeline = PaperBananaPipeline(
+        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
+    )
+
+    received_stages = []
+
+    def on_progress(event):
+        received_stages.append(event.stage)
+
+    await pipeline.generate(
+        GenerationInput(source_context="ctx", communicative_intent="intent"),
+        progress_callback=on_progress,
+    )
+
+    assert PipelineProgressStage.CAPTION_START in received_stages
+    assert PipelineProgressStage.CAPTION_END in received_stages
+    # START must come before END
+    start_idx = received_stages.index(PipelineProgressStage.CAPTION_START)
+    end_idx = received_stages.index(PipelineProgressStage.CAPTION_END)
+    assert start_idx < end_idx
+
+
+@pytest.mark.asyncio
+async def test_no_caption_progress_events_when_disabled(tmp_path):
+    """No CAPTION_* events are emitted when generate_caption=False."""
+    vlm = _MockVLM(["Plan", "Style", _critic_satisfied()])
+    settings = _make_settings(tmp_path, generate_caption=False)
+    pipeline = PaperBananaPipeline(
+        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
+    )
+
+    received_stages = []
+
+    def on_progress(event):
+        received_stages.append(event.stage)
+
+    await pipeline.generate(
+        GenerationInput(source_context="ctx", communicative_intent="intent"),
+        progress_callback=on_progress,
+    )
+
+    assert PipelineProgressStage.CAPTION_START not in received_stages
+    assert PipelineProgressStage.CAPTION_END not in received_stages
+
+
+@pytest.mark.asyncio
+async def test_caption_end_event_carries_caption_text(tmp_path):
+    """CAPTION_END event's extra dict contains the generated caption text."""
+    expected_caption = "Our method combines diffusion and attention."
+    vlm = _MockVLM(["Plan", "Style", _critic_satisfied(), expected_caption])
+    settings = _make_settings(tmp_path, generate_caption=True)
+    pipeline = PaperBananaPipeline(
+        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
+    )
+
+    caption_end_events = []
+
+    def on_progress(event):
+        if event.stage == PipelineProgressStage.CAPTION_END:
+            caption_end_events.append(event)
+
+    await pipeline.generate(
+        GenerationInput(source_context="ctx", communicative_intent="intent"),
+        progress_callback=on_progress,
+    )
+
+    assert len(caption_end_events) == 1
+    assert caption_end_events[0].extra is not None
+    assert caption_end_events[0].extra.get("caption") == expected_caption
+
+
+# ── continue_run: caption also generated ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_caption_in_continue_run(tmp_path):
+    """generate_caption=True also generates a caption in continue_run flow."""
+    run_id = "run_caption_continue"
+    run_dir = tmp_path / "outputs" / run_id
+    run_dir.mkdir(parents=True)
+
+    (run_dir / "run_input.json").write_text(
+        json.dumps(
+            {
+                "source_context": "Transformer architecture",
+                "communicative_intent": "Pipeline overview",
+                "diagram_type": "methodology",
+            }
+        )
+    )
+    iter1 = run_dir / "iter_1"
+    iter1.mkdir()
+    (iter1 / "details.json").write_text(
+        json.dumps(
+            {
+                "description": "Previous description",
+                "critique": {
+                    "critic_suggestions": ["Add arrows"],
+                    "revised_description": "Revised description",
+                },
+            }
+        )
+    )
+
+    state = load_resume_state(str(tmp_path / "outputs"), run_id)
+    expected_caption = "Illustration of the transformer pipeline with attention modules."
+    vlm = _MockVLM([_critic_satisfied(), expected_caption])
+    settings = Settings(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "refs"),
+        refinement_iterations=1,
+        save_iterations=False,
+        generate_caption=True,
+    )
+    pipeline = PaperBananaPipeline(
+        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
+    )
+
+    result = await pipeline.continue_run(resume_state=state, additional_iterations=1)
+
+    assert result.generated_caption == expected_caption
+    assert result.metadata["generated_caption"] == expected_caption
+
+
+@pytest.mark.asyncio
+async def test_no_caption_in_continue_run_when_disabled(tmp_path):
+    """generate_caption=False → generated_caption is None in continue_run."""
+    run_id = "run_no_caption_continue"
+    run_dir = tmp_path / "outputs" / run_id
+    run_dir.mkdir(parents=True)
+
+    (run_dir / "run_input.json").write_text(
+        json.dumps(
+            {
+                "source_context": "BERT fine-tuning",
+                "communicative_intent": "Fine-tuning pipeline",
+                "diagram_type": "methodology",
+            }
+        )
+    )
+    iter1 = run_dir / "iter_1"
+    iter1.mkdir()
+    (iter1 / "details.json").write_text(
+        json.dumps(
+            {
+                "description": "Description v1",
+                "critique": {"critic_suggestions": [], "revised_description": None},
+            }
+        )
+    )
+
+    state = load_resume_state(str(tmp_path / "outputs"), run_id)
+    vlm = _MockVLM([_critic_satisfied()])
+    settings = Settings(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "refs"),
+        refinement_iterations=1,
+        save_iterations=False,
+        generate_caption=False,
+    )
+    pipeline = PaperBananaPipeline(
+        settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen()
+    )
+
+    result = await pipeline.continue_run(resume_state=state, additional_iterations=1)
+    assert result.generated_caption is None
+    assert "generated_caption" not in result.metadata
+
+
+# ── GenerationOutput type tests ───────────────────────────────────
+
+
+def test_generation_output_generated_caption_field():
+    """GenerationOutput has generated_caption as an optional field defaulting to None."""
+    from paperbanana.core.types import GenerationOutput
+
+    out = GenerationOutput(image_path="a.png", description="desc")
+    assert out.generated_caption is None
+
+    out2 = GenerationOutput(
+        image_path="b.png",
+        description="desc",
+        generated_caption="A caption.",
+    )
+    assert out2.generated_caption == "A caption."
+
+
+def test_pipeline_progress_stage_has_caption_stages():
+    """PipelineProgressStage enum contains CAPTION_START and CAPTION_END."""
+    assert hasattr(PipelineProgressStage, "CAPTION_START")
+    assert hasattr(PipelineProgressStage, "CAPTION_END")
+    assert PipelineProgressStage.CAPTION_START.value == "caption_start"
+    assert PipelineProgressStage.CAPTION_END.value == "caption_end"
+
+
+# ── CLI wiring ─────────────────────────────────────────────────────
+
+
+def test_generate_command_has_generate_caption_flag():
+    """The 'generate' CLI command exposes --generate-caption."""
+    from paperbanana import cli
+
+    src = inspect.getsource(cli.generate)
+    assert "generate_caption" in src
+    assert "--generate-caption" in src
+
+
+def test_plot_command_has_generate_caption_flag():
+    """The 'plot' CLI command exposes --generate-caption."""
+    from paperbanana import cli
+
+    src = inspect.getsource(cli.plot)
+    assert "generate_caption" in src
+    assert "--generate-caption" in src
+
+
+def test_generate_caption_flag_sets_settings_override():
+    """When --generate-caption is passed, overrides include generate_caption=True."""
+    from paperbanana import cli
+
+    src = inspect.getsource(cli.generate)
+    # The override must only be set when flag is truthy
+    assert 'overrides["generate_caption"] = True' in src
+
+
+def test_plot_settings_includes_generate_caption():
+    """The plot command passes generate_caption into Settings."""
+    from paperbanana import cli
+
+    src = inspect.getsource(cli.plot)
+    assert "generate_caption=generate_caption" in src


### PR DESCRIPTION
**Summary**

Adds automatic figure caption generation as a post-pipeline step, enabling users to get a publication-ready 1–3 sentence caption alongside their generated diagram without any extra manual work.

Closes #98

**Why**

The pipeline already has everything needed to write a caption — the source context, the communicative intent, the final styled description, and the output image itself — but users still had to write the caption by hand after the run finished. 
This adds a single optional VLM+vision call at the end that does exactly that. 
Disabled by default to avoid unnecessary API costs.

**Changes**

- **New agent** `paperbanana/agents/caption.py`:
  - `CaptionAgent` makes one VLM+vision call after the final iteration
  - Errors degrade gracefully to `None` — the pipeline never fails because of a caption

- **New prompt templates** `prompts/diagram/caption.txt` and `prompts/plot/caption.txt`:
  - Enforces 1–3 sentence academic style, no figure numbers, no meta-language

- **Updated** `GenerationOutput` model with optional `generated_caption` field

- **New setting** `generate_caption: bool = False` in `Settings` and YAML config support

- **Pipeline** (`generate()` and `continue_run()`): calls `CaptionAgent` after final image
  is written; saves caption to `metadata.json`; adds `caption_seconds` to timing block

- **CLI** `--generate-caption` flag added to both `generate` and `plot` commands;
  prints caption below the output path when set

- **MCP** `generate_diagram` and `generate_plot` expose `generate_caption` param;
  returns `[TextContent(caption), Image]` when enabled

**Usage**
```
# Caption enabled
paperbanana generate --input method.txt --caption "Overview of our framework" \
  --generate-caption

# Output:
# ✓ Done! 42.3s total · 2 iterations
#   Output: outputs/run_20260326_123456_abc123/final_output.png
#   Run ID: run_20260326_123456_abc123
```