### PR TITLE
feat: add system health-check command (`paperbanana doctor`) (#138)

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -2466,5 +2466,17 @@ def studio(
     )
 
 
+@app.command()
+def doctor(
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON (for CI pipelines)."
+    ),
+) -> None:
+    """Check system health: optional dependencies, API keys, and reference data."""
+    from paperbanana.doctor import run_doctor
+
+    raise typer.Exit(run_doctor(output_json=json_output))
+
+
 if __name__ == "__main__":
     app()

--- a/paperbanana/doctor.py
+++ b/paperbanana/doctor.py
@@ -1,0 +1,218 @@
+"""Health-check logic for ``paperbanana doctor``."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console
+from rich.markup import escape as markup_escape
+from rich.table import Table
+
+console = Console()
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    label: str
+    ok: bool
+    detail: str
+    hint: Optional[str] = field(default=None)
+    critical: bool = field(default=False)
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+def check_python() -> CheckResult:
+    v = sys.version_info
+    return CheckResult("Python", True, f"{v.major}.{v.minor}.{v.micro}", critical=True)
+
+
+def check_paperbanana() -> CheckResult:
+    try:
+        v = pkg_version("paperbanana")
+        return CheckResult("paperbanana", True, v, critical=True)
+    except PackageNotFoundError:
+        return CheckResult("paperbanana", False, "not found", critical=True)
+
+
+def check_optional_package(label: str, package: str, extra: str) -> CheckResult:
+    try:
+        v = pkg_version(package)
+        return CheckResult(label, True, v)
+    except PackageNotFoundError:
+        hint = f"pip install 'paperbanana[{extra}]'"
+        return CheckResult(label, False, "not installed", hint)
+
+
+def check_env_key(env_var: str) -> CheckResult:
+    ok = bool(os.environ.get(env_var, "").strip())
+    return CheckResult(env_var, ok, "set" if ok else "not set")
+
+
+def check_aws_credentials() -> CheckResult:
+    has_env = bool(os.environ.get("AWS_ACCESS_KEY_ID", "").strip())
+    has_profile = bool(os.environ.get("AWS_PROFILE", "").strip())
+    has_file = Path.home().joinpath(".aws", "credentials").exists()
+    ok = has_env or has_profile or has_file
+    detail = "configured" if ok else "not configured"
+    hint = None if ok else "see: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html"
+    return CheckResult("AWS credentials", ok, detail, hint)
+
+
+def check_builtin_refs() -> CheckResult:
+    # Built-in reference set is always at this relative path inside the package.
+    # Do NOT use resolve_reference_path — that may return the expanded cache.
+    ref_dir = Path("data", "reference_sets")
+    index = ref_dir / "index.json"
+    if not index.exists():
+        return CheckResult("Built-in set", False, "index missing", critical=True)
+    try:
+        data = json.loads(index.read_text(encoding="utf-8"))
+        count = len(data.get("examples", []))
+        return CheckResult("Built-in set", True, f"{count} diagrams", critical=True)
+    except Exception:
+        return CheckResult("Built-in set", False, "unreadable", critical=True)
+
+
+def check_expanded_refs() -> CheckResult:
+    from paperbanana.data.manager import DatasetManager
+
+    try:
+        dm = DatasetManager()
+    except Exception:
+        return CheckResult(
+            "Expanded set", False, "unable to check", "paperbanana data download"
+        )
+    if not dm.is_downloaded():
+        return CheckResult(
+            "Expanded set", False, "not downloaded", "paperbanana data download"
+        )
+    info = dm.get_info() or {}
+    count = info.get("example_count") or dm.get_example_count()
+    datasets = info.get("datasets", [])
+    label = f"{count} diagrams ({', '.join(datasets)})" if datasets else f"{count} diagrams"
+    return CheckResult("Expanded set", True, label)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _status(ok: bool) -> str:
+    return "[green]\u2713[/green]" if ok else "[red]\u2717[/red]"
+
+
+def _render_section(title: str, results: list[CheckResult]) -> None:
+    console.print(f"\n  [bold]{title}[/bold]")
+    t = Table.grid(padding=(0, 2))
+    t.add_column(min_width=24)
+    t.add_column(min_width=18)
+    t.add_column(width=2)
+    t.add_column()
+    for r in results:
+        hint = f"  [dim]{markup_escape(r.hint)}[/dim]" if r.hint and not r.ok else ""
+        t.add_row(f"  {r.label}", r.detail, _status(r.ok), hint)
+    console.print(t)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+# google-genai is a *core* dependency, NOT optional — don't list it here.
+_OPTIONAL_PACKAGES = [
+    ("PDF (pymupdf)", "pymupdf", "pdf"),
+    ("Studio (gradio)", "gradio", "studio"),
+    ("OpenAI", "openai", "openai"),
+    ("Anthropic", "anthropic", "anthropic"),
+    ("Bedrock (boto3)", "boto3", "bedrock"),
+    ("MCP (fastmcp)", "fastmcp", "mcp"),
+]
+
+_API_KEYS = [
+    "GOOGLE_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENROUTER_API_KEY",
+]
+
+
+def run_doctor(output_json: bool = False) -> int:
+    """Run all health checks.
+
+    Returns 0 if all *critical* checks pass, 1 otherwise.
+    Optional features and API keys that are missing do NOT cause a failure
+    exit code — they are informational.
+    """
+    from paperbanana import __version__
+
+    runtime = [check_python(), check_paperbanana()]
+    optional = [check_optional_package(*args) for args in _OPTIONAL_PACKAGES]
+    api_keys = [check_env_key(k) for k in _API_KEYS] + [check_aws_credentials()]
+    refs = [check_builtin_refs(), check_expanded_refs()]
+
+    all_results = runtime + optional + api_keys + refs
+
+    # --- JSON output for CI ---
+    if output_json:
+        payload = {
+            "version": __version__,
+            "ok": not any(r.critical and not r.ok for r in all_results),
+            "checks": [
+                {
+                    "label": r.label,
+                    "ok": r.ok,
+                    "detail": r.detail,
+                    "hint": r.hint,
+                    "critical": r.critical,
+                }
+                for r in all_results
+            ],
+        }
+        console.print_json(json.dumps(payload))
+        return 0 if payload["ok"] else 1
+
+    # --- Rich table output ---
+    console.print(f"\n[bold]PaperBanana v{__version__}[/bold] \u2014 System Check")
+
+    _render_section("Runtime", runtime)
+    _render_section("Optional features", optional)
+    _render_section("API keys", api_keys)
+    _render_section("Reference data", refs)
+
+    failures = [r for r in all_results if not r.ok]
+    critical_failures = [r for r in all_results if r.critical and not r.ok]
+
+    console.print()
+    if not failures:
+        console.print("  [green]All checks passed.[/green]\n")
+        return 0
+
+    if critical_failures:
+        console.print(
+            f"  [red]{len(critical_failures)} critical issue(s) found.[/red]"
+        )
+    info_failures = [r for r in failures if not r.critical]
+    if info_failures:
+        console.print(
+            f"  [yellow]{len(info_failures)} optional feature(s) not configured.[/yellow]"
+        )
+    console.print()
+
+    # Exit 1 only when critical checks fail.
+    return 1 if critical_failures else 0

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,319 @@
+"""Tests for paperbanana doctor health-check command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from paperbanana.cli import app
+from paperbanana.doctor import (
+    CheckResult,
+    check_aws_credentials,
+    check_builtin_refs,
+    check_env_key,
+    check_expanded_refs,
+    check_optional_package,
+    check_paperbanana,
+    check_python,
+    run_doctor,
+)
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# CheckResult dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_check_result_ok_defaults():
+    r = CheckResult("Test", True, "1.0")
+    assert r.ok
+    assert r.hint is None
+    assert r.critical is False
+
+
+def test_check_result_failed_carries_hint():
+    r = CheckResult("Test", False, "not installed", "pip install foo")
+    assert not r.ok
+    assert r.hint == "pip install foo"
+
+
+def test_check_result_critical_flag():
+    r = CheckResult("Runtime", True, "ok", critical=True)
+    assert r.critical
+
+
+# ---------------------------------------------------------------------------
+# Runtime checks
+# ---------------------------------------------------------------------------
+
+
+def test_check_python_always_passes():
+    r = check_python()
+    assert r.ok
+    assert r.critical
+    import sys
+
+    assert str(sys.version_info.major) in r.detail
+
+
+def test_check_paperbanana_passes_when_installed():
+    r = check_paperbanana()
+    assert r.ok
+    assert r.critical
+    assert r.detail  # version string is non-empty
+
+
+def test_check_paperbanana_fails_when_missing():
+    from importlib.metadata import PackageNotFoundError
+
+    with patch(
+        "paperbanana.doctor.pkg_version", side_effect=PackageNotFoundError("paperbanana")
+    ):
+        r = check_paperbanana()
+    assert not r.ok
+    assert r.critical
+
+
+# ---------------------------------------------------------------------------
+# Optional package checks
+# ---------------------------------------------------------------------------
+
+
+def test_check_optional_package_installed():
+    # pydantic is always installed as a core dep
+    r = check_optional_package("Pydantic", "pydantic", "core")
+    assert r.ok
+    assert r.hint is None
+
+
+def test_check_optional_package_missing():
+    from importlib.metadata import PackageNotFoundError
+
+    with patch(
+        "paperbanana.doctor.pkg_version", side_effect=PackageNotFoundError("fakepkg")
+    ):
+        r = check_optional_package("FakePkg", "fakepkg", "fake")
+    assert not r.ok
+    assert r.detail == "not installed"
+    assert "paperbanana[fake]" in r.hint
+    assert not r.critical  # optional packages are not critical
+
+
+# ---------------------------------------------------------------------------
+# API key checks
+# ---------------------------------------------------------------------------
+
+
+def test_check_env_key_set(monkeypatch):
+    monkeypatch.setenv("TEST_KEY_XYZ", "abc123")
+    r = check_env_key("TEST_KEY_XYZ")
+    assert r.ok
+    assert r.detail == "set"
+
+
+def test_check_env_key_missing(monkeypatch):
+    monkeypatch.delenv("TEST_KEY_XYZ", raising=False)
+    r = check_env_key("TEST_KEY_XYZ")
+    assert not r.ok
+    assert r.detail == "not set"
+
+
+def test_check_env_key_empty_string(monkeypatch):
+    monkeypatch.setenv("TEST_KEY_XYZ", "   ")
+    r = check_env_key("TEST_KEY_XYZ")
+    assert not r.ok
+
+
+# ---------------------------------------------------------------------------
+# AWS credentials check
+# ---------------------------------------------------------------------------
+
+
+def test_check_aws_credentials_via_env(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    with patch.object(Path, "exists", return_value=False):
+        r = check_aws_credentials()
+    assert r.ok
+    assert r.detail == "configured"
+
+
+def test_check_aws_credentials_via_profile(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.setenv("AWS_PROFILE", "default")
+    with patch.object(Path, "exists", return_value=False):
+        r = check_aws_credentials()
+    assert r.ok
+
+
+def test_check_aws_credentials_via_file(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    with patch.object(Path, "exists", return_value=True):
+        r = check_aws_credentials()
+    assert r.ok
+
+
+def test_check_aws_credentials_missing(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    with patch.object(Path, "exists", return_value=False):
+        r = check_aws_credentials()
+    assert not r.ok
+    assert r.hint is not None
+
+
+# ---------------------------------------------------------------------------
+# Reference data checks
+# ---------------------------------------------------------------------------
+
+
+def test_check_builtin_refs_with_valid_index(tmp_path, monkeypatch):
+    index = tmp_path / "data" / "reference_sets" / "index.json"
+    index.parent.mkdir(parents=True)
+    index.write_text(json.dumps({"examples": [{"id": "a"}, {"id": "b"}]}), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    r = check_builtin_refs()
+    assert r.ok
+    assert r.critical
+    assert "2 diagrams" in r.detail
+
+
+def test_check_builtin_refs_missing_index(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    r = check_builtin_refs()
+    assert not r.ok
+    assert r.critical
+
+
+def test_check_expanded_refs_not_downloaded():
+    from paperbanana.data.manager import DatasetManager
+
+    with patch.object(DatasetManager, "is_downloaded", return_value=False):
+        r = check_expanded_refs()
+    assert not r.ok
+    assert "not downloaded" in r.detail
+    assert "paperbanana data download" in r.hint
+
+
+def test_check_expanded_refs_downloaded():
+    from paperbanana.data.manager import DatasetManager
+
+    with (
+        patch.object(DatasetManager, "is_downloaded", return_value=True),
+        patch.object(
+            DatasetManager,
+            "get_info",
+            return_value={"example_count": 42, "datasets": ["curated"]},
+        ),
+    ):
+        r = check_expanded_refs()
+    assert r.ok
+    assert "42 diagrams" in r.detail
+    assert "curated" in r.detail
+
+
+# ---------------------------------------------------------------------------
+# run_doctor orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_run_doctor_returns_int():
+    result = run_doctor()
+    assert isinstance(result, int)
+    assert result in (0, 1)
+
+
+def _patch_all_checks(**overrides):
+    """Return a context manager that patches all check functions with ok results."""
+    ok = CheckResult("x", True, "ok")
+    defaults = {
+        "check_python": ok,
+        "check_paperbanana": ok,
+        "check_optional_package": ok,
+        "check_env_key": ok,
+        "check_aws_credentials": ok,
+        "check_builtin_refs": CheckResult("Built-in set", True, "13 diagrams", critical=True),
+        "check_expanded_refs": ok,
+    }
+    defaults.update(overrides)
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    for name, rv in defaults.items():
+        stack.enter_context(patch(f"paperbanana.doctor.{name}", return_value=rv))
+    return stack
+
+
+def test_run_doctor_exit_0_when_all_pass():
+    with _patch_all_checks():
+        assert run_doctor() == 0
+
+
+def test_run_doctor_exit_1_when_critical_fails():
+    fail = CheckResult("paperbanana", False, "not found", critical=True)
+    with _patch_all_checks(check_paperbanana=fail):
+        assert run_doctor() == 1
+
+
+def test_run_doctor_exit_0_when_only_optional_fails():
+    """Missing optional packages should NOT cause exit code 1."""
+    fail = CheckResult("OpenAI", False, "not installed", "pip install 'paperbanana[openai]'")
+    with _patch_all_checks(check_optional_package=fail):
+        assert run_doctor() == 0
+
+
+def test_run_doctor_json_output():
+    with _patch_all_checks():
+        result = run_doctor(output_json=True)
+    assert result == 0
+
+
+def test_run_doctor_json_output_with_critical_failure():
+    fail = CheckResult("paperbanana", False, "not found", critical=True)
+    with _patch_all_checks(check_paperbanana=fail):
+        result = run_doctor(output_json=True)
+    assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_command_runs():
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code in (0, 1)
+    assert "PaperBanana" in result.output
+    assert "System Check" in result.output
+
+
+def test_doctor_command_shows_all_sections():
+    result = runner.invoke(app, ["doctor"])
+    assert "Runtime" in result.output
+    assert "Optional features" in result.output
+    assert "API keys" in result.output
+    assert "Reference data" in result.output
+
+
+def test_doctor_command_json_flag():
+    result = runner.invoke(app, ["doctor", "--json"])
+    assert result.exit_code in (0, 1)
+    # Output should be valid JSON
+    output = result.output.strip()
+    parsed = json.loads(output)
+    assert "version" in parsed
+    assert "ok" in parsed
+    assert "checks" in parsed
+
+
+def test_doctor_command_exit_1_when_critical_fails():
+    fail = CheckResult("paperbanana", False, "not found", critical=True)
+    with patch("paperbanana.doctor.check_paperbanana", return_value=fail):
+        result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1


### PR DESCRIPTION
# feat: add system health-check command (`paperbanana doctor`) (#138)

## Problem
New users had no single command to diagnose why PaperBanana wasn't
working. They had to attempt a full run, hit a mid-pipeline error,
find the install hint, fix it, and repeat — sometimes multiple times
for different missing pieces.

## Changes

### paperbanana/doctor.py (new)
CheckResult dataclass with critical/optional severity levels.
Individual check functions for runtime, optional packages, API keys,
AWS credentials (env vars, named profile, ~/.aws/credentials), and
reference data (built-in and expanded sets).
run_doctor() orchestrates all checks, renders Rich table, returns
exit code 1 only for critical failures (runtime, built-in refs);
missing optional features exit 0 with yellow informational summary.
--json flag emits machine-readable output for CI pipelines.

### paperbanana/cli.py
Thin doctor command with --json flag, delegates to run_doctor()

### tests/test_doctor.py (new, 29 tests)
Unit tests for every check function with mocked dependencies.
Critical vs optional exit code distinction tests.
JSON output validation.
CLI integration tests for sections, version output, and exit codes.

## Behavior after this change

$ paperbanana doctor


Shows structured status report across runtime, optional features,
API keys, and reference data. Exit 0 when basics work, exit 1 when
critical checks fail.

$ paperbanana doctor --json


Emits valid JSON with version, ok boolean, and per-check details.

Closes #138