### PR TITLE
Add native comparative evaluation for statistical plots

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ Key architectural layers:
 - **`paperbanana/providers/`** — Abstract `VLMProvider` and `ImageGenProvider` base classes in `base.py`. Concrete implementations in `vlm/` (OpenAI, Gemini, OpenRouter) and `image_gen/` (OpenAI, Google Imagen, OpenRouter). `ProviderRegistry` is the factory that creates providers from `Settings`.
 - **`prompts/`** — Text prompt templates organized by type (`diagram/`, `plot/`, `evaluation/`). Templates use `{placeholder}` formatting, loaded by `BaseAgent.load_prompt()`.
 - **`paperbanana/evaluation/`** — VLM-as-Judge system. Scores on 4 dimensions (Faithfulness, Readability, Conciseness, Aesthetics) with hierarchical aggregation.
-- **`mcp_server/`** — FastMCP server exposing three tools: `generate_diagram`, `generate_plot`, `evaluate_diagram`.
+- **`mcp_server/`** — FastMCP server exposing four tools: `generate_diagram`, `generate_plot`, `evaluate_diagram`, `evaluate_plot`.
 - **`data/reference_sets/`** — 13 curated methodology diagram examples used for in-context learning by the Retriever agent.
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ PaperBanana includes an MCP server for use with Claude Code, Cursor, or any MCP-
 }
 ```
 
-Three MCP tools are exposed: `generate_diagram`, `generate_plot`, and `evaluate_diagram`.
+Four MCP tools are exposed: `generate_diagram`, `generate_plot`, `evaluate_diagram`, and `evaluate_plot`.
 
 The repo also ships with 3 Claude Code skills:
 - `/generate-diagram <file> [caption]` - generate a methodology diagram from a text file

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -9,6 +9,7 @@ MCP server that exposes PaperBanana's diagram and plot generation as tools for C
 | `generate_diagram` | Generate a methodology diagram from text context + caption |
 | `generate_plot` | Generate a statistical plot from JSON data + intent description |
 | `evaluate_diagram` | Compare a generated diagram against a human reference (4 dimensions) |
+| `evaluate_plot` | Compare a generated statistical plot against a human reference (4 dimensions) |
 
 ## Installation
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -7,6 +7,7 @@ Tools:
     generate_diagram    — Generate a methodology diagram from text
     generate_plot       — Generate a statistical plot from JSON data
     evaluate_diagram    — Evaluate a generated diagram against a reference
+    evaluate_plot       — Evaluate a generated plot against a reference
     download_references — Download expanded reference set (~294 examples)
 
 Usage:
@@ -240,10 +241,55 @@ async def evaluate_diagram(
         source_context=context,
         caption=caption,
         reference_path=reference_path,
+        task=DiagramType.METHODOLOGY,
     )
 
     lines = [
         "Evaluation Results",
+        "=" * 40,
+        f"Faithfulness:  {scores.faithfulness.winner} — {scores.faithfulness.reasoning}",
+        f"Conciseness:   {scores.conciseness.winner} — {scores.conciseness.reasoning}",
+        f"Readability:   {scores.readability.winner} — {scores.readability.reasoning}",
+        f"Aesthetics:    {scores.aesthetics.winner} — {scores.aesthetics.reasoning}",
+        "-" * 40,
+        f"Overall Winner: {scores.overall_winner} (score: {scores.overall_score})",
+    ]
+    return "\n".join(lines)
+
+
+@mcp.tool
+async def evaluate_plot(
+    generated_path: str,
+    reference_path: str,
+    data_json: str,
+    intent: str,
+) -> str:
+    """Evaluate a generated statistical plot against a human reference on 4 dimensions.
+
+    Args:
+        generated_path: File path to the model-generated plot.
+        reference_path: File path to the human reference plot.
+        data_json: JSON string containing the source data used to generate the plot.
+        intent: Communicative intent used for plot generation.
+
+    Returns:
+        Formatted evaluation scores with per-dimension results and overall winner.
+    """
+    settings = Settings()
+    vlm = ProviderRegistry.create_vlm(settings)
+    judge = VLMJudge(vlm_provider=vlm, prompt_dir=find_prompt_dir())
+    source_context = f"Data for plotting:\n{data_json}"
+
+    scores = await judge.evaluate(
+        image_path=generated_path,
+        source_context=source_context,
+        caption=intent,
+        reference_path=reference_path,
+        task=DiagramType.STATISTICAL_PLOT,
+    )
+
+    lines = [
+        "Plot Evaluation Results",
         "=" * 40,
         f"Faithfulness:  {scores.faithfulness.winner} — {scores.faithfulness.reasoning}",
         f"Conciseness:   {scores.conciseness.winner} — {scores.conciseness.reasoning}",

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -1974,6 +1974,93 @@ def evaluate(
             console.print(f"\n[bold]{dim}[/bold]: {result.reasoning}")
 
 
+@app.command("evaluate-plot")
+def evaluate_plot(
+    generated: str = typer.Option(..., "--generated", "-g", help="Path to generated plot image"),
+    data: str = typer.Option(
+        ...,
+        "--data",
+        "-d",
+        help="Path to source data file used for plotting (CSV or JSON)",
+    ),
+    intent: str = typer.Option(..., "--intent", help="Communicative intent used for the plot"),
+    reference: str = typer.Option(..., "--reference", "-r", help="Path to human reference plot image"),
+    vlm_provider: str = typer.Option(
+        "gemini", "--vlm-provider", help="VLM provider for evaluation"
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show detailed agent progress and timing"
+    ),
+):
+    """Evaluate a generated statistical plot vs human reference (comparative)."""
+    configure_logging(verbose=verbose)
+    from paperbanana.core.plot_data import load_statistical_plot_payload
+    from paperbanana.core.utils import find_prompt_dir
+    from paperbanana.evaluation.judge import VLMJudge
+
+    generated_path = Path(generated)
+    if not generated_path.exists():
+        console.print(f"[red]Error: Generated image not found: {generated}[/red]")
+        raise typer.Exit(1)
+
+    reference_path = Path(reference)
+    if not reference_path.exists():
+        console.print(f"[red]Error: Reference image not found: {reference}[/red]")
+        raise typer.Exit(1)
+
+    data_path = Path(data)
+    if not data_path.exists():
+        console.print(f"[red]Error: Data file not found: {data}[/red]")
+        raise typer.Exit(1)
+
+    try:
+        source_context, _ = load_statistical_plot_payload(data_path)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    settings = Settings(vlm_provider=vlm_provider)
+    from paperbanana.providers.registry import ProviderRegistry
+
+    vlm = ProviderRegistry.create_vlm(settings)
+    judge = VLMJudge(vlm, prompt_dir=find_prompt_dir())
+
+    async def _run():
+        return await judge.evaluate(
+            image_path=str(generated_path),
+            source_context=source_context,
+            caption=intent,
+            reference_path=str(reference_path),
+            task=DiagramType.STATISTICAL_PLOT,
+        )
+
+    scores = asyncio.run(_run())
+
+    dims = ["faithfulness", "conciseness", "readability", "aesthetics"]
+    dim_lines = []
+    for dim in dims:
+        result = getattr(scores, dim)
+        dim_lines.append(f"{dim.capitalize():14s} {result.winner}")
+
+    console.print(
+        Panel.fit(
+            "[bold]Evaluation Results (Plot Comparative)[/bold]\n\n"
+            + "\n".join(dim_lines)
+            + f"\n[bold]{'Overall':14s} {scores.overall_winner}[/bold]",
+            border_style="cyan",
+        )
+    )
+
+    for dim in dims:
+        result = getattr(scores, dim)
+        if result.reasoning:
+            console.print(f"\n[bold]{dim}[/bold]: {result.reasoning}")
+
+
 @app.command("ablate-retrieval")
 def ablate_retrieval(
     input: str = typer.Option(

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -1984,7 +1984,12 @@ def evaluate_plot(
         help="Path to source data file used for plotting (CSV or JSON)",
     ),
     intent: str = typer.Option(..., "--intent", help="Communicative intent used for the plot"),
-    reference: str = typer.Option(..., "--reference", "-r", help="Path to human reference plot image"),
+    reference: str = typer.Option(
+        ...,
+        "--reference",
+        "-r",
+        help="Path to human reference plot image",
+    ),
     vlm_provider: str = typer.Option(
         "gemini", "--vlm-provider", help="VLM provider for evaluation"
     ),

--- a/paperbanana/evaluation/judge.py
+++ b/paperbanana/evaluation/judge.py
@@ -8,11 +8,11 @@ from typing import Optional
 import structlog
 
 from paperbanana.core.types import (
+    DimensionResult,
     DiagramType,
+    EvaluationScore,
     VALID_WINNERS,
     WINNER_SCORE_MAP,
-    DimensionResult,
-    EvaluationScore,
 )
 from paperbanana.core.utils import extract_json, load_image
 from paperbanana.providers.base import VLMProvider

--- a/paperbanana/evaluation/judge.py
+++ b/paperbanana/evaluation/judge.py
@@ -8,6 +8,7 @@ from typing import Optional
 import structlog
 
 from paperbanana.core.types import (
+    DiagramType,
     VALID_WINNERS,
     WINNER_SCORE_MAP,
     DimensionResult,
@@ -23,6 +24,17 @@ DIMENSIONS = ["faithfulness", "conciseness", "readability", "aesthetics"]
 # Primary dimensions take precedence in hierarchical aggregation
 PRIMARY_DIMENSIONS = ["faithfulness", "readability"]
 SECONDARY_DIMENSIONS = ["conciseness", "aesthetics"]
+_EVAL_TASK_TO_PROMPT_SUBDIR = {
+    DiagramType.METHODOLOGY: "diagram",
+    DiagramType.STATISTICAL_PLOT: "plot",
+}
+_EVAL_TASK_ALIASES = {
+    "diagram": "diagram",
+    "methodology": "diagram",
+    "methodology_diagram": "diagram",
+    "plot": "plot",
+    "statistical_plot": "plot",
+}
 
 
 class VLMJudge:
@@ -45,6 +57,7 @@ class VLMJudge:
         source_context: str,
         caption: str,
         reference_path: str,
+        task: DiagramType | str = DiagramType.METHODOLOGY,
     ) -> EvaluationScore:
         """Evaluate a generated image by comparing against a human reference.
 
@@ -59,6 +72,7 @@ class VLMJudge:
         """
         model_image = load_image(image_path)
         reference_image = load_image(reference_path)
+        prompt_subdir = self._resolve_prompt_subdir(task)
 
         # Both images: [Human reference, Model generated]
         images = [reference_image, model_image]
@@ -68,7 +82,12 @@ class VLMJudge:
         json_ok = getattr(self.vlm, "supports_json_mode", True)
         for dim in DIMENSIONS:
             logger.info("Evaluating dimension", dimension=dim, json_mode=json_ok)
-            prompt = self._load_eval_prompt(dim, source_context, caption)
+            prompt = self._load_eval_prompt(
+                dim,
+                source_context,
+                caption,
+                prompt_subdir=prompt_subdir,
+            )
             response = await self.vlm.generate(
                 prompt=prompt,
                 images=images,
@@ -88,13 +107,43 @@ class VLMJudge:
             overall_score=overall_score,
         )
 
-    def _load_eval_prompt(self, dimension: str, source_context: str, caption: str) -> str:
+    def _load_eval_prompt(
+        self,
+        dimension: str,
+        source_context: str,
+        caption: str,
+        *,
+        prompt_subdir: str = "diagram",
+    ) -> str:
         """Load evaluation prompt for a specific dimension."""
-        prompt_path = self.prompt_dir / "evaluation" / f"{dimension}.txt"
-        if not prompt_path.exists():
-            raise FileNotFoundError(f"Evaluation prompt not found: {prompt_path}")
+        candidates: list[Path]
+        if prompt_subdir == "diagram":
+            # Backward compatibility: support both new nested location and legacy paths.
+            candidates = [
+                self.prompt_dir / "evaluation" / "diagram" / f"{dimension}.txt",
+                self.prompt_dir / "evaluation" / f"{dimension}.txt",
+            ]
+        else:
+            candidates = [self.prompt_dir / "evaluation" / prompt_subdir / f"{dimension}.txt"]
+
+        prompt_path = next((p for p in candidates if p.exists()), None)
+        if prompt_path is None:
+            searched = ", ".join(str(p) for p in candidates)
+            raise FileNotFoundError(f"Evaluation prompt not found. Searched: {searched}")
         template = prompt_path.read_text(encoding="utf-8")
         return template.format(source_context=source_context, caption=caption)
+
+    def _resolve_prompt_subdir(self, task: DiagramType | str) -> str:
+        """Normalize evaluation task into prompt subdirectory name."""
+        if isinstance(task, DiagramType):
+            return _EVAL_TASK_TO_PROMPT_SUBDIR[task]
+
+        normalized = str(task).strip().lower()
+        if normalized in _EVAL_TASK_ALIASES:
+            return _EVAL_TASK_ALIASES[normalized]
+
+        allowed = ", ".join(sorted(_EVAL_TASK_ALIASES))
+        raise ValueError(f"Unsupported evaluation task '{task}'. Supported values: {allowed}")
 
     def _parse_result(self, response: str, dimension: str) -> DimensionResult:
         """Parse a comparative result from VLM response."""

--- a/paperbanana/evaluation/judge.py
+++ b/paperbanana/evaluation/judge.py
@@ -8,11 +8,11 @@ from typing import Optional
 import structlog
 
 from paperbanana.core.types import (
-    DimensionResult,
-    DiagramType,
-    EvaluationScore,
     VALID_WINNERS,
     WINNER_SCORE_MAP,
+    DiagramType,
+    DimensionResult,
+    EvaluationScore,
 )
 from paperbanana.core.utils import extract_json, load_image
 from paperbanana.providers.base import VLMProvider

--- a/paperbanana/studio/app.py
+++ b/paperbanana/studio/app.py
@@ -6,6 +6,7 @@ import math
 from pathlib import Path
 from typing import Any, Optional
 
+from paperbanana.core.types import DiagramType
 from paperbanana.studio import runs as runs_mod
 from paperbanana.studio.runner import (
     ASPECT_RATIO_CHOICES,
@@ -374,12 +375,21 @@ def build_studio_app(
                     "Compare a **generated** image to a **human reference** using the "
                     "paper’s VLM-as-judge protocol (four dimensions + overall)."
                 )
+                ev_target = gr.Radio(
+                    label="Evaluation target",
+                    choices=["Methodology diagram", "Statistical plot"],
+                    value="Methodology diagram",
+                )
                 g_img = gr.Image(label="Generated diagram", type="filepath")
                 r_img = gr.Image(label="Human reference", type="filepath")
                 ev_ctx = gr.Textbox(label="Source context", lines=8)
                 ev_ctx_f = gr.File(
                     label="Context file (optional)",
                     file_types=[".txt", ".md"],
+                )
+                ev_plot_data_f = gr.File(
+                    label="Plot data file (required for statistical plot evaluation)",
+                    file_types=[".csv", ".json"],
                 )
                 ev_cap = gr.Textbox(label="Figure caption", lines=2)
                 ev_log = gr.Textbox(label="Log", lines=6)
@@ -400,10 +410,12 @@ def build_studio_app(
                     op,
                     sp,
                     sd,
+                    target,
                     gen,
                     ref,
                     etext,
                     efile,
+                    plot_data_file,
                     ecap,
                 ):
                     _dotenv()
@@ -412,7 +424,21 @@ def build_studio_app(
                         gp = _upload_path(gen) or ""
                         rp = _upload_path(ref) or ""
                         ctx = merge_context(etext, _upload_path(efile))
-                        log, res = run_evaluate(st, gp, rp, ctx, ecap or "", verbose_logging=False)
+                        task = (
+                            DiagramType.STATISTICAL_PLOT
+                            if target == "Statistical plot"
+                            else DiagramType.METHODOLOGY
+                        )
+                        log, res = run_evaluate(
+                            st,
+                            gp,
+                            rp,
+                            ctx,
+                            ecap or "",
+                            evaluation_task=task,
+                            plot_data_path=_upload_path(plot_data_file) or "",
+                            verbose_logging=False,
+                        )
                         return log, res
                     except Exception as e:
                         return f"{type(e).__name__}: {e}", str(e)
@@ -433,10 +459,12 @@ def build_studio_app(
                         opt_in,
                         save_pr,
                         seed_val,
+                        ev_target,
                         g_img,
                         r_img,
                         ev_ctx,
                         ev_ctx_f,
+                        ev_plot_data_f,
                         ev_cap,
                     ],
                     outputs=[ev_log, ev_out],

--- a/paperbanana/studio/runner.py
+++ b/paperbanana/studio/runner.py
@@ -285,11 +285,14 @@ def run_evaluate(
     reference_path: str,
     source_context: str,
     caption: str,
+    evaluation_task: DiagramType = DiagramType.METHODOLOGY,
+    plot_data_path: str = "",
     verbose_logging: bool = False,
 ) -> tuple[str, str]:
     """VLM judge comparative evaluation. Returns (log, formatted results)."""
     configure_logging(verbose=verbose_logging)
-    lines: list[str] = ["Starting comparative evaluation (VLM judge)…"]
+    task_label = "plot" if evaluation_task == DiagramType.STATISTICAL_PLOT else "diagram"
+    lines: list[str] = [f"Starting comparative evaluation ({task_label}, VLM judge)…"]
     gp = Path(generated_path)
     rp = Path(reference_path)
     if not gp.is_file():
@@ -300,7 +303,21 @@ def run_evaluate(
         msg = f"Reference image not found: {reference_path}"
         lines.append(msg)
         return "\n".join(lines), msg
-    if not source_context.strip():
+    effective_context = source_context
+    if evaluation_task == DiagramType.STATISTICAL_PLOT:
+        plot_path = Path(plot_data_path)
+        if not plot_path.is_file():
+            msg = f"Plot data file not found: {plot_data_path}"
+            lines.append(msg)
+            return "\n".join(lines), msg
+        try:
+            effective_context, _ = load_statistical_plot_payload(plot_path)
+        except ValueError as e:
+            msg = f"Invalid plot data: {e}"
+            lines.append(msg)
+            return "\n".join(lines), msg
+
+    if not effective_context.strip():
         msg = "Source context is empty."
         lines.append(msg)
         return "\n".join(lines), msg
@@ -312,15 +329,16 @@ def run_evaluate(
         async def _go():
             return await judge.evaluate(
                 image_path=str(gp),
-                source_context=source_context,
+                source_context=effective_context,
                 caption=caption.strip(),
                 reference_path=str(rp),
+                task=evaluation_task,
             )
 
         scores = asyncio.run(_go())
         lines.append("Done.")
         dims = ["faithfulness", "conciseness", "readability", "aesthetics"]
-        out_parts = ["## Results\n"]
+        out_parts = [f"## Results ({task_label})\n"]
         for dim in dims:
             r = getattr(scores, dim)
             out_parts.append(f"**{dim}** — {r.winner} (score {r.score:.0f})\n")

--- a/prompts/evaluation/plot/aesthetics.txt
+++ b/prompts/evaluation/plot/aesthetics.txt
@@ -1,0 +1,43 @@
+# Role
+You are an expert judge in academic visual design. Your task is to evaluate the **Aesthetics** of a **Model Plot** compared to a **Human-created Plot**.
+
+## Inputs
+
+1. **Plot Intent**: {caption}
+2. **Human reference plot (Human)**: [Image 1]
+3. **Model-generated plot (Model)**: [Image 2]
+
+## Core Definition: What is Aesthetics?
+
+**Aesthetics** reflects visual polish and publication readiness: harmonious color choices, consistent typography, balanced spacing, and professional chart styling.
+
+## Veto Rules (The "Red Lines")
+
+If a plot commits any of the following errors, it fails aesthetics immediately:
+
+1. **Rendering artifacts:** Blurry marks, pixelation, broken glyphs, or distorted geometry.
+2. **Color disharmony:** Clashing palettes or inaccessible color choices that appear unprofessional.
+3. **Inconsistent style:** Mixed font families/sizes or arbitrary styling without visual coherence.
+4. **Black background:** Pure black backgrounds that are typically unsuitable for paper figures.
+
+## Decision Criteria
+
+Compare the two plots and select the strictly best option based on the Core Definition and Veto Rules:
+
+- **Model**: The Model plot has better visual polish while avoiding Veto errors.
+- **Human**: The Human plot has better visual polish while avoiding Veto errors.
+- **Both are good**: Both plots are aesthetically strong and publication-ready.
+- **Both are bad**: Both plots violate Veto rules or look unpolished.
+
+## Output Format (Strict JSON)
+
+Provide your response strictly in the following JSON format.
+
+The `comparison_reasoning` must be a single string following this structure: "Aesthetics of Human: ...; Aesthetics of Model: ...; Conclusion: ..."
+
+```json
+{{
+    "comparison_reasoning": "Aesthetics of Human: ...;\n Aesthetics of Model: ...;\n Conclusion: ...",
+    "winner": "Model" | "Human" | "Both are good" | "Both are bad"
+}}
+```

--- a/prompts/evaluation/plot/conciseness.txt
+++ b/prompts/evaluation/plot/conciseness.txt
@@ -1,0 +1,43 @@
+# Role
+You are an expert judge in academic visual design. Your task is to evaluate the **Conciseness** of a **Model Plot** compared to a **Human-created Plot**.
+
+## Inputs
+
+1. **Source Data Context**: {source_context}
+2. **Plot Intent**: {caption}
+3. **Human reference plot (Human)**: [Image 1]
+4. **Model-generated plot (Model)**: [Image 2]
+
+## Core Definition: What is Conciseness?
+
+**Conciseness** is the information signal-to-noise ratio. A concise plot communicates the intended insight with minimal clutter while preserving required context for interpretation.
+
+## Veto Rules (The "Red Lines")
+
+If a plot commits any of the following errors, it fails conciseness immediately:
+
+1. **Visual clutter:** Excessive decorations, redundant labels, or unnecessary chart junk that obscures the main message.
+2. **Over-annotation:** Long textual blocks inside the figure that should be in the caption/body text.
+3. **Redundant encodings:** Multiple unnecessary encodings (shape/color/pattern/3D effects) that do not add information.
+
+## Decision Criteria
+
+Compare the two plots and select the strictly best option based on the Core Definition and Veto Rules:
+
+- **Model**: The Model plot communicates the intended message more concisely.
+- **Human**: The Human plot communicates the intended message more concisely.
+- **Both are good**: Both plots are concise and avoid Veto errors.
+- **Both are bad**: Both plots violate one or more Veto rules or are similarly cluttered.
+
+## Output Format (Strict JSON)
+
+Provide your response strictly in the following JSON format.
+
+The `comparison_reasoning` must be a single string following this structure: "Conciseness of Human: ...; Conciseness of Model: ...; Conclusion: ..."
+
+```json
+{{
+    "comparison_reasoning": "Conciseness of Human: ...;\n Conciseness of Model: ...;\n Conclusion: ...",
+    "winner": "Model" | "Human" | "Both are good" | "Both are bad"
+}}
+```

--- a/prompts/evaluation/plot/faithfulness.txt
+++ b/prompts/evaluation/plot/faithfulness.txt
@@ -1,0 +1,46 @@
+# Role
+You are an expert judge in academic visual design. Your task is to evaluate the **Faithfulness** of a **Model Plot** by comparing it against a **Human-created Plot**.
+
+## Inputs
+
+1. **Source Data Context**: {source_context}
+2. **Plot Intent**: {caption}
+3. **Human reference plot (Human)**: [Image 1]
+4. **Model-generated plot (Model)**: [Image 2]
+
+## Core Definition: What is Faithfulness?
+
+**Faithfulness** is whether the visualized claims match the provided data context and intent. A faithful plot uses correct chart semantics (axes, scale behavior, grouping, trend direction) and does not fabricate values, categories, or relationships.
+
+**Important**: Different but equivalent design choices (e.g., color palette, marker style, bar ordering when values are unchanged) should not be penalized.
+
+## Veto Rules (The "Red Lines")
+
+If a plot commits any of the following errors, it fails faithfulness immediately:
+
+1. **Data fabrication:** Inventing values, categories, or series not supported by the provided data context.
+2. **Semantic contradiction:** Misrepresenting directionality, comparisons, relative magnitude, or uncertainty conveyed by the data.
+3. **Intent mismatch:** Failing to depict the requested analytical focus in the plot intent.
+4. **Broken labeling:** Axis labels, legends, units, or category names are missing or incorrect enough to change interpretation.
+
+## Decision Criteria
+
+Compare the two plots and select the strictly best option based on the Core Definition and Veto Rules:
+
+- **Model**: The Model plot is more faithful while avoiding Veto errors.
+- **Human**: The Human plot is more faithful while avoiding Veto errors.
+- **Both are good**: Both plots are faithful and avoid Veto errors.
+- **Both are bad**: Both plots violate one or more Veto rules or are fundamentally misleading.
+
+## Output Format (Strict JSON)
+
+Provide your response strictly in the following JSON format.
+
+The `comparison_reasoning` must be a single string following this structure: "Faithfulness of Human: ...; Faithfulness of Model: ...; Conclusion: ..."
+
+```json
+{{
+    "comparison_reasoning": "Faithfulness of Human: ...;\n Faithfulness of Model: ...;\n Conclusion: ...",
+    "winner": "Model" | "Human" | "Both are good" | "Both are bad"
+}}
+```

--- a/prompts/evaluation/plot/readability.txt
+++ b/prompts/evaluation/plot/readability.txt
@@ -1,0 +1,44 @@
+# Role
+You are an expert judge in academic visual design. Your task is to evaluate the **Readability** of a **Model Plot** compared to a **Human-created Plot**.
+
+## Inputs
+
+1. **Plot Intent**: {caption}
+2. **Human reference plot (Human)**: [Image 1]
+3. **Model-generated plot (Model)**: [Image 2]
+
+## Core Definition: What is Readability?
+
+**Readability** measures how quickly a reader can parse the chart and recover the intended comparison, trend, or distribution. A readable plot has clear labels, legible text, and an easy-to-follow visual hierarchy.
+
+## Veto Rules (The "Red Lines")
+
+If a plot commits any of the following errors, it fails readability immediately:
+
+1. **Illegible text:** Labels, ticks, or legends are too small, blurry, or low-contrast.
+2. **Ambiguous axes:** Missing axis labels/units or misleading scale presentation.
+3. **Occlusion/overlap:** Data marks, labels, or legends overlap enough to block interpretation.
+4. **Distracting layout:** Severe whitespace imbalance or awkward composition that harms interpretation.
+5. **Black background:** Pure black backgrounds that are generally incompatible with academic publication style.
+
+## Decision Criteria
+
+Readability is primarily pass/fail on Veto rules:
+
+- **Both are good**: Default when both plots avoid Veto failures and are easy to parse.
+- **Model**: Model avoids Veto errors and Human does not, or Model is clearly easier to read.
+- **Human**: Human avoids Veto errors and Model does not, or Human is clearly easier to read.
+- **Both are bad**: Both fail one or more Veto rules.
+
+## Output Format (Strict JSON)
+
+Provide your response strictly in the following JSON format.
+
+The `comparison_reasoning` must be a single string following this structure: "Readability of Human: ...; Readability of Model: ...; Conclusion: ..."
+
+```json
+{{
+    "comparison_reasoning": "Readability of Human: ...;\n Readability of Model: ...;\n Conclusion: ...",
+    "winner": "Model" | "Human" | "Both are good" | "Both are bad"
+}}
+```

--- a/server.json
+++ b/server.json
@@ -30,6 +30,10 @@
     {
       "name": "evaluate_diagram",
       "description": "Compare a generated diagram against a human reference on 4 dimensions"
+    },
+    {
+      "name": "evaluate_plot",
+      "description": "Compare a generated statistical plot against a human reference on 4 dimensions"
     }
   ]
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -629,3 +629,28 @@ def test_batch_prints_status_table_on_partial_failure(tmp_path, monkeypatch):
     assert "1 failed" in result.output
     assert "✓" in result.output
     assert "✗" in result.output
+
+
+def test_evaluate_plot_rejects_missing_data_file(tmp_path):
+    """evaluate-plot fails early when the data file does not exist."""
+    generated = tmp_path / "generated.png"
+    reference = tmp_path / "reference.png"
+    generated.write_bytes(b"fake-image")
+    reference.write_bytes(b"fake-image")
+
+    result = runner.invoke(
+        app,
+        [
+            "evaluate-plot",
+            "--generated",
+            str(generated),
+            "--reference",
+            str(reference),
+            "--data",
+            str(tmp_path / "missing.csv"),
+            "--intent",
+            "Compare method variants",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Data file not found" in result.output

--- a/tests/test_evaluation/test_judge.py
+++ b/tests/test_evaluation/test_judge.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
-from paperbanana.core.types import DimensionResult
+import pytest
+
+from paperbanana.core.types import DiagramType, DimensionResult
 from paperbanana.evaluation.judge import VLMJudge
 
 
@@ -210,3 +213,31 @@ def test_aggregate_complete_split():
         "aesthetics": _dim("Model"),
     }
     assert judge._hierarchical_aggregate(results) == "Both are good"
+
+
+def test_resolve_prompt_subdir_plot_task():
+    """Statistical plot task maps to plot-specific prompt directory."""
+    judge = _make_judge()
+    assert judge._resolve_prompt_subdir(DiagramType.STATISTICAL_PLOT) == "plot"
+    assert judge._resolve_prompt_subdir("plot") == "plot"
+    assert judge._resolve_prompt_subdir("statistical_plot") == "plot"
+
+
+def test_resolve_prompt_subdir_invalid_task():
+    """Unknown task names should fail fast with a clear error."""
+    judge = _make_judge()
+    with pytest.raises(ValueError):
+        judge._resolve_prompt_subdir("unknown-task")
+
+
+def test_load_eval_prompt_plot_uses_nested_prompt():
+    """Plot evaluation prompt is loaded from prompts/evaluation/plot/."""
+    judge = _make_judge()
+    rendered = judge._load_eval_prompt(
+        "faithfulness",
+        "ctx",
+        "caption",
+        prompt_subdir="plot",
+    )
+    expected = Path("prompts/evaluation/plot/faithfulness.txt").read_text(encoding="utf-8")
+    assert rendered == expected.format(source_context="ctx", caption="caption")

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -233,3 +233,27 @@ def test_run_composite_dotdot_filename_falls_back(tmp_path):
     )
     assert output_path is not None
     assert Path(output_path).name == "composite.png"
+
+
+def test_run_evaluate_plot_requires_data_file(tmp_path):
+    """Plot evaluation mode validates data path before provider setup."""
+    from paperbanana.core.config import Settings
+    from paperbanana.core.types import DiagramType
+    from paperbanana.studio.runner import run_evaluate
+
+    generated = tmp_path / "g.png"
+    reference = tmp_path / "r.png"
+    generated.write_bytes(b"x")
+    reference.write_bytes(b"y")
+
+    log, result = run_evaluate(
+        Settings(),
+        generated_path=str(generated),
+        reference_path=str(reference),
+        source_context="",
+        caption="Plot intent",
+        evaluation_task=DiagramType.STATISTICAL_PLOT,
+        plot_data_path=str(tmp_path / "missing.csv"),
+    )
+    assert "Plot data file not found" in log
+    assert "Plot data file not found" in result


### PR DESCRIPTION
## Summary:
Closes #150 
- Extend VLMJudge to support task-aware evaluation (diagram and plot) with prompt subdirectory resolution and legacy prompt fallback.
- Add CLI evaluate-plot, Studio Evaluate tab support for plot mode, and MCP evaluate_plot tool.
- Introduce plot-specific evaluation prompts and update docs/tests for full feature coverage.

## Test plan:
- Run pytest tests/test_evaluation/test_judge.py tests/test_cli.py tests/test_studio.py -q
- Confirm all pass (36 passed, 1 skipped).
- Verify no new lint errors in touched files.
