### PR TITLE
feat: add multi-panel composite figure generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,25 @@ items:
 
 Paths in the manifest are resolved relative to the manifest file's directory.
 
+**Composite figures:** Add an optional `composite` section to automatically stitch all generated panels into a single labeled figure after the batch completes:
+
+```yaml
+composite:
+  layout: "1x3"          # rows x cols, or "auto"
+  labels: auto            # (a), (b), (c)... or explicit list, or null
+  spacing: 20             # pixels between panels
+  label_position: bottom  # top or bottom
+  output: "composite.png"
+
+items:
+  - input: method_encoder.txt
+    caption: "Encoder architecture"
+    id: panel_a
+  # ...
+```
+
+The composite image is saved alongside the individual panels in the batch output directory. See `examples/composite_batch_manifest.yaml` for a complete example.
+
 **Generate a human-readable report** from an existing batch run (Markdown or HTML):
 
 ```bash
@@ -322,6 +341,29 @@ Paths are resolved relative to the manifest file’s directory.
 | `--venue` | | Venue style (neurips, icml, acl, ieee, custom) |
 | `--aspect-ratio` | `-ar` | Default aspect ratio when not set in the manifest |
 | `--verbose` | `-v` | Verbose logging |
+
+### `paperbanana composite` -- Compose Multi-Panel Figures
+
+Stitch multiple images into a single labeled figure with `(a)`, `(b)`, `(c)` sub-panel labels:
+
+```bash
+paperbanana composite \
+  panel_a.png panel_b.png panel_c.png \
+  --layout 1x3 \
+  --output figure2.png
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `IMAGES` | | Positional: paths to images to compose |
+| `--layout` | `-l` | Grid layout: `RxC` (e.g. `1x3`, `2x2`) or `auto` (default: auto) |
+| `--labels` | | Comma-separated labels, or `none` to disable (default: auto `(a),(b),...`) |
+| `--spacing` | `-s` | Pixel spacing between panels (default: 20) |
+| `--label-position` | | `top` or `bottom` (default: bottom) |
+| `--label-font-size` | | Font size for labels (default: 32) |
+| `--output` | `-o` | Output path (default: composite_output.png) |
+
+This command works on any existing images — no API calls needed. It is also triggered automatically when a batch manifest includes a `composite` section (see `paperbanana batch` above).
 
 ### `paperbanana evaluate` -- Quality Assessment
 

