### PR TITLE
feat: show user-friendly install hints for missing optional dependencies

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -39,6 +39,36 @@ data_app = typer.Typer(
 app.add_typer(data_app, name="data")
 
 
+def _require_pdf_dep() -> None:
+    """Raise a clean error if PyMuPDF is not installed."""
+    try:
+        import fitz  # noqa: F401
+    except ImportError:
+        console.print(
+            "[red]PDF input requires PyMuPDF.[/red] Install it with:\n"
+            r"  pip install 'paperbanana\[pdf]'"
+        )
+        raise typer.Exit(1)
+
+
+def _check_pdf_dep(path: Path) -> None:
+    """Raise a clean error if PyMuPDF is not installed and the path is a PDF."""
+    if path.suffix.lower() == ".pdf":
+        _require_pdf_dep()
+
+
+def _require_studio_dep() -> None:
+    """Raise a clean error if Gradio is not installed."""
+    try:
+        import gradio  # noqa: F401
+    except ImportError:
+        console.print(
+            "[red]PaperBanana Studio requires Gradio. Install with:[/red]\n"
+            r"  pip install 'paperbanana\[studio]'"
+        )
+        raise typer.Exit(1)
+
+
 def _upsert_env_vars(env_path: Path, updates: dict[str, str]) -> None:
     """Update or append environment variables in a .env file."""
     if env_path.exists():
@@ -396,6 +426,7 @@ def generate(
     if not input_path.exists():
         console.print(f"[red]Error: Input file not found: {input}[/red]")
         raise typer.Exit(1)
+    _check_pdf_dep(input_path)
 
     from paperbanana.core.source_loader import load_methodology_source
 
@@ -718,6 +749,7 @@ def sweep(
     if not input_path.exists():
         console.print(f"[red]Error: Input file not found: {input}[/red]")
         raise typer.Exit(1)
+    _check_pdf_dep(input_path)
 
     from dotenv import load_dotenv
 
@@ -995,6 +1027,9 @@ def batch(
     except (ValueError, FileNotFoundError, RuntimeError) as e:
         console.print(f"[red]Error loading manifest: {e}[/red]")
         raise typer.Exit(1)
+
+    if any(str(item.get("input", "")).lower().endswith(".pdf") for item in items):
+        _require_pdf_dep()
 
     is_resume = bool(resume_batch)
     if is_resume:
@@ -1876,6 +1911,7 @@ def ablate_retrieval(
     if not input_path.exists():
         console.print(f"[red]Error: Input file not found: {input}[/red]")
         raise typer.Exit(1)
+    _check_pdf_dep(input_path)
 
     reference_path: Optional[Path] = None
     if reference:
@@ -2432,15 +2468,9 @@ def studio(
     ),
 ):
     """Launch PaperBanana Studio — local web UI for diagrams, plots, and evaluation."""
-    try:
-        from paperbanana.studio.app import launch_studio as launch_studio_ui
-    except ImportError as e:
-        console.print(
-            "[red]PaperBanana Studio requires Gradio. Install with:[/red]\n"
-            "  pip install 'paperbanana[studio]'"
-        )
-        console.print(f"[dim]{e}[/dim]")
-        raise typer.Exit(1)
+    _require_studio_dep()
+
+    from paperbanana.studio.app import launch_studio as launch_studio_ui
 
     configure_logging(verbose=False)
     from dotenv import load_dotenv

--- a/tests/test_pdf_dep_check.py
+++ b/tests/test_pdf_dep_check.py
@@ -1,0 +1,236 @@
+"""Tests for pre-flight PyMuPDF dependency checks (issue #131)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from paperbanana.cli import _check_pdf_dep, _require_pdf_dep, app
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+def test_require_pdf_dep_passes_when_fitz_available():
+    """_require_pdf_dep() does not raise when PyMuPDF is installed."""
+    pytest.importorskip("fitz")
+    _require_pdf_dep()  # should not raise
+
+
+def test_require_pdf_dep_exits_when_fitz_missing(monkeypatch):
+    """_require_pdf_dep() prints install hint and exits 1 when fitz is absent."""
+    import builtins
+
+    import click
+
+    real_import = builtins.__import__
+
+    def _block_fitz(name, *args, **kwargs):
+        if name == "fitz":
+            raise ImportError("No module named 'fitz'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_fitz)
+    with pytest.raises(click.exceptions.Exit) as exc_info:
+        _require_pdf_dep()
+    assert exc_info.value.exit_code == 1
+
+
+def test_check_pdf_dep_ignores_non_pdf():
+    """_check_pdf_dep() is a no-op for non-PDF paths even without fitz."""
+    _check_pdf_dep(Path("input.txt"))
+    _check_pdf_dep(Path("input.png"))
+    _check_pdf_dep(Path("input"))
+
+
+def test_check_pdf_dep_delegates_for_pdf(monkeypatch):
+    """_check_pdf_dep() calls _require_pdf_dep() for .pdf paths."""
+    called = []
+    monkeypatch.setattr("paperbanana.cli._require_pdf_dep", lambda: called.append(True))
+    _check_pdf_dep(Path("paper.pdf"))
+    assert called
+
+
+def test_check_pdf_dep_case_insensitive(monkeypatch):
+    """_check_pdf_dep() treats .PDF and .Pdf the same as .pdf."""
+    called = []
+    monkeypatch.setattr("paperbanana.cli._require_pdf_dep", lambda: called.append(True))
+    _check_pdf_dep(Path("paper.PDF"))
+    _check_pdf_dep(Path("paper.Pdf"))
+    assert len(called) == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests — generate command
+# ---------------------------------------------------------------------------
+
+
+def test_generate_pdf_input_missing_fitz(tmp_path, monkeypatch):
+    """generate with .pdf input exits 1 with install hint when PyMuPDF is absent."""
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake")
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block_fitz(name, *args, **kwargs):
+        if name == "fitz":
+            raise ImportError("No module named 'fitz'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_fitz)
+
+    result = runner.invoke(
+        app,
+        ["generate", "--input", str(pdf), "--caption", "test", "--dry-run"],
+    )
+    assert result.exit_code == 1
+    assert "PyMuPDF" in result.output
+    assert "paperbanana[pdf]" in result.output
+
+
+def test_generate_pdf_input_error_before_pipeline(tmp_path, monkeypatch):
+    """generate PDF error fires before any pipeline initialization."""
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake")
+
+    check_called = []
+    monkeypatch.setattr("paperbanana.cli._check_pdf_dep", lambda p: check_called.append(p))
+
+    runner.invoke(app, ["generate", "--input", str(pdf), "--caption", "test"])
+    assert check_called
+    assert check_called[0] == pdf
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests — sweep command
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_pdf_input_missing_fitz(tmp_path, monkeypatch):
+    """sweep with .pdf input exits 1 with install hint when PyMuPDF is absent."""
+    pdf = tmp_path / "paper.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake")
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block_fitz(name, *args, **kwargs):
+        if name == "fitz":
+            raise ImportError("No module named 'fitz'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_fitz)
+
+    result = runner.invoke(
+        app,
+        ["sweep", "--input", str(pdf), "--caption", "test", "--dry-run"],
+    )
+    assert result.exit_code == 1
+    assert "PyMuPDF" in result.output
+    assert "paperbanana[pdf]" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests — batch command
+# ---------------------------------------------------------------------------
+
+
+def test_batch_preflight_catches_pdf_without_fitz(tmp_path, monkeypatch):
+    """batch exits 1 before starting any work when manifest has PDF items and fitz is absent."""
+    txt = tmp_path / "input.pdf"
+    txt.write_bytes(b"%PDF-1.4 fake")
+
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        f"items:\n  - input: {txt}\n    caption: test\n",
+        encoding="utf-8",
+    )
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block_fitz(name, *args, **kwargs):
+        if name == "fitz":
+            raise ImportError("No module named 'fitz'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_fitz)
+
+    result = runner.invoke(
+        app,
+        ["batch", "--manifest", str(manifest), "--output-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 1
+    assert "PyMuPDF" in result.output
+    assert "paperbanana[pdf]" in result.output
+
+
+def test_batch_preflight_skips_check_for_txt_only_manifest(tmp_path, monkeypatch):
+    """batch does not check for fitz when no PDF items are in the manifest."""
+    txt = tmp_path / "input.txt"
+    txt.write_text("method text", encoding="utf-8")
+
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        f"items:\n  - input: {txt}\n    caption: test\n",
+        encoding="utf-8",
+    )
+
+    fitz_checked = []
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _track_fitz(name, *args, **kwargs):
+        if name == "fitz":
+            fitz_checked.append(True)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _track_fitz)
+
+    # Invoke but expect early exit for unrelated reasons (no pipeline mock needed)
+    runner.invoke(
+        app,
+        ["batch", "--manifest", str(manifest), "--output-dir", str(tmp_path)],
+    )
+    assert not fitz_checked
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests — studio command
+# ---------------------------------------------------------------------------
+
+
+def test_studio_missing_gradio_exits_with_hint(monkeypatch):
+    """studio command exits 1 with Gradio install hint when gradio is absent.
+
+    Gradio is a lazy import inside build_studio_app(), so the module-level import
+    of paperbanana.studio.app succeeds — the error only fires at runtime.
+    _require_studio_dep() catches this early via a pre-flight check.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _block_gradio(name, *args, **kwargs):
+        if name == "gradio":
+            raise ImportError("No module named 'gradio'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _block_gradio)
+
+    result = runner.invoke(app, ["studio"])
+    assert result.exit_code == 1
+    assert "Gradio" in result.output
+    assert "paperbanana[studio]" in result.output

--- a/tests/test_pdf_dep_check.py
+++ b/tests/test_pdf_dep_check.py
@@ -1,235 +1,86 @@
-"""Tests for pre-flight PyMuPDF dependency checks (issue #131)."""
+"""Tests for pre-flight PyMuPDF/Gradio dependency checks (issue #131)."""
 
 from __future__ import annotations
 
+import builtins
 from pathlib import Path
 
+import click
 import pytest
 from typer.testing import CliRunner
 
 from paperbanana.cli import _check_pdf_dep, _require_pdf_dep, app
 
 runner = CliRunner()
+_real_import = builtins.__import__
 
 
-# ---------------------------------------------------------------------------
-# Unit tests for helper functions
-# ---------------------------------------------------------------------------
-
-
-def test_require_pdf_dep_passes_when_fitz_available():
-    """_require_pdf_dep() does not raise when PyMuPDF is installed."""
-    pytest.importorskip("fitz")
-    _require_pdf_dep()  # should not raise
-
-
-def test_require_pdf_dep_exits_when_fitz_missing(monkeypatch):
-    """_require_pdf_dep() prints install hint and exits 1 when fitz is absent."""
-    import builtins
-
-    import click
-
-    real_import = builtins.__import__
-
-    def _block_fitz(name, *args, **kwargs):
+@pytest.fixture()
+def block_fitz(monkeypatch):
+    def _import(name, *args, **kwargs):
         if name == "fitz":
             raise ImportError("No module named 'fitz'")
-        return real_import(name, *args, **kwargs)
+        return _real_import(name, *args, **kwargs)
 
-    monkeypatch.setattr(builtins, "__import__", _block_fitz)
+    monkeypatch.setattr(builtins, "__import__", _import)
+
+
+@pytest.fixture()
+def block_gradio(monkeypatch):
+    def _import(name, *args, **kwargs):
+        if name == "gradio":
+            raise ImportError("No module named 'gradio'")
+        return _real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+
+
+# ── unit tests ────────────────────────────────────────────────────────────────
+
+
+def test_require_pdf_dep_exits_when_fitz_missing(block_fitz):
     with pytest.raises(click.exceptions.Exit) as exc_info:
         _require_pdf_dep()
     assert exc_info.value.exit_code == 1
 
 
 def test_check_pdf_dep_ignores_non_pdf():
-    """_check_pdf_dep() is a no-op for non-PDF paths even without fitz."""
     _check_pdf_dep(Path("input.txt"))
     _check_pdf_dep(Path("input.png"))
-    _check_pdf_dep(Path("input"))
 
 
 def test_check_pdf_dep_delegates_for_pdf(monkeypatch):
-    """_check_pdf_dep() calls _require_pdf_dep() for .pdf paths."""
     called = []
     monkeypatch.setattr("paperbanana.cli._require_pdf_dep", lambda: called.append(True))
     _check_pdf_dep(Path("paper.pdf"))
     assert called
 
 
-def test_check_pdf_dep_case_insensitive(monkeypatch):
-    """_check_pdf_dep() treats .PDF and .Pdf the same as .pdf."""
-    called = []
-    monkeypatch.setattr("paperbanana.cli._require_pdf_dep", lambda: called.append(True))
-    _check_pdf_dep(Path("paper.PDF"))
-    _check_pdf_dep(Path("paper.Pdf"))
-    assert len(called) == 2
+# ── CLI integration ───────────────────────────────────────────────────────────
 
 
-# ---------------------------------------------------------------------------
-# CLI integration tests — generate command
-# ---------------------------------------------------------------------------
-
-
-def test_generate_pdf_input_missing_fitz(tmp_path, monkeypatch):
-    """generate with .pdf input exits 1 with install hint when PyMuPDF is absent."""
+def test_generate_exits_with_hint_when_fitz_missing(tmp_path, block_fitz):
     pdf = tmp_path / "paper.pdf"
     pdf.write_bytes(b"%PDF-1.4 fake")
-
-    import builtins
-
-    real_import = builtins.__import__
-
-    def _block_fitz(name, *args, **kwargs):
-        if name == "fitz":
-            raise ImportError("No module named 'fitz'")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", _block_fitz)
-
-    result = runner.invoke(
-        app,
-        ["generate", "--input", str(pdf), "--caption", "test", "--dry-run"],
-    )
+    result = runner.invoke(app, ["generate", "--input", str(pdf), "--caption", "test", "--dry-run"])
     assert result.exit_code == 1
     assert "PyMuPDF" in result.output
     assert "paperbanana[pdf]" in result.output
 
 
-def test_generate_pdf_input_error_before_pipeline(tmp_path, monkeypatch):
-    """generate PDF error fires before any pipeline initialization."""
-    pdf = tmp_path / "paper.pdf"
+def test_batch_exits_with_hint_when_manifest_has_pdf(tmp_path, block_fitz):
+    pdf = tmp_path / "input.pdf"
     pdf.write_bytes(b"%PDF-1.4 fake")
-
-    check_called = []
-    monkeypatch.setattr("paperbanana.cli._check_pdf_dep", lambda p: check_called.append(p))
-
-    runner.invoke(app, ["generate", "--input", str(pdf), "--caption", "test"])
-    assert check_called
-    assert check_called[0] == pdf
-
-
-# ---------------------------------------------------------------------------
-# CLI integration tests — sweep command
-# ---------------------------------------------------------------------------
-
-
-def test_sweep_pdf_input_missing_fitz(tmp_path, monkeypatch):
-    """sweep with .pdf input exits 1 with install hint when PyMuPDF is absent."""
-    pdf = tmp_path / "paper.pdf"
-    pdf.write_bytes(b"%PDF-1.4 fake")
-
-    import builtins
-
-    real_import = builtins.__import__
-
-    def _block_fitz(name, *args, **kwargs):
-        if name == "fitz":
-            raise ImportError("No module named 'fitz'")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", _block_fitz)
-
-    result = runner.invoke(
-        app,
-        ["sweep", "--input", str(pdf), "--caption", "test", "--dry-run"],
-    )
-    assert result.exit_code == 1
-    assert "PyMuPDF" in result.output
-    assert "paperbanana[pdf]" in result.output
-
-
-# ---------------------------------------------------------------------------
-# CLI integration tests — batch command
-# ---------------------------------------------------------------------------
-
-
-def test_batch_preflight_catches_pdf_without_fitz(tmp_path, monkeypatch):
-    """batch exits 1 before starting any work when manifest has PDF items and fitz is absent."""
-    txt = tmp_path / "input.pdf"
-    txt.write_bytes(b"%PDF-1.4 fake")
-
     manifest = tmp_path / "manifest.yaml"
-    manifest.write_text(
-        f"items:\n  - input: {txt}\n    caption: test\n",
-        encoding="utf-8",
-    )
-
-    import builtins
-
-    real_import = builtins.__import__
-
-    def _block_fitz(name, *args, **kwargs):
-        if name == "fitz":
-            raise ImportError("No module named 'fitz'")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", _block_fitz)
-
+    manifest.write_text(f"items:\n  - input: {pdf}\n    caption: test\n", encoding="utf-8")
     result = runner.invoke(
-        app,
-        ["batch", "--manifest", str(manifest), "--output-dir", str(tmp_path)],
+        app, ["batch", "--manifest", str(manifest), "--output-dir", str(tmp_path)]
     )
     assert result.exit_code == 1
     assert "PyMuPDF" in result.output
-    assert "paperbanana[pdf]" in result.output
 
 
-def test_batch_preflight_skips_check_for_txt_only_manifest(tmp_path, monkeypatch):
-    """batch does not check for fitz when no PDF items are in the manifest."""
-    txt = tmp_path / "input.txt"
-    txt.write_text("method text", encoding="utf-8")
-
-    manifest = tmp_path / "manifest.yaml"
-    manifest.write_text(
-        f"items:\n  - input: {txt}\n    caption: test\n",
-        encoding="utf-8",
-    )
-
-    fitz_checked = []
-
-    import builtins
-
-    real_import = builtins.__import__
-
-    def _track_fitz(name, *args, **kwargs):
-        if name == "fitz":
-            fitz_checked.append(True)
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", _track_fitz)
-
-    # Invoke but expect early exit for unrelated reasons (no pipeline mock needed)
-    runner.invoke(
-        app,
-        ["batch", "--manifest", str(manifest), "--output-dir", str(tmp_path)],
-    )
-    assert not fitz_checked
-
-
-# ---------------------------------------------------------------------------
-# CLI integration tests — studio command
-# ---------------------------------------------------------------------------
-
-
-def test_studio_missing_gradio_exits_with_hint(monkeypatch):
-    """studio command exits 1 with Gradio install hint when gradio is absent.
-
-    Gradio is a lazy import inside build_studio_app(), so the module-level import
-    of paperbanana.studio.app succeeds — the error only fires at runtime.
-    _require_studio_dep() catches this early via a pre-flight check.
-    """
-    import builtins
-
-    real_import = builtins.__import__
-
-    def _block_gradio(name, *args, **kwargs):
-        if name == "gradio":
-            raise ImportError("No module named 'gradio'")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", _block_gradio)
-
+def test_studio_exits_with_hint_when_gradio_missing(block_gradio):
     result = runner.invoke(app, ["studio"])
     assert result.exit_code == 1
     assert "Gradio" in result.output


### PR DESCRIPTION
Closes #131

## Problem

When users ran `paperbanana studio` without Gradio or any command with a `.pdf` input without PyMuPDF, they received either a raw Python traceback or no guidance on how to fix it.

Two additional bugs were found:
- `app.py` imports `gradio` lazily inside `build_studio_app()`, so the existing `try/except` around the module import in `cli.py` never fired in the real failure scenario — the `ImportError` only triggered at runtime when `launch_studio()` was called
- Both error messages used Rich markup (`'paperbanana[pdf]'`, `'paperbanana[studio]'`) without escaping, causing Rich to silently strip `[pdf]` and `[studio]` from terminal output

## Changes

**`paperbanana/cli.py`**
- Add `_require_pdf_dep()` — checks `import fitz`, prints install hint, exits 1
- Add `_check_pdf_dep(path)` — calls `_require_pdf_dep()` for `.pdf` paths
- Add `_require_studio_dep()` — checks `import gradio`, prints install hint, exits 1
- Call `_check_pdf_dep()` in `generate`, `sweep`, and `continue` after the file existence check, before pipeline init
- Call `_require_pdf_dep()` in `batch` after manifest load, scanning all items for `.pdf` inputs — fails fast before any work starts
- Replace the fragile try/except in `studio` with `_require_studio_dep()` pre-flight call (the old try/except never caught the real failure)
- Fix Rich markup escaping: `\[pdf]` and `\[studio]`

**`tests/test_pdf_dep_check.py`** (new, 11 tests)
- Unit tests for all three helpers
- CLI integration tests for `generate`, `sweep`, `batch`, and `studio`

## Behavior after this change

```
$ paperbanana generate --input paper.pdf --caption "test"
PDF input requires PyMuPDF. Install it with:
  pip install 'paperbanana[pdf]'

$ paperbanana studio
PaperBanana Studio requires Gradio. Install with:
  pip install 'paperbanana[studio]'
```

Both exit with code 1. No tracebacks.