### PR TITLE
feat: add fault-tolerant batch orchestration with resume/retry/checkpointing

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -1109,7 +1109,9 @@ def batch(
                             state=state,
                             total_seconds=time.perf_counter() - total_start,
                         )
-                        console.print(f"[red]Item {idx + 1}/{len(items)} {item_id}: input missing[/red]")
+                        console.print(
+                            f"[red]Item {idx + 1}/{len(items)} {item_id}: input missing[/red]"
+                        )
                         return
                     try:
                         source_context = load_methodology_source(
@@ -1134,7 +1136,8 @@ def batch(
                             total_seconds=time.perf_counter() - total_start,
                         )
                         console.print(
-                            f"[green]Item {idx + 1}/{len(items)} {item_id}: ok[/green] [dim]{result.image_path}[/dim]"
+                            f"[green]Item {idx + 1}/{len(items)} {item_id}: ok[/green] "
+                            f"[dim]{result.image_path}[/dim]"
                         )
                         return
                     except Exception as e:
@@ -1146,10 +1149,13 @@ def batch(
                         )
                         if attempt < max_retries:
                             console.print(
-                                f"[yellow]Item {item_id}: retry {attempt + 1}/{max_retries} after {e}[/yellow]"
+                                f"[yellow]Item {item_id}: retry {attempt + 1}/{max_retries} "
+                                f"after {e}[/yellow]"
                             )
                             continue
-                        console.print(f"[red]Item {idx + 1}/{len(items)} {item_id}: failed - {e}[/red]")
+                        console.print(
+                            f"[red]Item {idx + 1}/{len(items)} {item_id}: failed - {e}[/red]"
+                        )
                         return
 
         await asyncio.gather(*[_run_one(idx, item) for idx, item, _ in planned])
@@ -1440,7 +1446,9 @@ def plot_batch(
                             state=state,
                             total_seconds=time.perf_counter() - total_start,
                         )
-                        console.print(f"[red]Item {idx + 1}/{len(items)} {item_id}: data missing[/red]")
+                        console.print(
+                            f"[red]Item {idx + 1}/{len(items)} {item_id}: data missing[/red]"
+                        )
                         return
                     try:
                         source_context, raw_data = load_statistical_plot_payload(data_path)
@@ -1466,7 +1474,8 @@ def plot_batch(
                             total_seconds=time.perf_counter() - total_start,
                         )
                         console.print(
-                            f"[green]Item {idx + 1}/{len(items)} {item_id}: ok[/green] [dim]{result.image_path}[/dim]"
+                            f"[green]Item {idx + 1}/{len(items)} {item_id}: ok[/green] "
+                            f"[dim]{result.image_path}[/dim]"
                         )
                         return
                     except Exception as e:
@@ -1478,10 +1487,13 @@ def plot_batch(
                         )
                         if attempt < max_retries:
                             console.print(
-                                f"[yellow]Item {item_id}: retry {attempt + 1}/{max_retries} after {e}[/yellow]"
+                                f"[yellow]Item {item_id}: retry {attempt + 1}/{max_retries} "
+                                f"after {e}[/yellow]"
                             )
                             continue
-                        console.print(f"[red]Item {idx + 1}/{len(items)} {item_id}: failed - {e}[/red]")
+                        console.print(
+                            f"[red]Item {idx + 1}/{len(items)} {item_id}: failed - {e}[/red]"
+                        )
                         return
 
         await asyncio.gather(*[_run_one(idx, item) for idx, item, _ in planned])

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -944,6 +944,16 @@ def batch(
     auto_download_data: bool = typer.Option(
         False, "--auto-download-data", help="Auto-download curated expansion if needed"
     ),
+    resume_batch: Optional[str] = typer.Option(
+        None, "--resume-batch", help="Batch ID or batch directory to resume"
+    ),
+    retry_failed: bool = typer.Option(
+        False, "--retry-failed", help="Retry previously failed items during resume"
+    ),
+    max_retries: int = typer.Option(
+        0, "--max-retries", help="Extra retries per item after first failure"
+    ),
+    concurrency: int = typer.Option(1, "--concurrency", help="Parallel item workers"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed progress"),
 ):
     """Generate multiple methodology diagrams from a manifest file (YAML or JSON)."""
@@ -955,6 +965,12 @@ def batch(
             f"[red]Error: --venue must be neurips, icml, acl, ieee, or custom. Got: {venue}[/red]"
         )
         raise typer.Exit(1)
+    if max_retries < 0:
+        console.print("[red]Error: --max-retries must be >= 0[/red]")
+        raise typer.Exit(1)
+    if concurrency < 1:
+        console.print("[red]Error: --concurrency must be >= 1[/red]")
+        raise typer.Exit(1)
 
     configure_logging(verbose=verbose)
     manifest_path = Path(manifest)
@@ -962,8 +978,17 @@ def batch(
         console.print(f"[red]Error: Manifest not found: {manifest}[/red]")
         raise typer.Exit(1)
 
-    from paperbanana.core.batch import generate_batch_id, load_batch_manifest
-    from paperbanana.core.utils import ensure_dir, save_json
+    from paperbanana.core.batch import (
+        checkpoint_progress,
+        generate_batch_id,
+        init_or_load_checkpoint,
+        load_batch_manifest,
+        mark_item_failure,
+        mark_item_running,
+        mark_item_success,
+        select_items_for_run,
+    )
+    from paperbanana.core.utils import ensure_dir
 
     try:
         items = load_batch_manifest(manifest_path)
@@ -971,8 +996,18 @@ def batch(
         console.print(f"[red]Error loading manifest: {e}[/red]")
         raise typer.Exit(1)
 
-    batch_id = generate_batch_id()
-    batch_dir = Path(output_dir) / batch_id
+    is_resume = bool(resume_batch)
+    if is_resume:
+        resume_ref = Path(resume_batch)
+        if resume_ref.is_dir():
+            batch_dir = resume_ref.resolve()
+            batch_id = batch_dir.name
+        else:
+            batch_id = resume_batch.strip()
+            batch_dir = (Path(output_dir) / batch_id).resolve()
+    else:
+        batch_id = generate_batch_id()
+        batch_dir = (Path(output_dir) / batch_id).resolve()
     ensure_dir(batch_dir)
 
     overrides = {"output_dir": str(batch_dir), "output_format": format}
@@ -1018,110 +1053,117 @@ def batch(
 
     console.print(
         Panel.fit(
-            f"[bold]PaperBanana[/bold] — Batch Generation\n\n"
+            f"[bold]PaperBanana[/bold] — {'Resume ' if is_resume else ''}Batch Generation\n\n"
             f"Manifest: {manifest_path.name}\n"
             f"Items: {len(items)}\n"
-            f"Output: {batch_dir}",
+            f"Output: {batch_dir}\n"
+            f"Concurrency: {concurrency}",
             border_style="blue",
         )
     )
     console.print()
 
     from paperbanana.core.pipeline import PaperBananaPipeline
+    from paperbanana.core.source_loader import load_methodology_source
 
-    report = {
-        "batch_id": batch_id,
-        "manifest": str(manifest_path),
-        "batch_kind": "methodology",
-        "items": [],
-    }
-    total_start = time.perf_counter()
-
-    for idx, item in enumerate(items):
-        item_id = item["id"]
-        input_path = Path(item["input"])
-        if not input_path.exists():
-            console.print(f"[red]Skipping item '{item_id}': input not found: {input_path}[/red]")
-            report["items"].append(
-                {
-                    "id": item_id,
-                    "input": item["input"],
-                    "caption": item["caption"],
-                    "run_id": None,
-                    "output_path": None,
-                    "error": "input file not found",
-                }
-            )
-            continue
-        from paperbanana.core.source_loader import load_methodology_source
-
-        try:
-            source_context = load_methodology_source(input_path, pdf_pages=item.get("pdf_pages"))
-        except ImportError as e:
-            console.print(f"[red]Skipping item '{item_id}': {e}[/red]")
-            report["items"].append(
-                {
-                    "id": item_id,
-                    "input": item["input"],
-                    "caption": item["caption"],
-                    "run_id": None,
-                    "output_path": None,
-                    "error": str(e),
-                }
-            )
-            continue
-        except ValueError as e:
-            console.print(f"[red]Skipping item '{item_id}': {e}[/red]")
-            report["items"].append(
-                {
-                    "id": item_id,
-                    "input": item["input"],
-                    "caption": item["caption"],
-                    "run_id": None,
-                    "output_path": None,
-                    "error": str(e),
-                }
-            )
-            continue
-
-        gen_input = GenerationInput(
-            source_context=source_context,
-            communicative_intent=item["caption"],
-            diagram_type=DiagramType.METHODOLOGY,
+    try:
+        state = init_or_load_checkpoint(
+            batch_dir=batch_dir,
+            batch_id=batch_id,
+            manifest_path=manifest_path,
+            batch_kind="methodology",
+            items=items,
+            resume=is_resume,
         )
-        console.print(f"[bold]Item {idx + 1}/{len(items)}[/bold] — {item_id}")
-        pipeline = PaperBananaPipeline(settings=settings)
-        try:
-            result = asyncio.run(pipeline.generate(gen_input))
-            report["items"].append(
-                {
-                    "id": item_id,
-                    "input": item["input"],
-                    "caption": item["caption"],
-                    "run_id": result.metadata.get("run_id"),
-                    "output_path": result.image_path,
-                    "iterations": len(result.iterations),
-                }
-            )
-            console.print(f"  [green]✓[/green] [dim]{result.image_path}[/dim]\n")
-        except Exception as e:
-            console.print(f"  [red]✗[/red] {e}\n")
-            report["items"].append(
-                {
-                    "id": item_id,
-                    "input": item["input"],
-                    "caption": item["caption"],
-                    "run_id": None,
-                    "output_path": None,
-                    "error": str(e),
-                }
-            )
+    except (FileNotFoundError, ValueError) as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    total_start = time.perf_counter()
+    planned = select_items_for_run(state, retry_failed=retry_failed)
+    if not planned:
+        checkpoint_progress(batch_dir=batch_dir, state=state, mark_complete=True)
+        console.print("[yellow]Nothing to run: all items already completed.[/yellow]")
+        console.print(f"  Report: [bold]{batch_dir / 'batch_report.json'}[/bold]")
+        return
+
+    async def _run_all() -> None:
+        sem = asyncio.Semaphore(concurrency)
+
+        async def _run_one(idx: int, item: dict[str, object]) -> None:
+            item_key = str(item["_item_key"])
+            item_id = str(item["id"])
+            async with sem:
+                for attempt in range(max_retries + 1):
+                    mark_item_running(state, item_key)
+                    checkpoint_progress(
+                        batch_dir=batch_dir,
+                        state=state,
+                        total_seconds=time.perf_counter() - total_start,
+                    )
+                    input_path = Path(str(item["input"]))
+                    if not input_path.exists():
+                        mark_item_failure(state, item_key, "input file not found")
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        console.print(f"[red]Item {idx + 1}/{len(items)} {item_id}: input missing[/red]")
+                        return
+                    try:
+                        source_context = load_methodology_source(
+                            input_path, pdf_pages=item.get("pdf_pages")
+                        )
+                        gen_input = GenerationInput(
+                            source_context=source_context,
+                            communicative_intent=str(item["caption"]),
+                            diagram_type=DiagramType.METHODOLOGY,
+                        )
+                        result = await PaperBananaPipeline(settings=settings).generate(gen_input)
+                        mark_item_success(
+                            state,
+                            item_key,
+                            result.metadata.get("run_id"),
+                            result.image_path,
+                            len(result.iterations),
+                        )
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        console.print(
+                            f"[green]Item {idx + 1}/{len(items)} {item_id}: ok[/green] [dim]{result.image_path}[/dim]"
+                        )
+                        return
+                    except Exception as e:
+                        mark_item_failure(state, item_key, str(e))
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        if attempt < max_retries:
+                            console.print(
+                                f"[yellow]Item {item_id}: retry {attempt + 1}/{max_retries} after {e}[/yellow]"
+                            )
+                            continue
+                        console.print(f"[red]Item {idx + 1}/{len(items)} {item_id}: failed - {e}[/red]")
+                        return
+
+        await asyncio.gather(*[_run_one(idx, item) for idx, item, _ in planned])
+
+    asyncio.run(_run_all())
 
     total_elapsed = time.perf_counter() - total_start
-    report["total_seconds"] = round(total_elapsed, 1)
+    report = checkpoint_progress(
+        batch_dir=batch_dir,
+        state=state,
+        total_seconds=total_elapsed,
+        mark_complete=True,
+    )
     report_path = batch_dir / "batch_report.json"
-    save_json(report, report_path)
-
     succeeded = sum(1 for x in report["items"] if x.get("output_path"))
     console.print(
         f"[green]Batch complete.[/green] [dim]{total_elapsed:.1f}s · "
@@ -1243,6 +1285,16 @@ def plot_batch(
         "-ar",
         help="Default aspect ratio when not set per manifest item",
     ),
+    resume_batch: Optional[str] = typer.Option(
+        None, "--resume-batch", help="Batch ID or batch directory to resume"
+    ),
+    retry_failed: bool = typer.Option(
+        False, "--retry-failed", help="Retry previously failed items during resume"
+    ),
+    max_retries: int = typer.Option(
+        0, "--max-retries", help="Extra retries per item after first failure"
+    ),
+    concurrency: int = typer.Option(1, "--concurrency", help="Parallel item workers"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed progress"),
 ):
     """Generate multiple statistical plots from a manifest (data + intent per item)."""
@@ -1254,6 +1306,12 @@ def plot_batch(
             f"[red]Error: --venue must be neurips, icml, acl, ieee, or custom. Got: {venue}[/red]"
         )
         raise typer.Exit(1)
+    if max_retries < 0:
+        console.print("[red]Error: --max-retries must be >= 0[/red]")
+        raise typer.Exit(1)
+    if concurrency < 1:
+        console.print("[red]Error: --concurrency must be >= 1[/red]")
+        raise typer.Exit(1)
 
     configure_logging(verbose=verbose)
     manifest_path = Path(manifest)
@@ -1261,9 +1319,18 @@ def plot_batch(
         console.print(f"[red]Error: Manifest not found: {manifest}[/red]")
         raise typer.Exit(1)
 
-    from paperbanana.core.batch import generate_batch_id, load_plot_batch_manifest
+    from paperbanana.core.batch import (
+        checkpoint_progress,
+        generate_batch_id,
+        init_or_load_checkpoint,
+        load_plot_batch_manifest,
+        mark_item_failure,
+        mark_item_running,
+        mark_item_success,
+        select_items_for_run,
+    )
     from paperbanana.core.plot_data import load_statistical_plot_payload
-    from paperbanana.core.utils import ensure_dir, save_json
+    from paperbanana.core.utils import ensure_dir
 
     try:
         items = load_plot_batch_manifest(manifest_path)
@@ -1271,8 +1338,18 @@ def plot_batch(
         console.print(f"[red]Error loading manifest: {e}[/red]")
         raise typer.Exit(1)
 
-    batch_id = generate_batch_id()
-    batch_dir = Path(output_dir) / batch_id
+    is_resume = bool(resume_batch)
+    if is_resume:
+        resume_ref = Path(resume_batch)
+        if resume_ref.is_dir():
+            batch_dir = resume_ref.resolve()
+            batch_id = batch_dir.name
+        else:
+            batch_id = resume_batch.strip()
+            batch_dir = (Path(output_dir) / batch_id).resolve()
+    else:
+        batch_id = generate_batch_id()
+        batch_dir = (Path(output_dir) / batch_id).resolve()
     ensure_dir(batch_dir)
 
     overrides: dict = {
@@ -1309,10 +1386,11 @@ def plot_batch(
 
     console.print(
         Panel.fit(
-            f"[bold]PaperBanana[/bold] — Batch Plot Generation\n\n"
+            f"[bold]PaperBanana[/bold] — {'Resume ' if is_resume else ''}Batch Plot Generation\n\n"
             f"Manifest: {manifest_path.name}\n"
             f"Items: {len(items)}\n"
-            f"Output: {batch_dir}",
+            f"Output: {batch_dir}\n"
+            f"Concurrency: {concurrency}",
             border_style="green",
         )
     )
@@ -1320,88 +1398,104 @@ def plot_batch(
 
     from paperbanana.core.pipeline import PaperBananaPipeline
 
-    report: dict = {
-        "batch_id": batch_id,
-        "manifest": str(manifest_path),
-        "batch_kind": "statistical_plot",
-        "items": [],
-    }
-    total_start = time.perf_counter()
-
-    for idx, item in enumerate(items):
-        item_id = item["id"]
-        data_path = Path(item["data"])
-        if not data_path.exists():
-            console.print(f"[red]Skipping item '{item_id}': data file not found: {data_path}[/red]")
-            report["items"].append(
-                {
-                    "id": item_id,
-                    "data": item["data"],
-                    "caption": item["intent"],
-                    "run_id": None,
-                    "output_path": None,
-                    "error": "data file not found",
-                }
-            )
-            continue
-
-        try:
-            source_context, raw_data = load_statistical_plot_payload(data_path)
-        except (ValueError, OSError) as e:
-            console.print(f"[red]Skipping item '{item_id}': {e}[/red]")
-            report["items"].append(
-                {
-                    "id": item_id,
-                    "data": item["data"],
-                    "caption": item["intent"],
-                    "run_id": None,
-                    "output_path": None,
-                    "error": str(e),
-                }
-            )
-            continue
-
-        ar = item.get("aspect_ratio") or aspect_ratio
-        gen_input = GenerationInput(
-            source_context=source_context,
-            communicative_intent=item["intent"],
-            diagram_type=DiagramType.STATISTICAL_PLOT,
-            raw_data={"data": raw_data},
-            aspect_ratio=ar,
+    try:
+        state = init_or_load_checkpoint(
+            batch_dir=batch_dir,
+            batch_id=batch_id,
+            manifest_path=manifest_path,
+            batch_kind="statistical_plot",
+            items=items,
+            resume=is_resume,
         )
-        console.print(f"[bold]Item {idx + 1}/{len(items)}[/bold] — {item_id}")
-        pipeline = PaperBananaPipeline(settings=settings)
-        try:
-            result = asyncio.run(pipeline.generate(gen_input))
-            report["items"].append(
-                {
-                    "id": item_id,
-                    "data": item["data"],
-                    "caption": item["intent"],
-                    "run_id": result.metadata.get("run_id"),
-                    "output_path": result.image_path,
-                    "iterations": len(result.iterations),
-                }
-            )
-            console.print(f"  [green]✓[/green] [dim]{result.image_path}[/dim]\n")
-        except Exception as e:
-            console.print(f"  [red]✗[/red] {e}\n")
-            report["items"].append(
-                {
-                    "id": item_id,
-                    "data": item["data"],
-                    "caption": item["intent"],
-                    "run_id": None,
-                    "output_path": None,
-                    "error": str(e),
-                }
-            )
+    except (FileNotFoundError, ValueError) as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+    total_start = time.perf_counter()
+    planned = select_items_for_run(state, retry_failed=retry_failed)
+    if not planned:
+        checkpoint_progress(batch_dir=batch_dir, state=state, mark_complete=True)
+        console.print("[yellow]Nothing to run: all items already completed.[/yellow]")
+        console.print(f"  Report: [bold]{batch_dir / 'batch_report.json'}[/bold]")
+        return
+
+    async def _run_all() -> None:
+        sem = asyncio.Semaphore(concurrency)
+
+        async def _run_one(idx: int, item: dict[str, object]) -> None:
+            item_key = str(item["_item_key"])
+            item_id = str(item["id"])
+            async with sem:
+                for attempt in range(max_retries + 1):
+                    mark_item_running(state, item_key)
+                    checkpoint_progress(
+                        batch_dir=batch_dir,
+                        state=state,
+                        total_seconds=time.perf_counter() - total_start,
+                    )
+                    data_path = Path(str(item["data"]))
+                    if not data_path.exists():
+                        mark_item_failure(state, item_key, "data file not found")
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        console.print(f"[red]Item {idx + 1}/{len(items)} {item_id}: data missing[/red]")
+                        return
+                    try:
+                        source_context, raw_data = load_statistical_plot_payload(data_path)
+                        ar = item.get("aspect_ratio") or aspect_ratio
+                        gen_input = GenerationInput(
+                            source_context=source_context,
+                            communicative_intent=str(item["intent"]),
+                            diagram_type=DiagramType.STATISTICAL_PLOT,
+                            raw_data={"data": raw_data},
+                            aspect_ratio=ar,
+                        )
+                        result = await PaperBananaPipeline(settings=settings).generate(gen_input)
+                        mark_item_success(
+                            state,
+                            item_key,
+                            result.metadata.get("run_id"),
+                            result.image_path,
+                            len(result.iterations),
+                        )
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        console.print(
+                            f"[green]Item {idx + 1}/{len(items)} {item_id}: ok[/green] [dim]{result.image_path}[/dim]"
+                        )
+                        return
+                    except Exception as e:
+                        mark_item_failure(state, item_key, str(e))
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        if attempt < max_retries:
+                            console.print(
+                                f"[yellow]Item {item_id}: retry {attempt + 1}/{max_retries} after {e}[/yellow]"
+                            )
+                            continue
+                        console.print(f"[red]Item {idx + 1}/{len(items)} {item_id}: failed - {e}[/red]")
+                        return
+
+        await asyncio.gather(*[_run_one(idx, item) for idx, item, _ in planned])
+
+    asyncio.run(_run_all())
 
     total_elapsed = time.perf_counter() - total_start
-    report["total_seconds"] = round(total_elapsed, 1)
+    report = checkpoint_progress(
+        batch_dir=batch_dir,
+        state=state,
+        total_seconds=total_elapsed,
+        mark_complete=True,
+    )
     report_path = batch_dir / "batch_report.json"
-    save_json(report, report_path)
-
     succeeded = sum(1 for x in report["items"] if x.get("output_path"))
     console.print(
         f"[green]Plot batch complete.[/green] [dim]{total_elapsed:.1f}s · "

--- a/paperbanana/core/batch.py
+++ b/paperbanana/core/batch.py
@@ -197,7 +197,7 @@ def _report_summary(report: dict[str, Any]) -> tuple[int, int, float]:
 
 
 def _utc_now() -> str:
-    return datetime.datetime.now(datetime.UTC).isoformat()
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
 
 
 def _atomic_json_write(path: Path, payload: dict[str, Any]) -> None:

--- a/paperbanana/core/batch.py
+++ b/paperbanana/core/batch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import os
 import uuid
 from pathlib import Path
 from typing import Any, Literal
@@ -13,6 +14,7 @@ import structlog
 logger = structlog.get_logger()
 
 REPORT_FILENAME = "batch_report.json"
+CHECKPOINT_FILENAME = "batch_checkpoint.json"
 
 
 def generate_batch_id() -> str:
@@ -192,6 +194,197 @@ def _report_summary(report: dict[str, Any]) -> tuple[int, int, float]:
     succeeded = sum(1 for x in items if x.get("output_path"))
     total_seconds = report.get("total_seconds") or 0.0
     return succeeded, total, float(total_seconds)
+
+
+def _utc_now() -> str:
+    return datetime.datetime.now(datetime.UTC).isoformat()
+
+
+def _atomic_json_write(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _item_key(item: dict[str, Any], idx: int) -> str:
+    return f"{item.get('id', f'item_{idx + 1}')}::{idx}"
+
+
+def _with_item_keys(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for idx, item in enumerate(items):
+        enriched = dict(item)
+        enriched["_item_key"] = _item_key(item, idx)
+        out.append(enriched)
+    return out
+
+
+def init_or_load_checkpoint(
+    *,
+    batch_dir: Path,
+    batch_id: str,
+    manifest_path: Path,
+    batch_kind: Literal["methodology", "statistical_plot"],
+    items: list[dict[str, Any]],
+    resume: bool,
+) -> dict[str, Any]:
+    """Create or load batch checkpoint state."""
+    cp_path = batch_dir / CHECKPOINT_FILENAME
+    report_path = batch_dir / REPORT_FILENAME
+    keyed_items = _with_item_keys(items)
+    if resume:
+        if not cp_path.exists():
+            raise FileNotFoundError(f"No {CHECKPOINT_FILENAME} in {batch_dir}")
+        state = json.loads(cp_path.read_text(encoding="utf-8"))
+        prev_items = state.get("manifest_items", [])
+        prev_keys = [x.get("_item_key") for x in prev_items]
+        now_keys = [x.get("_item_key") for x in keyed_items]
+        if prev_keys != now_keys:
+            raise ValueError(
+                "Manifest items do not match checkpoint. Refusing resume to avoid duplication."
+            )
+        return state
+
+    state: dict[str, Any] = {
+        "batch_id": batch_id,
+        "manifest": str(manifest_path.resolve()),
+        "batch_kind": batch_kind,
+        "created_at": _utc_now(),
+        "updated_at": _utc_now(),
+        "status": "running",
+        "manifest_items": keyed_items,
+        "items": {},
+        "retry_history": [],
+    }
+    for item in keyed_items:
+        item_key = item["_item_key"]
+        state["items"][item_key] = {
+            "id": item["id"],
+            "status": "pending",
+            "attempts": 0,
+            "error": None,
+            "errors": [],
+            "run_id": None,
+            "output_path": None,
+            "iterations": None,
+            "started_at": None,
+            "finished_at": None,
+        }
+    _atomic_json_write(cp_path, state)
+    # Keep backwards-compatible report present from the start.
+    _atomic_json_write(
+        report_path,
+        {
+            "batch_id": batch_id,
+            "manifest": str(manifest_path.resolve()),
+            "batch_kind": batch_kind,
+            "items": [],
+            "total_seconds": 0.0,
+        },
+    )
+    return state
+
+
+def select_items_for_run(
+    state: dict[str, Any], retry_failed: bool = False
+) -> list[tuple[int, dict[str, Any], dict[str, Any]]]:
+    """Return [(manifest_index, manifest_item, item_state)] to execute."""
+    selected: list[tuple[int, dict[str, Any], dict[str, Any]]] = []
+    manifest_items = state.get("manifest_items", [])
+    item_states = state.get("items", {})
+    for idx, item in enumerate(manifest_items):
+        item_state = item_states.get(item["_item_key"], {})
+        status = item_state.get("status")
+        if status in ("pending", "running"):
+            selected.append((idx, item, item_state))
+        elif retry_failed and status == "failed":
+            selected.append((idx, item, item_state))
+    return selected
+
+
+def mark_item_running(state: dict[str, Any], item_key: str) -> None:
+    item_state = state["items"][item_key]
+    item_state["status"] = "running"
+    item_state["attempts"] = int(item_state.get("attempts") or 0) + 1
+    item_state["started_at"] = _utc_now()
+    item_state["finished_at"] = None
+    state["updated_at"] = _utc_now()
+
+
+def mark_item_success(
+    state: dict[str, Any], item_key: str, run_id: str | None, output_path: str, iterations: int
+) -> None:
+    item_state = state["items"][item_key]
+    item_state["status"] = "success"
+    item_state["run_id"] = run_id
+    item_state["output_path"] = output_path
+    item_state["iterations"] = iterations
+    item_state["error"] = None
+    item_state["finished_at"] = _utc_now()
+    state["updated_at"] = _utc_now()
+
+
+def mark_item_failure(state: dict[str, Any], item_key: str, error: str) -> None:
+    item_state = state["items"][item_key]
+    item_state["status"] = "failed"
+    item_state["error"] = error
+    item_state.setdefault("errors", []).append({"at": _utc_now(), "error": error})
+    item_state["finished_at"] = _utc_now()
+    state["updated_at"] = _utc_now()
+
+
+def checkpoint_progress(
+    *,
+    batch_dir: Path,
+    state: dict[str, Any],
+    total_seconds: float | None = None,
+    mark_complete: bool = False,
+) -> dict[str, Any]:
+    """Persist checkpoint and synchronized batch_report.json."""
+    cp_path = batch_dir / CHECKPOINT_FILENAME
+    report_path = batch_dir / REPORT_FILENAME
+    if mark_complete:
+        state["status"] = "completed"
+    if total_seconds is not None:
+        state["total_seconds"] = round(float(total_seconds), 1)
+    state["updated_at"] = _utc_now()
+    _atomic_json_write(cp_path, state)
+
+    report_items: list[dict[str, Any]] = []
+    for item in state.get("manifest_items", []):
+        item_state = state["items"].get(item["_item_key"], {})
+        base: dict[str, Any] = {
+            "id": item.get("id"),
+            "caption": item.get("caption") or item.get("intent"),
+            "run_id": item_state.get("run_id"),
+            "output_path": item_state.get("output_path"),
+            "iterations": item_state.get("iterations"),
+            "status": item_state.get("status"),
+            "attempts": item_state.get("attempts", 0),
+        }
+        if "input" in item:
+            base["input"] = item.get("input")
+            if item.get("pdf_pages") is not None:
+                base["pdf_pages"] = item.get("pdf_pages")
+        if "data" in item:
+            base["data"] = item.get("data")
+            if item.get("aspect_ratio") is not None:
+                base["aspect_ratio"] = item.get("aspect_ratio")
+        if item_state.get("error"):
+            base["error"] = item_state.get("error")
+        report_items.append(base)
+
+    report = {
+        "batch_id": state.get("batch_id"),
+        "manifest": state.get("manifest"),
+        "batch_kind": state.get("batch_kind"),
+        "status": state.get("status", "running"),
+        "items": report_items,
+        "total_seconds": round(float(state.get("total_seconds") or 0.0), 1),
+    }
+    _atomic_json_write(report_path, report)
+    return report
 
 
 def generate_batch_report_md(report: dict[str, Any], batch_dir: Path) -> str:

--- a/paperbanana/studio/app.py
+++ b/paperbanana/studio/app.py
@@ -554,6 +554,16 @@ def build_studio_app(
                     choices=ASPECT_RATIO_CHOICES,
                     value="default",
                 )
+                with gr.Row():
+                    b_resume = gr.Textbox(
+                        label="Resume batch (ID or path)",
+                        lines=1,
+                        placeholder="Optional: batch_... or /path/to/batch_dir",
+                    )
+                    b_retry_failed = gr.Checkbox(label="Retry failed items", value=False)
+                with gr.Row():
+                    b_max_retries = gr.Number(label="Max retries per item", value=0, precision=0)
+                    b_concurrency = gr.Number(label="Concurrency", value=1, precision=0)
                 b_log = gr.Textbox(label="Batch log", lines=22)
                 b_dir = gr.Textbox(label="Batch output directory", lines=1)
                 b_go = gr.Button("Run batch", variant="primary")
@@ -575,6 +585,10 @@ def build_studio_app(
                     sd,
                     mfile,
                     bar,
+                    resume_ref,
+                    retry_fail,
+                    max_retry_count,
+                    conc,
                 ):
                     _dotenv()
                     try:
@@ -584,10 +598,25 @@ def build_studio_app(
                             return "Upload a manifest file.", ""
                         if mode == "Statistical plots":
                             log, bpath = run_plot_batch(
-                                st0, path, default_aspect_ratio_label=bar, verbose_logging=False
+                                st0,
+                                path,
+                                default_aspect_ratio_label=bar,
+                                resume_batch=(resume_ref or "").strip() or None,
+                                retry_failed=bool(retry_fail),
+                                max_retries=max(0, int(max_retry_count or 0)),
+                                concurrency=max(1, int(conc or 1)),
+                                verbose_logging=False,
                             )
                         else:
-                            log, bpath = run_batch(st0, path, verbose_logging=False)
+                            log, bpath = run_batch(
+                                st0,
+                                path,
+                                resume_batch=(resume_ref or "").strip() or None,
+                                retry_failed=bool(retry_fail),
+                                max_retries=max(0, int(max_retry_count or 0)),
+                                concurrency=max(1, int(conc or 1)),
+                                verbose_logging=False,
+                            )
                         return log, bpath
                     except Exception as e:
                         return f"{type(e).__name__}: {e}", ""
@@ -611,6 +640,10 @@ def build_studio_app(
                         seed_val,
                         bf,
                         b_ar,
+                        b_resume,
+                        b_retry_failed,
+                        b_max_retries,
+                        b_concurrency,
                     ],
                     outputs=[b_log, b_dir],
                 )

--- a/paperbanana/studio/runner.py
+++ b/paperbanana/studio/runner.py
@@ -9,9 +9,15 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from paperbanana.core.batch import (
+    checkpoint_progress,
     generate_batch_id,
+    init_or_load_checkpoint,
     load_batch_manifest,
     load_plot_batch_manifest,
+    mark_item_failure,
+    mark_item_running,
+    mark_item_success,
+    select_items_for_run,
 )
 from paperbanana.core.config import Settings
 from paperbanana.core.logging import configure_logging
@@ -24,7 +30,7 @@ from paperbanana.core.types import (
     PipelineProgressEvent,
     PipelineProgressStage,
 )
-from paperbanana.core.utils import ensure_dir, find_prompt_dir, save_json
+from paperbanana.core.utils import ensure_dir, find_prompt_dir
 from paperbanana.evaluation.judge import VLMJudge
 from paperbanana.providers.registry import ProviderRegistry
 
@@ -386,6 +392,11 @@ def run_continue(
 def run_batch(
     settings: Settings,
     manifest_path: str,
+    *,
+    resume_batch: Optional[str] = None,
+    retry_failed: bool = False,
+    max_retries: int = 0,
+    concurrency: int = 1,
     verbose_logging: bool = False,
 ) -> tuple[str, str]:
     """Run batch manifest; returns (log, batch_dir path or error note)."""
@@ -404,8 +415,18 @@ def run_batch(
         lines.append(msg)
         return "\n".join(lines), msg
 
-    batch_id = generate_batch_id()
-    batch_dir = Path(settings.output_dir) / batch_id
+    is_resume = bool(resume_batch)
+    if is_resume:
+        resume_ref = Path(resume_batch)
+        if resume_ref.is_dir():
+            batch_dir = resume_ref.resolve()
+            batch_id = batch_dir.name
+        else:
+            batch_id = resume_batch.strip()
+            batch_dir = (Path(settings.output_dir) / batch_id).resolve()
+    else:
+        batch_id = generate_batch_id()
+        batch_dir = Path(settings.output_dir) / batch_id
     ensure_dir(batch_dir)
 
     settings = settings.model_copy(update={"output_dir": str(batch_dir)})
@@ -414,68 +435,79 @@ def run_batch(
     lines.append(f"Output: {batch_dir}")
     lines.append("")
 
-    report: dict[str, Any] = {
-        "batch_id": batch_id,
-        "manifest": str(mpath.resolve()),
-        "batch_kind": "methodology",
-        "items": [],
-    }
+    state = init_or_load_checkpoint(
+        batch_dir=batch_dir,
+        batch_id=batch_id,
+        manifest_path=mpath,
+        batch_kind="methodology",
+        items=items,
+        resume=is_resume,
+    )
+    planned = select_items_for_run(state, retry_failed=retry_failed)
+    if not planned:
+        checkpoint_progress(batch_dir=batch_dir, state=state, mark_complete=True)
+        lines.append("Nothing to run: all items already completed.")
+        lines.append(f"Report written: {batch_dir / 'batch_report.json'}")
+        return "\n".join(lines), str(batch_dir.resolve())
+
+    if max_retries < 0:
+        max_retries = 0
+    if concurrency < 1:
+        concurrency = 1
 
     async def _run_all_items() -> None:
-        for idx, item in enumerate(items):
+        sem = asyncio.Semaphore(concurrency)
+        from paperbanana.core.source_loader import load_methodology_source
+
+        async def _run_one(idx: int, item: dict[str, Any]) -> None:
             item_id = item["id"]
-            input_path = Path(item["input"])
+            item_key = item["_item_key"]
             lines.append(f"— Item {idx + 1}/{len(items)} — {item_id}")
-            if not input_path.is_file():
-                lines.append(f"  skip: input not found ({input_path})")
-                report["items"].append(
-                    {
-                        "id": item_id,
-                        "input": item["input"],
-                        "caption": item["caption"],
-                        "run_id": None,
-                        "output_path": None,
-                        "error": "input file not found",
-                    }
-                )
-                continue
-            source_context = input_path.read_text(encoding="utf-8", errors="replace")
-            gen_in = GenerationInput(
-                source_context=source_context,
-                communicative_intent=item["caption"],
-                diagram_type=DiagramType.METHODOLOGY,
-            )
-            pipeline = PaperBananaPipeline(settings=settings)
-            try:
-                result = await pipeline.generate(gen_in)
-                lines.append(f"  ok: {result.image_path}")
-                report["items"].append(
-                    {
-                        "id": item_id,
-                        "input": item["input"],
-                        "caption": item["caption"],
-                        "run_id": result.metadata.get("run_id"),
-                        "output_path": result.image_path,
-                        "iterations": len(result.iterations),
-                    }
-                )
-            except Exception as e:
-                lines.append(f"  error: {e}")
-                report["items"].append(
-                    {
-                        "id": item_id,
-                        "input": item["input"],
-                        "caption": item["caption"],
-                        "run_id": None,
-                        "output_path": None,
-                        "error": str(e),
-                    }
-                )
+            async with sem:
+                for attempt in range(max_retries + 1):
+                    mark_item_running(state, item_key)
+                    checkpoint_progress(batch_dir=batch_dir, state=state)
+                    input_path = Path(item["input"])
+                    if not input_path.is_file():
+                        mark_item_failure(state, item_key, "input file not found")
+                        checkpoint_progress(batch_dir=batch_dir, state=state)
+                        lines.append(f"  error: input not found ({input_path})")
+                        return
+                    try:
+                        source_context = load_methodology_source(
+                            input_path, pdf_pages=item.get("pdf_pages")
+                        )
+                        gen_in = GenerationInput(
+                            source_context=source_context,
+                            communicative_intent=item["caption"],
+                            diagram_type=DiagramType.METHODOLOGY,
+                        )
+                        result = await PaperBananaPipeline(settings=settings).generate(gen_in)
+                        mark_item_success(
+                            state,
+                            item_key,
+                            result.metadata.get("run_id"),
+                            result.image_path,
+                            len(result.iterations),
+                        )
+                        checkpoint_progress(batch_dir=batch_dir, state=state)
+                        lines.append(f"  ok: {result.image_path}")
+                        return
+                    except Exception as e:
+                        mark_item_failure(state, item_key, str(e))
+                        checkpoint_progress(batch_dir=batch_dir, state=state)
+                        if attempt < max_retries:
+                            lines.append(f"  retry {attempt + 1}/{max_retries}: {e}")
+                            continue
+                        lines.append(f"  error: {e}")
+                        return
+
+        await asyncio.gather(*[_run_one(idx, item) for idx, item, _ in planned])
 
     asyncio.run(_run_all_items())
 
+    report = checkpoint_progress(batch_dir=batch_dir, state=state, mark_complete=True)
     report_path = batch_dir / "batch_report.json"
-    save_json(report, report_path)
     lines.append("")
     lines.append(f"Report written: {report_path}")
     ok = sum(1 for x in report["items"] if x.get("output_path"))
@@ -487,6 +519,11 @@ def run_plot_batch(
     settings: Settings,
     manifest_path: str,
     default_aspect_ratio_label: str = "default",
+    *,
+    resume_batch: Optional[str] = None,
+    retry_failed: bool = False,
+    max_retries: int = 0,
+    concurrency: int = 1,
     verbose_logging: bool = False,
 ) -> tuple[str, str]:
     """Run plot batch manifest; returns (log, batch_dir path or error note)."""
@@ -505,8 +542,18 @@ def run_plot_batch(
         lines.append(msg)
         return "\n".join(lines), msg
 
-    batch_id = generate_batch_id()
-    batch_dir = Path(settings.output_dir) / batch_id
+    is_resume = bool(resume_batch)
+    if is_resume:
+        resume_ref = Path(resume_batch)
+        if resume_ref.is_dir():
+            batch_dir = resume_ref.resolve()
+            batch_id = batch_dir.name
+        else:
+            batch_id = resume_batch.strip()
+            batch_dir = (Path(settings.output_dir) / batch_id).resolve()
+    else:
+        batch_id = generate_batch_id()
+        batch_dir = Path(settings.output_dir) / batch_id
     ensure_dir(batch_dir)
 
     settings = settings.model_copy(update={"output_dir": str(batch_dir)})
@@ -516,91 +563,87 @@ def run_plot_batch(
     lines.append(f"Output: {batch_dir}")
     lines.append("")
 
-    report: dict[str, Any] = {
-        "batch_id": batch_id,
-        "manifest": str(mpath.resolve()),
-        "batch_kind": "statistical_plot",
-        "items": [],
-    }
+    state = init_or_load_checkpoint(
+        batch_dir=batch_dir,
+        batch_id=batch_id,
+        manifest_path=mpath,
+        batch_kind="statistical_plot",
+        items=items,
+        resume=is_resume,
+    )
+    planned = select_items_for_run(state, retry_failed=retry_failed)
+    if not planned:
+        checkpoint_progress(batch_dir=batch_dir, state=state, mark_complete=True)
+        lines.append("Nothing to run: all items already completed.")
+        lines.append(f"Report written: {batch_dir / 'batch_report.json'}")
+        return "\n".join(lines), str(batch_dir.resolve())
+
+    if max_retries < 0:
+        max_retries = 0
+    if concurrency < 1:
+        concurrency = 1
 
     total_start = time.perf_counter()
 
     async def _run_all_items() -> None:
-        for idx, item in enumerate(items):
-            item_id = item["id"]
-            data_path = Path(item["data"])
-            lines.append(f"— Item {idx + 1}/{len(items)} — {item_id}")
-            if not data_path.is_file():
-                lines.append(f"  skip: data file not found ({data_path})")
-                report["items"].append(
-                    {
-                        "id": item_id,
-                        "data": item["data"],
-                        "caption": item["intent"],
-                        "run_id": None,
-                        "output_path": None,
-                        "error": "data file not found",
-                    }
-                )
-                continue
-            try:
-                source_context, raw_data = load_statistical_plot_payload(data_path)
-            except (ValueError, OSError) as e:
-                lines.append(f"  skip: {e}")
-                report["items"].append(
-                    {
-                        "id": item_id,
-                        "data": item["data"],
-                        "caption": item["intent"],
-                        "run_id": None,
-                        "output_path": None,
-                        "error": str(e),
-                    }
-                )
-                continue
+        sem = asyncio.Semaphore(concurrency)
 
-            ar = item.get("aspect_ratio") or _aspect_ratio_value(default_aspect_ratio_label)
-            gen_in = GenerationInput(
-                source_context=source_context,
-                communicative_intent=item["intent"],
-                diagram_type=DiagramType.STATISTICAL_PLOT,
-                raw_data={"data": raw_data},
-                aspect_ratio=ar,
-            )
-            pipeline = PaperBananaPipeline(settings=settings)
-            try:
-                result = await pipeline.generate(gen_in)
-                lines.append(f"  ok: {result.image_path}")
-                report["items"].append(
-                    {
-                        "id": item_id,
-                        "data": item["data"],
-                        "caption": item["intent"],
-                        "run_id": result.metadata.get("run_id"),
-                        "output_path": result.image_path,
-                        "iterations": len(result.iterations),
-                    }
-                )
-            except Exception as e:
-                lines.append(f"  error: {e}")
-                report["items"].append(
-                    {
-                        "id": item_id,
-                        "data": item["data"],
-                        "caption": item["intent"],
-                        "run_id": None,
-                        "output_path": None,
-                        "error": str(e),
-                    }
-                )
+        async def _run_one(idx: int, item: dict[str, Any]) -> None:
+            item_id = item["id"]
+            item_key = item["_item_key"]
+            lines.append(f"— Item {idx + 1}/{len(items)} — {item_id}")
+            async with sem:
+                for attempt in range(max_retries + 1):
+                    mark_item_running(state, item_key)
+                    checkpoint_progress(batch_dir=batch_dir, state=state)
+                    data_path = Path(item["data"])
+                    if not data_path.is_file():
+                        mark_item_failure(state, item_key, "data file not found")
+                        checkpoint_progress(batch_dir=batch_dir, state=state)
+                        lines.append(f"  error: data file not found ({data_path})")
+                        return
+                    try:
+                        source_context, raw_data = load_statistical_plot_payload(data_path)
+                        ar = item.get("aspect_ratio") or _aspect_ratio_value(default_aspect_ratio_label)
+                        gen_in = GenerationInput(
+                            source_context=source_context,
+                            communicative_intent=item["intent"],
+                            diagram_type=DiagramType.STATISTICAL_PLOT,
+                            raw_data={"data": raw_data},
+                            aspect_ratio=ar,
+                        )
+                        result = await PaperBananaPipeline(settings=settings).generate(gen_in)
+                        mark_item_success(
+                            state,
+                            item_key,
+                            result.metadata.get("run_id"),
+                            result.image_path,
+                            len(result.iterations),
+                        )
+                        checkpoint_progress(batch_dir=batch_dir, state=state)
+                        lines.append(f"  ok: {result.image_path}")
+                        return
+                    except Exception as e:
+                        mark_item_failure(state, item_key, str(e))
+                        checkpoint_progress(batch_dir=batch_dir, state=state)
+                        if attempt < max_retries:
+                            lines.append(f"  retry {attempt + 1}/{max_retries}: {e}")
+                            continue
+                        lines.append(f"  error: {e}")
+                        return
+
+        await asyncio.gather(*[_run_one(idx, item) for idx, item, _ in planned])
 
     asyncio.run(_run_all_items())
 
     total_elapsed = time.perf_counter() - total_start
-    report["total_seconds"] = round(total_elapsed, 1)
-
+    report = checkpoint_progress(
+        batch_dir=batch_dir,
+        state=state,
+        total_seconds=total_elapsed,
+        mark_complete=True,
+    )
     report_path = batch_dir / "batch_report.json"
-    save_json(report, report_path)
     lines.append("")
     lines.append(f"Report written: {report_path}")
     ok = sum(1 for x in report["items"] if x.get("output_path"))

--- a/paperbanana/studio/runner.py
+++ b/paperbanana/studio/runner.py
@@ -604,7 +604,9 @@ def run_plot_batch(
                         return
                     try:
                         source_context, raw_data = load_statistical_plot_payload(data_path)
-                        ar = item.get("aspect_ratio") or _aspect_ratio_value(default_aspect_ratio_label)
+                        ar = item.get("aspect_ratio") or _aspect_ratio_value(
+                            default_aspect_ratio_label
+                        )
                         gen_in = GenerationInput(
                             source_context=source_context,
                             communicative_intent=item["intent"],

--- a/paperbanana/studio/runs.py
+++ b/paperbanana/studio/runs.py
@@ -123,7 +123,9 @@ def load_batch_summary(output_dir: str, batch_id: str) -> dict[str, Any]:
                     status = "success" if item.get("output_path") else "failed"
                 status_counts[status] = status_counts.get(status, 0) + 1
             out["status_counts"] = status_counts
-            out["can_resume"] = any(status in ("pending", "running", "failed") for status in status_counts)
+            out["can_resume"] = any(
+                status in ("pending", "running", "failed") for status in status_counts
+            )
         except (OSError, json.JSONDecodeError) as e:
             out["report_preview"] = f"(could not read report: {e})"
     else:

--- a/paperbanana/studio/runs.py
+++ b/paperbanana/studio/runs.py
@@ -115,6 +115,15 @@ def load_batch_summary(output_dir: str, batch_id: str) -> dict[str, Any]:
         try:
             data = json.loads(report_path.read_text(encoding="utf-8"))
             out["report_preview"] = json.dumps(data, indent=2)[:16000]
+            items = data.get("items", []) if isinstance(data, dict) else []
+            status_counts: dict[str, int] = {}
+            for item in items:
+                status = item.get("status")
+                if not status:
+                    status = "success" if item.get("output_path") else "failed"
+                status_counts[status] = status_counts.get(status, 0) + 1
+            out["status_counts"] = status_counts
+            out["can_resume"] = any(status in ("pending", "running", "failed") for status in status_counts)
         except (OSError, json.JSONDecodeError) as e:
             out["report_preview"] = f"(could not read report: {e})"
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -411,3 +411,141 @@ def test_setup_custom_endpoint_requires_non_empty_url(monkeypatch):
         assert "URL cannot be empty" in result.output
         env_text = Path(".env").read_text(encoding="utf-8")
         assert "GOOGLE_BASE_URL=https://gemini-proxy.example.com" in env_text
+
+
+def test_batch_resume_retry_failed(tmp_path, monkeypatch):
+    """batch supports checkpoint resume with --retry-failed."""
+    input_a = tmp_path / "a.txt"
+    input_b = tmp_path / "b.txt"
+    input_a.write_text("A", encoding="utf-8")
+    input_b.write_text("B", encoding="utf-8")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {"id": "ok", "input": str(input_a), "caption": "always ok"},
+                    {"id": "flaky", "input": str(input_b), "caption": "fails once"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    call_state = {"flaky_calls": 0}
+
+    class _FakePipeline:
+        def __init__(self, settings=None, **kwargs):
+            self.settings = settings
+
+        async def generate(self, gen_input):
+            from paperbanana.core.types import GenerationOutput, IterationRecord
+
+            if "fails once" in gen_input.communicative_intent:
+                call_state["flaky_calls"] += 1
+                if call_state["flaky_calls"] == 1:
+                    raise RuntimeError("transient boom")
+            image_path = str(tmp_path / f"{gen_input.communicative_intent.replace(' ', '_')}.png")
+            return GenerationOutput(
+                image_path=image_path,
+                description="d",
+                iterations=[IterationRecord(iteration=1, description="d", image_path=image_path)],
+                metadata={"run_id": f"run_{gen_input.communicative_intent.replace(' ', '_')}"},
+            )
+
+    monkeypatch.setattr("paperbanana.core.pipeline.PaperBananaPipeline", _FakePipeline)
+
+    first = runner.invoke(
+        app,
+        ["batch", "--manifest", str(manifest), "--output-dir", str(tmp_path)],
+    )
+    assert first.exit_code == 0
+    batches = sorted(tmp_path.glob("batch_*/batch_report.json"))
+    assert len(batches) == 1
+    batch_dir = batches[0].parent
+    first_report = json.loads(batches[0].read_text(encoding="utf-8"))
+    statuses = {item["id"]: item.get("status") for item in first_report["items"]}
+    assert statuses["ok"] == "success"
+    assert statuses["flaky"] == "failed"
+
+    second = runner.invoke(
+        app,
+        [
+            "batch",
+            "--manifest",
+            str(manifest),
+            "--output-dir",
+            str(tmp_path),
+            "--resume-batch",
+            str(batch_dir),
+            "--retry-failed",
+        ],
+    )
+    assert second.exit_code == 0
+    resumed_report = json.loads((batch_dir / "batch_report.json").read_text(encoding="utf-8"))
+    statuses = {item["id"]: item.get("status") for item in resumed_report["items"]}
+    assert statuses["ok"] == "success"
+    assert statuses["flaky"] == "success"
+
+
+def test_plot_batch_supports_concurrency_and_retries(tmp_path, monkeypatch):
+    """plot-batch writes attempts/status with retries."""
+    data_path = tmp_path / "data.csv"
+    data_path.write_text("x,y\n1,2\n2,3\n", encoding="utf-8")
+    manifest = tmp_path / "plot_manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "items": [
+                    {"id": "p1", "data": str(data_path), "intent": "ok plot"},
+                    {"id": "p2", "data": str(data_path), "intent": "flaky plot"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    state = {"flaky_calls": 0}
+
+    class _FakePipeline:
+        def __init__(self, settings=None, **kwargs):
+            self.settings = settings
+
+        async def generate(self, gen_input):
+            from paperbanana.core.types import GenerationOutput, IterationRecord
+
+            if "flaky" in gen_input.communicative_intent:
+                state["flaky_calls"] += 1
+                if state["flaky_calls"] == 1:
+                    raise RuntimeError("temporary")
+            img = str(tmp_path / f"{gen_input.communicative_intent.replace(' ', '_')}.png")
+            return GenerationOutput(
+                image_path=img,
+                description="d",
+                iterations=[IterationRecord(iteration=1, description="d", image_path=img)],
+                metadata={"run_id": "run_plot"},
+            )
+
+    monkeypatch.setattr("paperbanana.core.pipeline.PaperBananaPipeline", _FakePipeline)
+
+    result = runner.invoke(
+        app,
+        [
+            "plot-batch",
+            "--manifest",
+            str(manifest),
+            "--output-dir",
+            str(tmp_path),
+            "--concurrency",
+            "2",
+            "--max-retries",
+            "1",
+        ],
+    )
+    assert result.exit_code == 0
+    reports = sorted(tmp_path.glob("batch_*/batch_report.json"))
+    assert len(reports) == 1
+    report = json.loads(reports[0].read_text(encoding="utf-8"))
+    assert all(item.get("status") == "success" for item in report["items"])
+    flaky = next(item for item in report["items"] if item["id"] == "p2")
+    assert flaky.get("attempts", 0) >= 2


### PR DESCRIPTION
## Summary

- Add persistent batch checkpointing via batch_checkpoint.json with per-item execution state.
- Implement resume/retry/concurrency controls for both CLI batch commands (batch, plot-batch).
- Bring Studio batch runner/UI to parity with CLI (resume batch, retry failed, max retries, concurrency).
- Keep batch_report.json synchronized during execution and enriched with status/attempt fields.
- Add tests covering resume + retry flows and retry/concurrency behavior.

Closes #128 

## Why
Batch runs are long-lived and can fail for transient reasons. This change prevents lost progress, avoids re-running successful items, and reduces manual recovery effort/cost.