--- a/examples/composite_batch_manifest.yaml
+++ b/examples/composite_batch_manifest.yaml
@@ -1,0 +1,18 @@
+# Batch manifest with composite figure output.
+# Generates individual panels, then stitches them into a single labeled figure.
+# Run: paperbanana batch --manifest examples/composite_batch_manifest.yaml
+
+composite:
+  layout: "1x2"           # rows x cols (or "auto")
+  labels: auto             # auto generates (a), (b), (c); or explicit list
+  spacing: 20              # pixels between panels
+  label_position: bottom   # top or bottom
+  output: "composite.png"  # saved in the batch output directory
+
+items:
+  - input: sample_inputs/transformer_method.txt
+    caption: "Encoder-decoder architecture with multi-head attention"
+    id: panel_a
+  - input: sample_inputs/mamba_method.txt
+    caption: "Mamba block with selective state space"
+    id: panel_b

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -1179,9 +1179,7 @@ def batch(
 
     # Auto-composite if manifest has a composite section
     if composite_config is not None:
-        output_paths = [
-            x["output_path"] for x in report["items"] if x.get("output_path")
-        ]
+        output_paths = [x["output_path"] for x in report["items"] if x.get("output_path")]
         if output_paths:
             from paperbanana.core.composite import compose_images
 
@@ -1197,9 +1195,7 @@ def batch(
                     label_position=composite_config.get("label_position", "bottom"),
                     output_path=comp_path,
                 )
-                console.print(
-                    f"  Composite: [bold]{comp_path}[/bold]"
-                )
+                console.print(f"  Composite: [bold]{comp_path}[/bold]")
             except Exception as e:
                 console.print(f"  [yellow]Composite failed: {e}[/yellow]")
 
@@ -1268,9 +1264,7 @@ def batch_report(
 
 @app.command()
 def composite(
-    images: list[str] = typer.Argument(
-        ..., help="Paths to images to compose into a single figure"
-    ),
+    images: list[str] = typer.Argument(..., help="Paths to images to compose into a single figure"),
     layout: str = typer.Option(
         "auto", "--layout", "-l", help="Grid layout: 'RxC' (e.g. '1x3', '2x2') or 'auto'"
     ),
@@ -1283,9 +1277,7 @@ def composite(
     label_position: str = typer.Option(
         "bottom", "--label-position", help="Label placement: 'top' or 'bottom'"
     ),
-    label_font_size: int = typer.Option(
-        32, "--label-font-size", help="Font size for panel labels"
-    ),
+    label_font_size: int = typer.Option(32, "--label-font-size", help="Font size for panel labels"),
     output: str = typer.Option(
         "composite_output.png", "--output", "-o", help="Output path for the composite image"
     ),

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -982,7 +982,7 @@ def batch(
         checkpoint_progress,
         generate_batch_id,
         init_or_load_checkpoint,
-        load_batch_manifest,
+        load_batch_manifest_with_composite,
         mark_item_failure,
         mark_item_running,
         mark_item_success,
@@ -991,7 +991,7 @@ def batch(
     from paperbanana.core.utils import ensure_dir
 
     try:
-        items = load_batch_manifest(manifest_path)
+        items, composite_config = load_batch_manifest_with_composite(manifest_path)
     except (ValueError, FileNotFoundError, RuntimeError) as e:
         console.print(f"[red]Error loading manifest: {e}[/red]")
         raise typer.Exit(1)
@@ -1177,6 +1177,32 @@ def batch(
     )
     console.print(f"  Report: [bold]{report_path}[/bold]")
 
+    # Auto-composite if manifest has a composite section
+    if composite_config is not None:
+        output_paths = [
+            x["output_path"] for x in report["items"] if x.get("output_path")
+        ]
+        if output_paths:
+            from paperbanana.core.composite import compose_images
+
+            comp_output = composite_config.get("output") or "composite.png"
+            comp_path = batch_dir / comp_output
+            try:
+                compose_images(
+                    image_paths=output_paths,
+                    layout=composite_config.get("layout", "auto"),
+                    labels=composite_config.get("labels"),
+                    auto_label=composite_config.get("auto_label", True),
+                    spacing=composite_config.get("spacing", 20),
+                    label_position=composite_config.get("label_position", "bottom"),
+                    output_path=comp_path,
+                )
+                console.print(
+                    f"  Composite: [bold]{comp_path}[/bold]"
+                )
+            except Exception as e:
+                console.print(f"  [yellow]Composite failed: {e}[/yellow]")
+
 
 @app.command("batch-report")
 def batch_report(
@@ -1238,6 +1264,71 @@ def batch_report(
     except ValueError as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)
+
+
+@app.command()
+def composite(
+    images: list[str] = typer.Argument(
+        ..., help="Paths to images to compose into a single figure"
+    ),
+    layout: str = typer.Option(
+        "auto", "--layout", "-l", help="Grid layout: 'RxC' (e.g. '1x3', '2x2') or 'auto'"
+    ),
+    labels: Optional[str] = typer.Option(
+        None,
+        "--labels",
+        help="Comma-separated labels (e.g. '(a),(b),(c)') or 'none' to disable",
+    ),
+    spacing: int = typer.Option(20, "--spacing", "-s", help="Pixel spacing between panels"),
+    label_position: str = typer.Option(
+        "bottom", "--label-position", help="Label placement: 'top' or 'bottom'"
+    ),
+    label_font_size: int = typer.Option(
+        32, "--label-font-size", help="Font size for panel labels"
+    ),
+    output: str = typer.Option(
+        "composite_output.png", "--output", "-o", help="Output path for the composite image"
+    ),
+):
+    """Compose multiple images into a single labeled multi-panel figure."""
+    if label_position not in ("top", "bottom"):
+        console.print(
+            f"[red]Error: --label-position must be 'top' or 'bottom'. Got: {label_position}[/red]"
+        )
+        raise typer.Exit(1)
+
+    for img_path in images:
+        if not Path(img_path).exists():
+            console.print(f"[red]Error: Image not found: {img_path}[/red]")
+            raise typer.Exit(1)
+
+    from paperbanana.core.composite import compose_images
+
+    label_list: list[str] | None = None
+    auto_label = True
+    if labels is not None:
+        if labels.lower() == "none":
+            auto_label = False
+        else:
+            label_list = [item.strip() for item in labels.split(",")]
+            auto_label = False
+
+    try:
+        compose_images(
+            image_paths=images,
+            layout=layout,
+            labels=label_list,
+            auto_label=auto_label,
+            spacing=spacing,
+            label_position=label_position,
+            label_font_size=label_font_size,
+            output_path=output,
+        )
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    console.print(f"[green]Composite saved to:[/green] [bold]{output}[/bold]")
 
 
 @app.command("plot-batch")

--- a/paperbanana/core/batch.py
+++ b/paperbanana/core/batch.py
@@ -24,21 +24,15 @@ def generate_batch_id() -> str:
     return f"batch_{ts}_{short_uuid}"
 
 
-def load_batch_manifest(manifest_path: Path) -> list[dict[str, Any]]:
-    """Load a batch manifest (YAML or JSON) and return a list of items.
+def _parse_manifest_raw(manifest_path: Path) -> tuple[list, dict[str, Any] | None]:
+    """Parse a manifest file and return (items_list, full_data_dict_or_None).
 
-    Each item is a dict with:
-      - input: path to methodology text or PDF file (resolved relative to manifest parent)
-      - caption: figure caption / communicative intent
-      - id: optional string identifier for the item (default: index-based)
-      - pdf_pages: optional 1-based page selection for PDF inputs (e.g. "1-5" or "2,4,6-8")
-
-    Paths in the manifest are resolved relative to the manifest file's directory.
+    The full data dict is returned when the manifest is an object (not a bare list)
+    so callers can inspect extra keys like 'composite'.
     """
     manifest_path = Path(manifest_path).resolve()
     if not manifest_path.exists():
         raise FileNotFoundError(f"Manifest not found: {manifest_path}")
-    parent = manifest_path.parent
     raw = manifest_path.read_text(encoding="utf-8")
     suffix = manifest_path.suffix.lower()
     if suffix in (".yaml", ".yml"):
@@ -51,8 +45,6 @@ def load_batch_manifest(manifest_path: Path) -> list[dict[str, Any]]:
                 "PyYAML is required for YAML manifests. Install with: pip install pyyaml"
             )
     elif suffix == ".json":
-        import json
-
         data = json.loads(raw)
     else:
         raise ValueError(f"Manifest must be .yaml, .yml, or .json. Got: {manifest_path.suffix}")
@@ -60,11 +52,28 @@ def load_batch_manifest(manifest_path: Path) -> list[dict[str, Any]]:
     if data is None:
         raise ValueError("Manifest is empty")
     if isinstance(data, list):
-        items = data
-    elif isinstance(data, dict) and "items" in data:
-        items = data["items"]
-    else:
-        raise ValueError("Manifest must be a list of items or an object with an 'items' list")
+        return data, None
+    if isinstance(data, dict) and "items" in data:
+        return data["items"], data
+    raise ValueError("Manifest must be a list of items or an object with an 'items' list")
+
+
+def load_batch_manifest(
+    manifest_path: Path,
+) -> list[dict[str, Any]]:
+    """Load a batch manifest (YAML or JSON) and return a list of items.
+
+    Each item is a dict with:
+      - input: path to methodology text or PDF file (resolved relative to manifest parent)
+      - caption: figure caption / communicative intent
+      - id: optional string identifier for the item (default: index-based)
+      - pdf_pages: optional 1-based page selection for PDF inputs (e.g. "1-5" or "2,4,6-8")
+
+    Paths in the manifest are resolved relative to the manifest file's directory.
+    """
+    manifest_path = Path(manifest_path).resolve()
+    parent = manifest_path.parent
+    items, _ = _parse_manifest_raw(manifest_path)
 
     result = []
     for i, entry in enumerate(items):
@@ -89,6 +98,24 @@ def load_batch_manifest(manifest_path: Path) -> list[dict[str, Any]]:
             }
         )
     return result
+
+
+def load_batch_manifest_with_composite(
+    manifest_path: Path,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """Load a batch manifest and return (items, composite_config).
+
+    composite_config is None when the manifest has no ``composite`` section.
+    """
+    from paperbanana.core.composite import parse_composite_config
+
+    manifest_path = Path(manifest_path).resolve()
+    items = load_batch_manifest(manifest_path)
+    _, full_data = _parse_manifest_raw(manifest_path)
+    composite_config = None
+    if full_data is not None:
+        composite_config = parse_composite_config(full_data)
+    return items, composite_config
 
 
 def load_plot_batch_manifest(manifest_path: Path) -> list[dict[str, Any]]:

--- a/paperbanana/core/composite.py
+++ b/paperbanana/core/composite.py
@@ -1,0 +1,240 @@
+"""Composite figure generation: stitch multiple images into a labeled grid."""
+
+from __future__ import annotations
+
+import string
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+import structlog
+from PIL import Image, ImageDraw, ImageFont
+
+logger = structlog.get_logger()
+
+# Default settings
+DEFAULT_SPACING = 20
+DEFAULT_LABEL_FONT_SIZE = 32
+DEFAULT_BG_COLOR = (255, 255, 255)
+DEFAULT_LABEL_COLOR = (0, 0, 0)
+
+
+def _auto_labels(count: int) -> list[str]:
+    """Generate (a), (b), (c), ... labels."""
+    return [f"({c})" for c in string.ascii_lowercase[:count]]
+
+
+def _parse_layout(layout: str, image_count: int) -> tuple[int, int]:
+    """Parse a layout string like '2x3' into (rows, cols).
+
+    Also accepts 'auto' which picks a reasonable grid for the image count.
+    """
+    if layout.lower() == "auto":
+        if image_count <= 3:
+            return 1, image_count
+        if image_count <= 4:
+            return 2, 2
+        if image_count <= 6:
+            return 2, 3
+        if image_count <= 9:
+            return 3, 3
+        cols = 4
+        rows = (image_count + cols - 1) // cols
+        return rows, cols
+
+    parts = layout.lower().split("x")
+    if len(parts) != 2:
+        raise ValueError(f"Layout must be 'RxC' (e.g. '2x3') or 'auto'. Got: {layout!r}")
+    try:
+        rows, cols = int(parts[0]), int(parts[1])
+    except ValueError:
+        raise ValueError(f"Layout must be 'RxC' with integers. Got: {layout!r}")
+    if rows < 1 or cols < 1:
+        raise ValueError(f"Layout rows and cols must be >= 1. Got: {rows}x{cols}")
+    if rows * cols < image_count:
+        raise ValueError(
+            f"Layout {rows}x{cols} ({rows * cols} cells) cannot fit {image_count} images"
+        )
+    return rows, cols
+
+
+def _get_font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    """Try to load a TrueType font, fall back to default."""
+    try:
+        return ImageFont.truetype("DejaVuSans-Bold.ttf", size)
+    except (OSError, IOError):
+        try:
+            return ImageFont.truetype("Arial Bold.ttf", size)
+        except (OSError, IOError):
+            return ImageFont.load_default()
+
+
+def compose_images(
+    image_paths: list[str | Path],
+    *,
+    layout: str = "auto",
+    labels: Optional[list[str]] = None,
+    auto_label: bool = True,
+    spacing: int = DEFAULT_SPACING,
+    label_position: Literal["top", "bottom"] = "bottom",
+    label_font_size: int = DEFAULT_LABEL_FONT_SIZE,
+    bg_color: tuple[int, int, int] = DEFAULT_BG_COLOR,
+    label_color: tuple[int, int, int] = DEFAULT_LABEL_COLOR,
+    output_path: Optional[str | Path] = None,
+) -> Image.Image:
+    """Compose multiple images into a single labeled grid.
+
+    Args:
+        image_paths: Paths to input images.
+        layout: Grid layout as 'RxC' (e.g. '1x3', '2x2') or 'auto'.
+        labels: Explicit labels per panel. Overrides auto_label.
+        auto_label: If True and labels is None, generate (a), (b), (c), ...
+        spacing: Pixel spacing between panels and around edges.
+        label_position: Place labels 'top' or 'bottom' of each panel.
+        label_font_size: Font size for labels.
+        bg_color: Background color (RGB).
+        label_color: Label text color (RGB).
+        output_path: If provided, save the composite image to this path.
+
+    Returns:
+        The composite PIL Image.
+    """
+    if not image_paths:
+        raise ValueError("At least one image path is required")
+
+    # Load images
+    images: list[Image.Image] = []
+    for p in image_paths:
+        img = Image.open(p).convert("RGB")
+        images.append(img)
+
+    count = len(images)
+    rows, cols = _parse_layout(layout, count)
+
+    # Resolve labels
+    panel_labels: list[str] | None = None
+    if labels is not None:
+        if len(labels) != count:
+            raise ValueError(f"Expected {count} labels, got {len(labels)}")
+        panel_labels = labels
+    elif auto_label:
+        panel_labels = _auto_labels(count)
+
+    # Calculate label height
+    label_height = 0
+    font = _get_font(label_font_size)
+    if panel_labels:
+        label_height = label_font_size + 8  # text height + padding
+
+    # Resize panels: equal height per row, preserving aspect ratio
+    # First pass: determine target cell size
+    # Scale all images to have the same height, then figure out column widths
+    target_row_height = min(img.size[1] for img in images)
+    # Cap at a reasonable maximum
+    target_row_height = min(target_row_height, 1200)
+
+    scaled: list[Image.Image] = []
+    for img in images:
+        w, h = img.size
+        if h != target_row_height:
+            scale = target_row_height / h
+            new_w = max(1, round(w * scale))
+            img = img.resize((new_w, target_row_height), Image.LANCZOS)
+        scaled.append(img)
+
+    # Determine column widths: max width in each column
+    col_widths = [0] * cols
+    for i, img in enumerate(scaled):
+        col = i % cols
+        col_widths[col] = max(col_widths[col], img.size[0])
+
+    # Build the composite
+    cell_height = target_row_height + label_height
+    total_width = sum(col_widths) + spacing * (cols + 1)
+    total_height = cell_height * rows + spacing * (rows + 1)
+
+    composite = Image.new("RGB", (total_width, total_height), bg_color)
+    draw = ImageDraw.Draw(composite)
+
+    for i, img in enumerate(scaled):
+        row = i // cols
+        col = i % cols
+
+        # Calculate position: center image within its cell column
+        x_offset = spacing + sum(col_widths[:col]) + spacing * col
+        x_center_offset = (col_widths[col] - img.size[0]) // 2
+        y_offset = spacing + row * (cell_height + spacing)
+
+        if label_position == "top" and panel_labels:
+            img_y = y_offset + label_height
+        else:
+            img_y = y_offset
+
+        composite.paste(img, (x_offset + x_center_offset, img_y))
+
+        # Draw label
+        if panel_labels and i < len(panel_labels):
+            label_text = panel_labels[i]
+            bbox = draw.textbbox((0, 0), label_text, font=font)
+            text_w = bbox[2] - bbox[0]
+            label_x = x_offset + (col_widths[col] - text_w) // 2
+
+            if label_position == "top":
+                label_y = y_offset + 2
+            else:
+                label_y = img_y + img.size[1] + 2
+
+            draw.text((label_x, label_y), label_text, fill=label_color, font=font)
+
+    if output_path is not None:
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        composite.save(str(output_path))
+        logger.info("Composite image saved", path=str(output_path), panels=count, layout=layout)
+
+    return composite
+
+
+def parse_composite_config(manifest_data: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """Extract and validate the optional 'composite' section from a batch manifest.
+
+    Returns None if no composite section is present.
+    """
+    composite = manifest_data.get("composite")
+    if composite is None:
+        return None
+    if not isinstance(composite, dict):
+        raise ValueError("'composite' must be a mapping")
+
+    config: dict[str, Any] = {}
+
+    layout = composite.get("layout", "auto")
+    if not isinstance(layout, str):
+        raise ValueError("composite.layout must be a string (e.g. '2x3' or 'auto')")
+    config["layout"] = layout
+
+    labels = composite.get("labels", "auto")
+    if isinstance(labels, str) and labels.lower() == "auto":
+        config["auto_label"] = True
+        config["labels"] = None
+    elif isinstance(labels, list):
+        config["auto_label"] = False
+        config["labels"] = [str(item) for item in labels]
+    elif labels is None or labels is False:
+        config["auto_label"] = False
+        config["labels"] = None
+    else:
+        raise ValueError("composite.labels must be 'auto', a list of strings, or null")
+
+    spacing = composite.get("spacing", DEFAULT_SPACING)
+    if not isinstance(spacing, int) or spacing < 0:
+        raise ValueError("composite.spacing must be a non-negative integer")
+    config["spacing"] = spacing
+
+    label_position = composite.get("label_position", "bottom")
+    if label_position not in ("top", "bottom"):
+        raise ValueError("composite.label_position must be 'top' or 'bottom'")
+    config["label_position"] = label_position
+
+    config["output"] = composite.get("output")
+
+    return config

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -161,9 +161,7 @@ def test_parse_composite_config_none():
 
 
 def test_parse_composite_config_auto_labels():
-    config = parse_composite_config(
-        {"items": [], "composite": {"layout": "1x3", "labels": "auto"}}
-    )
+    config = parse_composite_config({"items": [], "composite": {"layout": "1x3", "labels": "auto"}})
     assert config is not None
     assert config["layout"] == "1x3"
     assert config["auto_label"] is True
@@ -171,18 +169,14 @@ def test_parse_composite_config_auto_labels():
 
 
 def test_parse_composite_config_explicit_labels():
-    config = parse_composite_config(
-        {"items": [], "composite": {"labels": ["(a)", "(b)"]}}
-    )
+    config = parse_composite_config({"items": [], "composite": {"labels": ["(a)", "(b)"]}})
     assert config is not None
     assert config["auto_label"] is False
     assert config["labels"] == ["(a)", "(b)"]
 
 
 def test_parse_composite_config_no_labels():
-    config = parse_composite_config(
-        {"items": [], "composite": {"labels": None}}
-    )
+    config = parse_composite_config({"items": [], "composite": {"labels": None}})
     assert config is not None
     assert config["auto_label"] is False
     assert config["labels"] is None
@@ -216,9 +210,7 @@ def test_parse_composite_config_invalid_label_position():
 
 
 def test_parse_composite_config_output():
-    config = parse_composite_config(
-        {"items": [], "composite": {"output": "figure2.png"}}
-    )
+    config = parse_composite_config({"items": [], "composite": {"output": "figure2.png"}})
     assert config["output"] == "figure2.png"
 
 

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,0 +1,294 @@
+"""Tests for paperbanana.core.composite — image composition and manifest parsing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from paperbanana.core.composite import (
+    _auto_labels,
+    _parse_layout,
+    compose_images,
+    parse_composite_config,
+)
+
+# ---------------------------------------------------------------------------
+# _auto_labels
+# ---------------------------------------------------------------------------
+
+
+def test_auto_labels():
+    assert _auto_labels(3) == ["(a)", "(b)", "(c)"]
+    assert _auto_labels(1) == ["(a)"]
+    assert _auto_labels(0) == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_layout
+# ---------------------------------------------------------------------------
+
+
+def test_parse_layout_explicit():
+    assert _parse_layout("1x3", 3) == (1, 3)
+    assert _parse_layout("2x2", 4) == (2, 2)
+    assert _parse_layout("3x1", 3) == (3, 1)
+
+
+def test_parse_layout_auto():
+    assert _parse_layout("auto", 2) == (1, 2)
+    assert _parse_layout("auto", 3) == (1, 3)
+    assert _parse_layout("auto", 4) == (2, 2)
+    assert _parse_layout("auto", 6) == (2, 3)
+    assert _parse_layout("auto", 9) == (3, 3)
+    assert _parse_layout("auto", 10) == (3, 4)
+
+
+def test_parse_layout_not_enough_cells():
+    with pytest.raises(ValueError, match="cannot fit"):
+        _parse_layout("1x2", 3)
+
+
+def test_parse_layout_invalid_format():
+    with pytest.raises(ValueError, match="RxC"):
+        _parse_layout("abc", 2)
+
+
+def test_parse_layout_zero():
+    with pytest.raises(ValueError, match=">= 1"):
+        _parse_layout("0x3", 1)
+
+
+# ---------------------------------------------------------------------------
+# compose_images
+# ---------------------------------------------------------------------------
+
+
+def _make_test_images(tmp_path: Path, count: int, size: tuple[int, int] = (200, 150)):
+    """Create simple test images and return their paths."""
+    paths = []
+    colors = [(255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 0), (255, 0, 255), (0, 255, 255)]
+    for i in range(count):
+        img = Image.new("RGB", size, colors[i % len(colors)])
+        p = tmp_path / f"panel_{i}.png"
+        img.save(str(p))
+        paths.append(str(p))
+    return paths
+
+
+def test_compose_images_basic(tmp_path: Path):
+    paths = _make_test_images(tmp_path, 3)
+    result = compose_images(paths, layout="1x3")
+    assert isinstance(result, Image.Image)
+    assert result.size[0] > 200  # wider than a single panel
+    assert result.size[1] > 0
+
+
+def test_compose_images_auto_layout(tmp_path: Path):
+    paths = _make_test_images(tmp_path, 4)
+    result = compose_images(paths, layout="auto")
+    assert isinstance(result, Image.Image)
+
+
+def test_compose_images_saves_to_file(tmp_path: Path):
+    paths = _make_test_images(tmp_path, 2)
+    out = tmp_path / "composite.png"
+    result = compose_images(paths, layout="1x2", output_path=out)
+    assert out.exists()
+    reopened = Image.open(out)
+    assert reopened.size == result.size
+
+
+def test_compose_images_custom_labels(tmp_path: Path):
+    paths = _make_test_images(tmp_path, 2)
+    result = compose_images(paths, labels=["Fig A", "Fig B"])
+    assert isinstance(result, Image.Image)
+
+
+def test_compose_images_no_labels(tmp_path: Path):
+    paths = _make_test_images(tmp_path, 2)
+    result = compose_images(paths, auto_label=False)
+    assert isinstance(result, Image.Image)
+
+
+def test_compose_images_label_count_mismatch(tmp_path: Path):
+    paths = _make_test_images(tmp_path, 2)
+    with pytest.raises(ValueError, match="Expected 2 labels"):
+        compose_images(paths, labels=["(a)"])
+
+
+def test_compose_images_empty_raises():
+    with pytest.raises(ValueError, match="At least one"):
+        compose_images([])
+
+
+def test_compose_images_top_labels(tmp_path: Path):
+    paths = _make_test_images(tmp_path, 3)
+    result = compose_images(paths, layout="1x3", label_position="top")
+    assert isinstance(result, Image.Image)
+
+
+def test_compose_images_different_sizes(tmp_path: Path):
+    """Panels of different sizes should be scaled to equal height."""
+    img1 = Image.new("RGB", (300, 200), (255, 0, 0))
+    img2 = Image.new("RGB", (100, 400), (0, 255, 0))
+    p1 = tmp_path / "wide.png"
+    p2 = tmp_path / "tall.png"
+    img1.save(str(p1))
+    img2.save(str(p2))
+    result = compose_images([str(p1), str(p2)], layout="1x2")
+    assert isinstance(result, Image.Image)
+
+
+def test_compose_images_2x2_grid(tmp_path: Path):
+    paths = _make_test_images(tmp_path, 4)
+    result = compose_images(paths, layout="2x2", spacing=10)
+    assert isinstance(result, Image.Image)
+    # 2x2 should be roughly square-ish
+    w, h = result.size
+    assert w > 0 and h > 0
+
+
+# ---------------------------------------------------------------------------
+# parse_composite_config
+# ---------------------------------------------------------------------------
+
+
+def test_parse_composite_config_none():
+    assert parse_composite_config({"items": []}) is None
+
+
+def test_parse_composite_config_auto_labels():
+    config = parse_composite_config(
+        {"items": [], "composite": {"layout": "1x3", "labels": "auto"}}
+    )
+    assert config is not None
+    assert config["layout"] == "1x3"
+    assert config["auto_label"] is True
+    assert config["labels"] is None
+
+
+def test_parse_composite_config_explicit_labels():
+    config = parse_composite_config(
+        {"items": [], "composite": {"labels": ["(a)", "(b)"]}}
+    )
+    assert config is not None
+    assert config["auto_label"] is False
+    assert config["labels"] == ["(a)", "(b)"]
+
+
+def test_parse_composite_config_no_labels():
+    config = parse_composite_config(
+        {"items": [], "composite": {"labels": None}}
+    )
+    assert config is not None
+    assert config["auto_label"] is False
+    assert config["labels"] is None
+
+
+def test_parse_composite_config_defaults():
+    config = parse_composite_config({"items": [], "composite": {}})
+    assert config is not None
+    assert config["layout"] == "auto"
+    assert config["auto_label"] is True
+    assert config["spacing"] == 20
+    assert config["label_position"] == "bottom"
+
+
+def test_parse_composite_config_custom_spacing():
+    config = parse_composite_config(
+        {"items": [], "composite": {"spacing": 40, "label_position": "top"}}
+    )
+    assert config["spacing"] == 40
+    assert config["label_position"] == "top"
+
+
+def test_parse_composite_config_invalid_spacing():
+    with pytest.raises(ValueError, match="spacing"):
+        parse_composite_config({"items": [], "composite": {"spacing": -5}})
+
+
+def test_parse_composite_config_invalid_label_position():
+    with pytest.raises(ValueError, match="label_position"):
+        parse_composite_config({"items": [], "composite": {"label_position": "left"}})
+
+
+def test_parse_composite_config_output():
+    config = parse_composite_config(
+        {"items": [], "composite": {"output": "figure2.png"}}
+    )
+    assert config["output"] == "figure2.png"
+
+
+# ---------------------------------------------------------------------------
+# load_batch_manifest_with_composite
+# ---------------------------------------------------------------------------
+
+
+def test_load_batch_manifest_with_composite_no_composite(tmp_path: Path):
+    from paperbanana.core.batch import load_batch_manifest_with_composite
+
+    txt = tmp_path / "a.txt"
+    txt.write_text("x", encoding="utf-8")
+    m = tmp_path / "m.yaml"
+    m.write_text(
+        f"""items:
+  - input: {txt.name}
+    caption: "Fig 1"
+""",
+        encoding="utf-8",
+    )
+    items, comp = load_batch_manifest_with_composite(m)
+    assert len(items) == 1
+    assert comp is None
+
+
+def test_load_batch_manifest_with_composite_has_composite(tmp_path: Path):
+    from paperbanana.core.batch import load_batch_manifest_with_composite
+
+    txt = tmp_path / "a.txt"
+    txt.write_text("x", encoding="utf-8")
+    m = tmp_path / "m.yaml"
+    m.write_text(
+        f"""composite:
+  layout: "1x2"
+  labels: auto
+  spacing: 30
+items:
+  - input: {txt.name}
+    caption: "Fig A"
+  - input: {txt.name}
+    caption: "Fig B"
+""",
+        encoding="utf-8",
+    )
+    items, comp = load_batch_manifest_with_composite(m)
+    assert len(items) == 2
+    assert comp is not None
+    assert comp["layout"] == "1x2"
+    assert comp["spacing"] == 30
+
+
+def test_load_batch_manifest_with_composite_json(tmp_path: Path):
+    from paperbanana.core.batch import load_batch_manifest_with_composite
+
+    txt = tmp_path / "a.txt"
+    txt.write_text("x", encoding="utf-8")
+    m = tmp_path / "m.json"
+    m.write_text(
+        json.dumps(
+            {
+                "composite": {"layout": "auto", "output": "out.png"},
+                "items": [
+                    {"input": txt.name, "caption": "c1"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    items, comp = load_batch_manifest_with_composite(m)
+    assert len(items) == 1
+    assert comp is not None
+    assert comp["output"] == "out.png"


### PR DESCRIPTION
## Summary

- Add `paperbanana composite` CLI command for ad-hoc composition of existing images into labeled multi-panel figures
- Add `composite` section support in batch manifests — auto-composites panels after batch completes
- New `paperbanana/core/composite.py` module with `compose_images()` using Pillow (already a dependency)
- 28 new tests covering composition logic, layout parsing, manifest integration

Closes #127

## Changes

**New files:**
- `paperbanana/core/composite.py` — Core composition: grid layout, auto `(a),(b),(c)` labels, panel scaling, configurable spacing/font/position
- `tests/test_composite.py` — 28 tests
- `examples/composite_batch_manifest.yaml` — Example manifest with `composite` section

**Modified files:**
- `paperbanana/core/batch.py` — Extract `_parse_manifest_raw()` helper; add `load_batch_manifest_with_composite()` to parse optional `composite` section
- `paperbanana/cli.py` — Add `paperbanana composite` subcommand; add auto-composite step at end of `batch` command
- `README.md` — Document `composite` CLI command and batch manifest `composite` section

## Usage

**Standalone (no API calls):**
```bash
paperbanana composite panel_a.png panel_b.png panel_c.png \
  --layout 1x3 --output figure2.png
```

**Batch manifest with auto-composite:**
```yaml
composite:
  layout: "1x2"
  labels: auto
  spacing: 20
  output: "composite.png"

items:
  - input: method_encoder.txt
    caption: "Encoder architecture"
    id: panel_a
  - input: method_decoder.txt
    caption: "Decoder architecture"
    id: panel_b
```

## Test plan

- [x] `ruff check` passes (all files)
- [x] `pytest tests/test_composite.py` — 28/28 pass
- [x] `pytest tests/test_batch.py` — 15/15 pass (existing tests unbroken)
- [x] `pytest tests/test_cli.py` — 16/16 pass (existing tests unbroken)
- [x] Batch manifests without `composite` section work identically (backward compatible)