### PR TITLE
feat: add graceful agent failure handling and retry in generation pipeline (#135)

### DIFF
--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 import structlog
+from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential
 
 from paperbanana.agents.critic import CriticAgent
 from paperbanana.agents.optimizer import InputOptimizerAgent
@@ -19,6 +20,7 @@ from paperbanana.core.config import Settings
 from paperbanana.core.cost_tracker import CostTracker
 from paperbanana.core.prompt_recorder import PromptRecorder
 from paperbanana.core.types import (
+    CritiqueResult,
     DiagramType,
     GenerationInput,
     GenerationOutput,
@@ -62,6 +64,29 @@ def _emit_progress(
         callback(event)
     except Exception:
         logger.warning("Progress callback failed", stage=event.stage, exc_info=True)
+
+
+async def _call_with_retry(label, fn, *args, max_attempts=3, **kwargs):
+    """Retry an async agent call with exponential backoff.
+
+    Complements provider-level retries by catching agent-level failures
+    (e.g. response parsing errors, unexpected formats) that survive
+    the lower-level HTTP retry layer.
+    """
+    async for attempt in AsyncRetrying(
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_exponential(min=2, max=30),
+        reraise=True,
+    ):
+        with attempt:
+            attempt_num = attempt.retry_state.attempt_number
+            if attempt_num > 1:
+                logger.warning(
+                    f"Retrying {label}",
+                    attempt=attempt_num,
+                    max_attempts=max_attempts,
+                )
+            return await fn(*args, **kwargs)
 
 
 def _apply_ssl_skip():
@@ -340,48 +365,64 @@ class PaperBananaPipeline:
             )
             self._emit_progress("phase0_optimize_started")
             optimize_start = time.perf_counter()
-            optimized = await self.optimizer.run(
-                source_context=input.source_context,
-                caption=input.communicative_intent,
-                diagram_type=input.diagram_type,
-            )
-            optimize_seconds = time.perf_counter() - optimize_start
-            _emit_progress(
-                progress_callback,
-                PipelineProgressEvent(
-                    stage=PipelineProgressStage.OPTIMIZER_END,
-                    message="Optimizer done",
-                    seconds=optimize_seconds,
-                ),
-            )
-            logger.info(
-                "[Optimizer] done",
-                seconds=round(optimize_seconds, 1),
-            )
-            self._emit_progress(
-                "phase0_optimize_completed",
-                seconds=round(optimize_seconds, 1),
-            )
-
-            # Save originals and apply optimized versions
-            if self.settings.save_iterations:
-                save_json(
-                    {
-                        "original_context": input.source_context,
-                        "original_caption": input.communicative_intent,
-                        "optimized_context": optimized["optimized_context"],
-                        "optimized_caption": optimized["optimized_caption"],
-                    },
-                    self._run_dir / "optimization.json",
+            try:
+                optimized = await self.optimizer.run(
+                    source_context=input.source_context,
+                    caption=input.communicative_intent,
+                    diagram_type=input.diagram_type,
+                )
+                optimize_seconds = time.perf_counter() - optimize_start
+                _emit_progress(
+                    progress_callback,
+                    PipelineProgressEvent(
+                        stage=PipelineProgressStage.OPTIMIZER_END,
+                        message="Optimizer done",
+                        seconds=optimize_seconds,
+                    ),
+                )
+                logger.info(
+                    "[Optimizer] done",
+                    seconds=round(optimize_seconds, 1),
+                )
+                self._emit_progress(
+                    "phase0_optimize_completed",
+                    seconds=round(optimize_seconds, 1),
                 )
 
-            input = GenerationInput(
-                source_context=optimized["optimized_context"],
-                communicative_intent=optimized["optimized_caption"],
-                diagram_type=input.diagram_type,
-                raw_data=input.raw_data,
-                aspect_ratio=input.aspect_ratio,
-            )
+                # Save originals and apply optimized versions
+                if self.settings.save_iterations:
+                    save_json(
+                        {
+                            "original_context": input.source_context,
+                            "original_caption": input.communicative_intent,
+                            "optimized_context": optimized["optimized_context"],
+                            "optimized_caption": optimized["optimized_caption"],
+                        },
+                        self._run_dir / "optimization.json",
+                    )
+
+                input = GenerationInput(
+                    source_context=optimized["optimized_context"],
+                    communicative_intent=optimized["optimized_caption"],
+                    diagram_type=input.diagram_type,
+                    raw_data=input.raw_data,
+                    aspect_ratio=input.aspect_ratio,
+                )
+            except Exception:
+                optimize_seconds = time.perf_counter() - optimize_start
+                logger.warning(
+                    "Optimizer failed, continuing with original input",
+                    seconds=round(optimize_seconds, 1),
+                    exc_info=True,
+                )
+                _emit_progress(
+                    progress_callback,
+                    PipelineProgressEvent(
+                        stage=PipelineProgressStage.OPTIMIZER_END,
+                        message="Optimizer failed, using original input",
+                        seconds=optimize_seconds,
+                    ),
+                )
 
         # ── Phase 1: Linear Planning ─────────────────────────────────
 
@@ -407,7 +448,9 @@ class PaperBananaPipeline:
         if retrieval_mode == "external_only":
             examples = candidates[: self.settings.num_retrieval_examples]
         else:
-            examples = await self.retriever.run(
+            examples = await _call_with_retry(
+                "retriever",
+                self.retriever.run,
                 source_context=input.source_context,
                 caption=input.communicative_intent,
                 candidates=candidates,
@@ -450,7 +493,9 @@ class PaperBananaPipeline:
         )
         self._emit_progress("phase1_planning_started")
         planning_start = time.perf_counter()
-        description, planner_ratio = await self.planner.run(
+        description, planner_ratio = await _call_with_retry(
+            "planner",
+            self.planner.run,
             source_context=input.source_context,
             caption=input.communicative_intent,
             examples=examples,
@@ -486,13 +531,22 @@ class PaperBananaPipeline:
         )
         self._emit_progress("phase1_styling_started")
         styling_start = time.perf_counter()
-        optimized_description = await self.stylist.run(
-            description=description,
-            guidelines=guidelines,
-            source_context=input.source_context,
-            caption=input.communicative_intent,
-            diagram_type=input.diagram_type,
-        )
+        try:
+            optimized_description = await _call_with_retry(
+                "stylist",
+                self.stylist.run,
+                description=description,
+                guidelines=guidelines,
+                source_context=input.source_context,
+                caption=input.communicative_intent,
+                diagram_type=input.diagram_type,
+            )
+        except Exception:
+            logger.warning(
+                "Stylist failed after retries, falling back to planner output",
+                exc_info=True,
+            )
+            optimized_description = description
         styling_seconds = time.perf_counter() - styling_start
         _emit_progress(
             progress_callback,
@@ -581,7 +635,9 @@ class PaperBananaPipeline:
                 ),
             )
             visualizer_start = time.perf_counter()
-            image_path = await self.visualizer.run(
+            image_path = await _call_with_retry(
+                "visualizer",
+                self.visualizer.run,
                 description=current_description,
                 diagram_type=input.diagram_type,
                 raw_data=input.raw_data,
@@ -621,13 +677,23 @@ class PaperBananaPipeline:
                 ),
             )
             critic_start = time.perf_counter()
-            critique = await self.critic.run(
-                image_path=image_path,
-                description=current_description,
-                source_context=input.source_context,
-                caption=input.communicative_intent,
-                diagram_type=input.diagram_type,
-            )
+            try:
+                critique = await _call_with_retry(
+                    "critic",
+                    self.critic.run,
+                    image_path=image_path,
+                    description=current_description,
+                    source_context=input.source_context,
+                    caption=input.communicative_intent,
+                    diagram_type=input.diagram_type,
+                )
+            except Exception:
+                logger.warning(
+                    "Critic failed after retries, accepting current image",
+                    iteration=iter_index,
+                    exc_info=True,
+                )
+                critique = CritiqueResult()
             critic_seconds = time.perf_counter() - critic_start
             _emit_progress(
                 progress_callback,
@@ -882,7 +948,9 @@ class PaperBananaPipeline:
                 ),
             )
             visualizer_start = time.perf_counter()
-            image_path = await self.visualizer.run(
+            image_path = await _call_with_retry(
+                "visualizer",
+                self.visualizer.run,
                 description=current_description,
                 diagram_type=resume_state.diagram_type,
                 raw_data=resume_state.raw_data,
@@ -923,14 +991,24 @@ class PaperBananaPipeline:
                 ),
             )
             critic_start = time.perf_counter()
-            critique = await self.critic.run(
-                image_path=image_path,
-                description=current_description,
-                source_context=resume_state.source_context,
-                caption=resume_state.communicative_intent,
-                diagram_type=resume_state.diagram_type,
-                user_feedback=user_feedback,
-            )
+            try:
+                critique = await _call_with_retry(
+                    "critic",
+                    self.critic.run,
+                    image_path=image_path,
+                    description=current_description,
+                    source_context=resume_state.source_context,
+                    caption=resume_state.communicative_intent,
+                    diagram_type=resume_state.diagram_type,
+                    user_feedback=user_feedback,
+                )
+            except Exception:
+                logger.warning(
+                    "Critic failed after retries, accepting current image",
+                    iteration=iter_num,
+                    exc_info=True,
+                )
+                critique = CritiqueResult()
             critic_seconds = time.perf_counter() - critic_start
             _emit_progress(
                 progress_callback,

--- a/tests/test_pipeline/test_agent_failures.py
+++ b/tests/test_pipeline/test_agent_failures.py
@@ -1,0 +1,256 @@
+"""Tests for graceful agent failure handling and retry in the pipeline (issue #135)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("PIL", reason="PIL/Pillow required for pipeline image mock")
+from pathlib import Path
+
+from PIL import Image
+
+from paperbanana.core import pipeline as pipeline_mod
+from paperbanana.core.config import Settings
+from paperbanana.core.pipeline import PaperBananaPipeline
+from paperbanana.core.types import (
+    CritiqueResult,
+    DiagramType,
+    GenerationInput,
+)
+
+# ── Shared mocks ─────────────────────────────────────────────────
+
+
+class _MockVLM:
+    name = "mock-vlm"
+    model_name = "mock-model"
+
+    def __init__(self, responses: list[str]):
+        self._responses = responses
+        self._idx = 0
+
+    async def generate(self, *args, **kwargs):
+        idx = min(self._idx, len(self._responses) - 1)
+        self._idx += 1
+        return self._responses[idx]
+
+
+class _MockImageGen:
+    name = "mock-image-gen"
+    model_name = "mock-image-model"
+
+    async def generate(self, *args, **kwargs):
+        return Image.new("RGB", (128, 128), color=(255, 255, 255))
+
+
+def _make_settings(tmp_path, **overrides):
+    defaults = dict(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "empty_refs"),
+        refinement_iterations=1,
+        save_iterations=False,
+    )
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+def _default_input():
+    return GenerationInput(
+        source_context="Test methodology text",
+        communicative_intent="Test caption",
+        diagram_type=DiagramType.METHODOLOGY,
+    )
+
+
+# ── Fixture: fast retries (no waiting) ───────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _fast_retry(monkeypatch):
+    """Replace _call_with_retry with a zero-wait version for fast tests."""
+
+    async def _fast_call_with_retry(label, fn, *args, max_attempts=3, **kwargs):
+        last_exc = None
+        for attempt_num in range(1, max_attempts + 1):
+            try:
+                return await fn(*args, **kwargs)
+            except Exception as exc:
+                last_exc = exc
+                if attempt_num >= max_attempts:
+                    raise
+        raise last_exc  # unreachable but satisfies type checker
+
+    monkeypatch.setattr(pipeline_mod, "_call_with_retry", _fast_call_with_retry)
+
+
+# ── Test: Optimizer failure falls back to original input ─────────
+
+
+@pytest.mark.asyncio
+async def test_optimizer_failure_falls_back_to_original_input(tmp_path):
+    """When optimizer raises, pipeline continues with the original input."""
+    settings = _make_settings(tmp_path, optimize_inputs=True)
+    # VLM responses: planner, stylist, critic (optimizer is patched to fail)
+    vlm = _MockVLM(
+        responses=[
+            "Plan description",
+            "Styled description",
+            json.dumps({"critic_suggestions": [], "revised_description": None}),
+        ]
+    )
+    image_gen = _MockImageGen()
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=image_gen)
+
+    # Patch the optimizer to raise
+    pipeline.optimizer.run = AsyncMock(side_effect=RuntimeError("API timeout"))
+
+    result = await pipeline.generate(_default_input())
+
+    assert result.image_path
+    assert Path(result.image_path).exists()
+    # Pipeline completed successfully despite optimizer failure
+    assert len(result.iterations) >= 1
+
+
+# ── Test: Stylist failure falls back to planner output ───────────
+
+
+@pytest.mark.asyncio
+async def test_stylist_failure_falls_back_to_planner_output(tmp_path):
+    """When stylist fails after retries, pipeline uses the planner's raw output."""
+    settings = _make_settings(tmp_path)
+    # VLM responses: planner, critic (stylist is patched to fail)
+    vlm = _MockVLM(
+        responses=[
+            "Planner raw description",
+            json.dumps({"critic_suggestions": [], "revised_description": None}),
+        ]
+    )
+    image_gen = _MockImageGen()
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=image_gen)
+
+    pipeline.stylist.run = AsyncMock(side_effect=RuntimeError("Stylist API error"))
+
+    result = await pipeline.generate(_default_input())
+
+    assert result.image_path
+    assert Path(result.image_path).exists()
+    # Description should contain the planner output (stylist was bypassed)
+    assert "Planner raw description" in result.description
+
+
+# ── Test: Critic failure accepts current image ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_critic_failure_accepts_current_image(tmp_path):
+    """When critic fails, pipeline accepts the current image and stops iterating."""
+    settings = _make_settings(tmp_path, refinement_iterations=2)
+    # VLM responses: planner, stylist (critic is patched to fail)
+    vlm = _MockVLM(
+        responses=[
+            "Plan description",
+            "Styled description",
+        ]
+    )
+    image_gen = _MockImageGen()
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=image_gen)
+
+    pipeline.critic.run = AsyncMock(side_effect=RuntimeError("Critic API error"))
+
+    result = await pipeline.generate(_default_input())
+
+    assert result.image_path
+    assert Path(result.image_path).exists()
+    # Should have one iteration (critic failed but image was accepted)
+    assert len(result.iterations) == 1
+    # The fallback CritiqueResult should have no suggestions
+    assert not result.iterations[0].critique.needs_revision
+
+
+# ── Test: Retry succeeds after transient failures ────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_retries_on_transient_failure(tmp_path):
+    """A required agent that fails transiently succeeds after retry."""
+    settings = _make_settings(tmp_path)
+    vlm = _MockVLM(responses=[])
+    image_gen = _MockImageGen()
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=image_gen)
+
+    # Planner fails twice, succeeds on third attempt
+    call_count = 0
+
+    async def flaky_planner(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise RuntimeError("transient error")
+        return ("Planned description", None)
+
+    pipeline.planner.run = flaky_planner
+    pipeline.stylist.run = AsyncMock(return_value="Styled description")
+    pipeline.critic.run = AsyncMock(
+        return_value=CritiqueResult(critic_suggestions=[], revised_description=None)
+    )
+
+    result = await pipeline.generate(_default_input())
+
+    assert result.image_path
+    assert call_count == 3  # failed twice, succeeded on third
+
+
+# ── Test: Required phase raises after all retries exhausted ──────
+
+
+@pytest.mark.asyncio
+async def test_required_agent_raises_after_retries_exhausted(tmp_path):
+    """A required agent that always fails re-raises after all retry attempts."""
+    settings = _make_settings(tmp_path)
+    vlm = _MockVLM(responses=[])
+    image_gen = _MockImageGen()
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=image_gen)
+
+    pipeline.planner.run = AsyncMock(side_effect=RuntimeError("persistent error"))
+
+    with pytest.raises(RuntimeError, match="persistent error"):
+        await pipeline.generate(_default_input())
+
+
+# ── Test: Visualizer retries on transient failure ────────────────
+
+
+@pytest.mark.asyncio
+async def test_visualizer_retries_on_transient_failure(tmp_path):
+    """Visualizer succeeds after a transient failure is retried."""
+    settings = _make_settings(tmp_path)
+    vlm = _MockVLM(
+        responses=[
+            "Plan description",
+            "Styled description",
+            json.dumps({"critic_suggestions": [], "revised_description": None}),
+        ]
+    )
+    image_gen = _MockImageGen()
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=image_gen)
+
+    call_count = 0
+    original_visualizer_run = pipeline.visualizer.run
+
+    async def flaky_visualizer(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 2:
+            raise RuntimeError("image gen transient error")
+        return await original_visualizer_run(**kwargs)
+
+    pipeline.visualizer.run = flaky_visualizer
+
+    result = await pipeline.generate(_default_input())
+
+    assert result.image_path
+    assert call_count == 2  # failed once, succeeded on second


### PR DESCRIPTION
## Summary

Implements graceful agent failure handling and retry for the generation pipeline, addressing all four problems identified in #135:

- **Optimizer (optional phase):** Wrapped in `try/except` so failures log a warning and the pipeline continues with the original input instead of crashing
- **Retriever, Planner, Visualizer (required phases):** Calls now go through a `_call_with_retry` helper using `tenacity` (3 attempts, exponential backoff 2–30s), retrying transient errors at the agent level — complementing existing provider-level HTTP retries
- **Stylist (required phase with fallback):** Retried via `_call_with_retry`; if all retries fail, falls back to the Planner's raw output with a warning instead of discarding it
- **Critic (conditional skip):** Retried via `_call_with_retry`; on failure, creates an empty `CritiqueResult` (no suggestions → "accept current image") and exits the iteration loop gracefully instead of aborting
- All fixes applied to both `generate()` and `continue_run()` code paths

### Changes

| File | What changed |
|------|-------------|
| `paperbanana/core/pipeline.py` | Added `tenacity` + `CritiqueResult` imports, `_call_with_retry()` helper, `try/except` around Optimizer, retry wrappers on Retriever/Planner/Visualizer, fallback logic for Stylist and Critic in both `generate()` and `continue_run()` |
| `tests/test_pipeline/test_agent_failures.py` | 6 new tests covering all failure/retry/fallback scenarios |

## Test plan

- [x] `test_optimizer_failure_falls_back_to_original_input` — Optimizer raises → pipeline completes with original input
- [x] `test_stylist_failure_falls_back_to_planner_output` — Stylist raises → final description is planner output
- [x] `test_critic_failure_accepts_current_image` — Critic raises → image accepted, iteration stops gracefully
- [x] `test_agent_retries_on_transient_failure` — Planner fails 2x, succeeds on 3rd → pipeline completes
- [x] `test_required_agent_raises_after_retries_exhausted` — Planner always fails → re-raises after 3 attempts
- [x] `test_visualizer_retries_on_transient_failure` — Visualizer fails once → retried and succeeds
- [x] Full test suite: **413 passed**, 3 skipped (pre-existing), 0 failures
- [x] `ruff check` and `ruff format` clean

Closes #135
