### PR TITLE
feat: print per-item status table in CLI after batch run completes

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -12,6 +12,7 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Prompt
+from rich.table import Table
 
 from paperbanana.core.config import Settings
 from paperbanana.core.logging import configure_logging
@@ -955,6 +956,7 @@ def batch(
     ),
     concurrency: int = typer.Option(1, "--concurrency", help="Parallel item workers"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed progress"),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress per-item status table"),
 ):
     """Generate multiple methodology diagrams from a manifest file (YAML or JSON)."""
     if format not in ("png", "jpeg", "webp"):
@@ -1170,12 +1172,36 @@ def batch(
         mark_complete=True,
     )
     report_path = batch_dir / "batch_report.json"
-    succeeded = sum(1 for x in report["items"] if x.get("output_path"))
+    ri = report["items"]
+    succeeded = sum(1 for x in ri if x.get("status") == "success")
+    failed = sum(1 for x in ri if x.get("status") == "failed")
+    skipped = len(ri) - succeeded - failed
     console.print(
         f"[green]Batch complete.[/green] [dim]{total_elapsed:.1f}s · "
-        f"{succeeded}/{len(items)} succeeded[/dim]"
+        f"{succeeded} succeeded · {failed} failed · {skipped} skipped[/dim]"
     )
     console.print(f"  Report: [bold]{report_path}[/bold]")
+    if not quiet:
+        large_batch = len(ri) > 20
+        t = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+        t.add_column("#", style="dim", width=4)
+        t.add_column("Item", min_width=20)
+        t.add_column("Status", width=10)
+        t.add_column("Output / Error")
+        for idx, item in enumerate(ri):
+            if large_batch and item.get("status") == "success":
+                continue
+            ok = item.get("status") == "success"
+            status_str = "[green]✓ done[/green]" if ok else "[red]✗ failed[/red]"
+            detail = str(item.get("output_path" if ok else "error") or "—")
+            t.add_row(str(idx + 1), str(item.get("id", "—")), status_str, detail)
+        if large_batch and succeeded > 0:
+            console.print(
+                f"[dim]{succeeded} succeeded (hidden), {failed} failed (shown above)[/dim]"
+            )
+        console.print(t)
+    if failed > 0:
+        raise typer.Exit(1)
 
 
 @app.command("batch-report")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -459,7 +459,7 @@ def test_batch_resume_retry_failed(tmp_path, monkeypatch):
         app,
         ["batch", "--manifest", str(manifest), "--output-dir", str(tmp_path)],
     )
-    assert first.exit_code == 0
+    assert first.exit_code == 1  # flaky failed → non-zero exit
     batches = sorted(tmp_path.glob("batch_*/batch_report.json"))
     assert len(batches) == 1
     batch_dir = batches[0].parent
@@ -549,3 +549,51 @@ def test_plot_batch_supports_concurrency_and_retries(tmp_path, monkeypatch):
     assert all(item.get("status") == "success" for item in report["items"])
     flaky = next(item for item in report["items"] if item["id"] == "p2")
     assert flaky.get("attempts", 0) >= 2
+
+
+def test_batch_prints_status_table_on_partial_failure(tmp_path, monkeypatch):
+    """batch prints per-item table, correct counts, and exits 1 when any item fails."""
+    from paperbanana.core.types import CritiqueResult, GenerationOutput, IterationRecord
+
+    txt = tmp_path / "input.txt"
+    txt.write_text("methodology text", encoding="utf-8")
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text(
+        f"items:\n  - input: {txt.name}\n    caption: 'fig1'\n    id: item_ok\n"
+        f"  - input: {txt.name}\n    caption: 'fig2'\n    id: item_fail\n",
+        encoding="utf-8",
+    )
+    call_state = {"n": 0}
+
+    class _FakePipeline:
+        def __init__(self, settings=None, **kwargs):
+            pass
+
+        async def generate(self, gen_input):
+            call_state["n"] += 1
+            if call_state["n"] == 2:
+                raise RuntimeError("critic parse error")
+            img = str(tmp_path / "out.png")
+            return GenerationOutput(
+                image_path=img,
+                description="d",
+                iterations=[
+                    IterationRecord(
+                        iteration=1,
+                        description="d",
+                        image_path=img,
+                        critique=CritiqueResult(critic_suggestions=[]),
+                    )
+                ],
+                metadata={"run_id": "r1"},
+            )
+
+    monkeypatch.setattr("paperbanana.core.pipeline.PaperBananaPipeline", _FakePipeline)
+    result = runner.invoke(
+        app, ["batch", "--manifest", str(manifest), "--output-dir", str(tmp_path)]
+    )
+    assert result.exit_code == 1
+    assert "1 succeeded" in result.output
+    assert "1 failed" in result.output
+    assert "✓" in result.output
+    assert "✗" in result.output


### PR DESCRIPTION
---

**Closes #133**

### Problem

After a batch run, the CLI printed only a single summary line regardless of outcome. When items failed, users had to open and parse `batch_report.json` manually to find out which items failed and why.

### Changes

**`paperbanana/cli.py`**

- Add `quiet: bool` parameter (`--quiet / -q`) to the `batch` command
- Replace the bare summary `console.print` with a Rich `Table` showing per-item `#`, `Item`, `Status`, and `Output / Error`
- Update summary line from `N/M succeeded` to `N succeeded · N failed · N skipped` breakdown
- For batches >20 items, collapse successful rows and show only failed items with a note
- Raise `typer.Exit(1)` when any item failed so CI pipelines catch failures via exit code

**`tests/test_cli.py`**

- Update `test_batch_resume_retry_failed`: expected exit code corrected from `0` to `1`
- Add `test_batch_prints_status_table_on_partial_failure`: verifies table output, `✓`/`✗` symbols, count breakdown, and exit code 1 on partial failure

### Behavior after this change

```
Batch complete. 0.0s · 2 succeeded · 1 failed · 0 skipped
  Report: outputs/batch_abc/batch_report.json

#     Item                  Status      Output / Error
1     transformer_arch      ✓ done      outputs/batch_abc/transformer_arch/diagram.png
2     bert_pretraining      ✗ failed    critic response parse error (attempt 3/3)
3     gpt_architecture      ✓ done      outputs/batch_abc/gpt_architecture/diagram.png
```

Exit code is `1` when any item failed, `0` when all succeed. Pass `--quiet` to suppress the table.