### PR TITLE
feat: add Studio Composite tab for multi-panel figures

### DIFF
--- a/paperbanana/studio/app.py
+++ b/paperbanana/studio/app.py
@@ -702,15 +702,17 @@ def build_studio_app(
                             p = _upload_path(f)
                             if p:
                                 paths.append(p)
+                    spacing_int = int(spacing) if spacing is not None else 20
+                    font_int = int(font_size) if font_size is not None else 32
                     try:
                         log, out_path = run_composite(
                             paths,
                             output_dir=od or default_output_dir,
                             layout=str(layout) if layout else "auto",
                             labels=labels or "",
-                            spacing=int(spacing or 20),
+                            spacing=spacing_int,
                             label_position=str(label_pos or "bottom"),
-                            label_font_size=int(font_size or 32),
+                            label_font_size=font_int,
                             output_filename=filename or "composite.png",
                         )
                         return log, out_path

--- a/paperbanana/studio/app.py
+++ b/paperbanana/studio/app.py
@@ -14,6 +14,7 @@ from paperbanana.studio.runner import (
     build_settings,
     merge_context,
     run_batch,
+    run_composite,
     run_continue,
     run_evaluate,
     run_methodology,
@@ -646,6 +647,89 @@ def build_studio_app(
                         b_concurrency,
                     ],
                     outputs=[b_log, b_dir],
+                )
+
+            # ── Composite multi-panel figure ──────────────────────────────
+            with gr.Tab("Composite"):
+                gr.Markdown(
+                    "Compose multiple images into a single labeled multi-panel figure with "
+                    "`(a)`, `(b)`, `(c)` sub-panels. No API calls — pure local image processing."
+                )
+                cmp_files = gr.File(
+                    label="Panel images",
+                    file_count="multiple",
+                    file_types=[".png", ".jpg", ".jpeg", ".webp"],
+                )
+                with gr.Row():
+                    cmp_layout = gr.Dropdown(
+                        label="Layout",
+                        choices=["auto", "1x2", "1x3", "1x4", "2x2", "2x3", "3x3"],
+                        value="auto",
+                        allow_custom_value=True,
+                    )
+                    cmp_label_pos = gr.Radio(
+                        label="Label position",
+                        choices=["bottom", "top"],
+                        value="bottom",
+                    )
+                cmp_labels = gr.Textbox(
+                    label="Labels",
+                    placeholder="Comma-separated (e.g. (a),(b),(c)), empty=auto, 'none'=disable",
+                    value="",
+                )
+                with gr.Row():
+                    cmp_spacing = gr.Number(label="Spacing (px)", value=20, precision=0)
+                    cmp_font = gr.Number(label="Label font size", value=32, precision=0)
+                cmp_filename = gr.Textbox(label="Output filename", value="composite.png")
+                cmp_go = gr.Button("Compose figure", variant="primary")
+                cmp_log = gr.Textbox(label="Log", lines=8)
+                cmp_out = gr.Image(label="Composite output", type="filepath")
+
+                def _do_composite(
+                    od,
+                    files,
+                    layout,
+                    labels,
+                    spacing,
+                    label_pos,
+                    font_size,
+                    filename,
+                ):
+                    _dotenv()
+                    paths = []
+                    if files:
+                        for f in files:
+                            p = _upload_path(f)
+                            if p:
+                                paths.append(p)
+                    try:
+                        log, out_path = run_composite(
+                            paths,
+                            output_dir=od or default_output_dir,
+                            layout=str(layout) if layout else "auto",
+                            labels=labels or "",
+                            spacing=int(spacing or 20),
+                            label_position=str(label_pos or "bottom"),
+                            label_font_size=int(font_size or 32),
+                            output_filename=filename or "composite.png",
+                        )
+                        return log, out_path
+                    except Exception as e:
+                        return f"{type(e).__name__}: {e}", None
+
+                cmp_go.click(
+                    _do_composite,
+                    inputs=[
+                        out_dir,
+                        cmp_files,
+                        cmp_layout,
+                        cmp_labels,
+                        cmp_spacing,
+                        cmp_label_pos,
+                        cmp_font,
+                        cmp_filename,
+                    ],
+                    outputs=[cmp_log, cmp_out],
                 )
 
             # ── Runs browser ──────────────────────────────────────────────

--- a/paperbanana/studio/runner.py
+++ b/paperbanana/studio/runner.py
@@ -654,6 +654,15 @@ def run_plot_batch(
     return "\n".join(lines), str(batch_dir.resolve())
 
 
+def _sanitize_output_filename(name: str) -> str:
+    """Strip directory components and reject traversal attempts."""
+    cleaned = (name or "").strip() or "composite.png"
+    base = Path(cleaned).name
+    if not base or base in (".", ".."):
+        return "composite.png"
+    return base
+
+
 def run_composite(
     image_paths: list[str],
     *,
@@ -669,6 +678,8 @@ def run_composite(
 
     Returns (log, output_path). output_path is None on failure.
     """
+    from typing import Literal, cast
+
     from paperbanana.core.composite import compose_images
 
     lines: list[str] = ["Starting composite figure generation…"]
@@ -689,18 +700,25 @@ def run_composite(
         lines.append(msg)
         return "\n".join(lines), None
 
+    if label_font_size <= 0:
+        msg = f"label_font_size must be > 0. Got: {label_font_size}"
+        lines.append(msg)
+        return "\n".join(lines), None
+
     label_list: Optional[list[str]] = None
     auto_label = True
-    if labels.strip():
-        if labels.strip().lower() == "none":
+    stripped_labels = labels.strip()
+    if stripped_labels:
+        if stripped_labels.lower() == "none":
             auto_label = False
         else:
             label_list = [item.strip() for item in labels.split(",") if item.strip()]
             auto_label = False
 
-    out_dir = Path(output_dir or "outputs").resolve()
+    out_dir_str = (output_dir or "").strip() or "outputs"
+    out_dir = Path(out_dir_str).resolve()
     ensure_dir(out_dir)
-    safe_name = output_filename.strip() or "composite.png"
+    safe_name = _sanitize_output_filename(output_filename)
     output_path = out_dir / safe_name
 
     lines.append(f"Panels: {len(valid_paths)}")
@@ -714,19 +732,17 @@ def run_composite(
             labels=label_list,
             auto_label=auto_label,
             spacing=spacing,
-            label_position=label_position,  # type: ignore[arg-type]
+            label_position=cast(Literal["top", "bottom"], label_position),
             label_font_size=label_font_size,
             output_path=output_path,
         )
     except (ValueError, OSError) as e:
-        err = f"{type(e).__name__}: {e}"
         lines.append("FAILED")
-        lines.append(err)
+        lines.append(f"{type(e).__name__}: {e}")
         return "\n".join(lines), None
     except Exception as e:
-        err = f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}"
         lines.append("FAILED")
-        lines.append(err)
+        lines.append(f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}")
         return "\n".join(lines), None
 
     lines.append("Done.")

--- a/paperbanana/studio/runner.py
+++ b/paperbanana/studio/runner.py
@@ -652,3 +652,82 @@ def run_plot_batch(
     lines.append(f"Succeeded: {ok}/{len(items)}")
     lines.append(f"Total time: {report['total_seconds']}s")
     return "\n".join(lines), str(batch_dir.resolve())
+
+
+def run_composite(
+    image_paths: list[str],
+    *,
+    output_dir: str,
+    layout: str = "auto",
+    labels: str = "",
+    spacing: int = 20,
+    label_position: str = "bottom",
+    label_font_size: int = 32,
+    output_filename: str = "composite.png",
+) -> tuple[str, Optional[str]]:
+    """Compose multiple uploaded images into a single labeled multi-panel figure.
+
+    Returns (log, output_path). output_path is None on failure.
+    """
+    from paperbanana.core.composite import compose_images
+
+    lines: list[str] = ["Starting composite figure generation…"]
+
+    valid_paths = [p for p in image_paths if p and Path(p).is_file()]
+    if not valid_paths:
+        msg = "No valid image files provided. Upload at least one image."
+        lines.append(msg)
+        return "\n".join(lines), None
+
+    if label_position not in ("top", "bottom"):
+        msg = f"label_position must be 'top' or 'bottom'. Got: {label_position!r}"
+        lines.append(msg)
+        return "\n".join(lines), None
+
+    if spacing < 0:
+        msg = f"spacing must be >= 0. Got: {spacing}"
+        lines.append(msg)
+        return "\n".join(lines), None
+
+    label_list: Optional[list[str]] = None
+    auto_label = True
+    if labels.strip():
+        if labels.strip().lower() == "none":
+            auto_label = False
+        else:
+            label_list = [item.strip() for item in labels.split(",") if item.strip()]
+            auto_label = False
+
+    out_dir = Path(output_dir or "outputs").resolve()
+    ensure_dir(out_dir)
+    safe_name = output_filename.strip() or "composite.png"
+    output_path = out_dir / safe_name
+
+    lines.append(f"Panels: {len(valid_paths)}")
+    lines.append(f"Layout: {layout}")
+    lines.append(f"Output: {output_path}")
+
+    try:
+        compose_images(
+            image_paths=valid_paths,
+            layout=layout,
+            labels=label_list,
+            auto_label=auto_label,
+            spacing=spacing,
+            label_position=label_position,  # type: ignore[arg-type]
+            label_font_size=label_font_size,
+            output_path=output_path,
+        )
+    except (ValueError, OSError) as e:
+        err = f"{type(e).__name__}: {e}"
+        lines.append("FAILED")
+        lines.append(err)
+        return "\n".join(lines), None
+    except Exception as e:
+        err = f"{type(e).__name__}: {e}\n\n{traceback.format_exc()}"
+        lines.append("FAILED")
+        lines.append(err)
+        return "\n".join(lines), None
+
+    lines.append("Done.")
+    return "\n".join(lines), str(output_path)

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -55,3 +55,88 @@ def test_build_studio_app():
     _ = gradio
     demo = build_studio_app(default_output_dir="outputs", config_path=None)
     assert demo is not None
+
+
+def test_run_composite_smoke(tmp_path):
+    from PIL import Image
+
+    from paperbanana.studio.runner import run_composite
+
+    p1 = tmp_path / "a.png"
+    p2 = tmp_path / "b.png"
+    Image.new("RGB", (100, 80), (255, 0, 0)).save(str(p1))
+    Image.new("RGB", (100, 80), (0, 255, 0)).save(str(p2))
+
+    out_dir = tmp_path / "out"
+    log, output_path = run_composite(
+        [str(p1), str(p2)],
+        output_dir=str(out_dir),
+        layout="1x2",
+        output_filename="result.png",
+    )
+    assert output_path is not None
+    assert (out_dir / "result.png").exists()
+    assert "Done." in log
+
+
+def test_run_composite_no_files_returns_error(tmp_path):
+    from paperbanana.studio.runner import run_composite
+
+    log, output_path = run_composite(
+        [],
+        output_dir=str(tmp_path),
+    )
+    assert output_path is None
+    assert "No valid image" in log
+
+
+def test_run_composite_invalid_label_position(tmp_path):
+    from PIL import Image
+
+    from paperbanana.studio.runner import run_composite
+
+    p = tmp_path / "x.png"
+    Image.new("RGB", (50, 50), (0, 0, 255)).save(str(p))
+    log, output_path = run_composite(
+        [str(p)],
+        output_dir=str(tmp_path),
+        label_position="left",
+    )
+    assert output_path is None
+    assert "label_position" in log
+
+
+def test_run_composite_explicit_labels(tmp_path):
+    from PIL import Image
+
+    from paperbanana.studio.runner import run_composite
+
+    p1 = tmp_path / "a.png"
+    p2 = tmp_path / "b.png"
+    Image.new("RGB", (60, 60), (255, 0, 0)).save(str(p1))
+    Image.new("RGB", (60, 60), (0, 255, 0)).save(str(p2))
+
+    log, output_path = run_composite(
+        [str(p1), str(p2)],
+        output_dir=str(tmp_path / "out"),
+        labels="Fig A, Fig B",
+        layout="1x2",
+    )
+    assert output_path is not None
+    assert "Done." in log
+
+
+def test_run_composite_disable_labels(tmp_path):
+    from PIL import Image
+
+    from paperbanana.studio.runner import run_composite
+
+    p = tmp_path / "x.png"
+    Image.new("RGB", (60, 60), (0, 0, 255)).save(str(p))
+    log, output_path = run_composite(
+        [str(p)],
+        output_dir=str(tmp_path / "out"),
+        labels="none",
+    )
+    assert output_path is not None
+    assert "Done." in log

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 
@@ -140,3 +142,94 @@ def test_run_composite_disable_labels(tmp_path):
     )
     assert output_path is not None
     assert "Done." in log
+
+
+def test_run_composite_zero_spacing_allowed(tmp_path):
+    from PIL import Image
+
+    from paperbanana.studio.runner import run_composite
+
+    p1 = tmp_path / "a.png"
+    p2 = tmp_path / "b.png"
+    Image.new("RGB", (40, 40), (255, 0, 0)).save(str(p1))
+    Image.new("RGB", (40, 40), (0, 255, 0)).save(str(p2))
+
+    log, output_path = run_composite(
+        [str(p1), str(p2)],
+        output_dir=str(tmp_path / "out"),
+        layout="1x2",
+        spacing=0,
+    )
+    assert output_path is not None
+    assert "Done." in log
+
+
+def test_run_composite_negative_spacing_rejected(tmp_path):
+    from PIL import Image
+
+    from paperbanana.studio.runner import run_composite
+
+    p = tmp_path / "x.png"
+    Image.new("RGB", (40, 40), (255, 0, 0)).save(str(p))
+    log, output_path = run_composite(
+        [str(p)],
+        output_dir=str(tmp_path / "out"),
+        spacing=-5,
+    )
+    assert output_path is None
+    assert "spacing" in log
+
+
+def test_run_composite_invalid_font_size_rejected(tmp_path):
+    from PIL import Image
+
+    from paperbanana.studio.runner import run_composite
+
+    p = tmp_path / "x.png"
+    Image.new("RGB", (40, 40), (255, 0, 0)).save(str(p))
+    log, output_path = run_composite(
+        [str(p)],
+        output_dir=str(tmp_path / "out"),
+        label_font_size=0,
+    )
+    assert output_path is None
+    assert "label_font_size" in log
+
+
+def test_run_composite_path_traversal_sanitized(tmp_path):
+    from PIL import Image
+
+    from paperbanana.studio.runner import run_composite
+
+    p = tmp_path / "x.png"
+    Image.new("RGB", (40, 40), (255, 0, 0)).save(str(p))
+
+    out_dir = tmp_path / "out"
+    log, output_path = run_composite(
+        [str(p)],
+        output_dir=str(out_dir),
+        output_filename="../escape.png",
+    )
+    assert output_path is not None
+    # Output must stay inside the configured output_dir
+    assert Path(output_path).parent.resolve() == out_dir.resolve()
+    assert Path(output_path).name == "escape.png"
+    assert not (tmp_path / "escape.png").exists()
+
+
+def test_run_composite_dotdot_filename_falls_back(tmp_path):
+    from PIL import Image
+
+    from paperbanana.studio.runner import run_composite
+
+    p = tmp_path / "x.png"
+    Image.new("RGB", (40, 40), (255, 0, 0)).save(str(p))
+
+    out_dir = tmp_path / "out"
+    log, output_path = run_composite(
+        [str(p)],
+        output_dir=str(out_dir),
+        output_filename="..",
+    )
+    assert output_path is not None
+    assert Path(output_path).name == "composite.png"


### PR DESCRIPTION
## Summary

- Add `run_composite()` wrapper to `paperbanana/studio/runner.py`
- Add new "Composite" tab to PaperBanana Studio between Batch and Runs
- 5 new tests in `tests/test_studio.py` covering the runner wrapper

Closes #151

## Why

PR #142 added the `paperbanana composite` CLI command and the optional `composite:` section in batch manifests, but Studio had no UI for it. Studio was the only major user-facing surface where composite was unreachable — every other feature (Diagram, Plot, Evaluate, Continue, Batch, Runs) already has a tab. This closes the CLI/Studio parity gap.

## Changes

**`paperbanana/studio/runner.py`** — `run_composite()` wrapper:
- Takes uploaded image paths + Gradio-friendly inputs
- Validates label position, spacing, and presence of files
- Writes the composite to `output_dir/output_filename`
- Returns `(log, output_path)` matching the pattern of `run_evaluate()` / `run_batch()`
- Pure local image processing — zero API calls

**`paperbanana/studio/app.py`** — new "Composite" tab:
- Multi-file upload (`gr.File(file_count=\"multiple\")`) accepting png/jpg/jpeg/webp
- Layout dropdown (`auto`, `1x2`, `1x3`, `1x4`, `2x2`, `2x3`, `3x3`, custom)
- Label position radio (`bottom` / `top`)
- Comma-separated labels input (empty = auto, `none` = disabled)
- Spacing + label font size number inputs
- Output filename text input
- Compose button → log panel + inline image preview

**`tests/test_studio.py`** — 5 new tests:
- `test_run_composite_smoke` — happy path with two test images
- `test_run_composite_no_files_returns_error` — graceful failure on empty input
- `test_run_composite_invalid_label_position` — rejects invalid positions
- `test_run_composite_explicit_labels` — comma-separated labels parsed correctly
- `test_run_composite_disable_labels` — `none` literal disables auto-labeling

## Test plan

- [x] \`ruff check\` passes (all files)
- [x] \`ruff format --check\` passes
- [x] \`pytest tests/test_studio.py tests/test_composite.py\` — 38/38 pass
- [x] \`pytest tests/\` — 464 passed, 1 skipped (gradio not installed locally), 1 pre-existing failure unrelated
- [x] No new dependencies (Pillow already required, Gradio already optional)
- [x] No changes to the core composite module or CLI
- [x] Module imports cleanly without gradio installed (lazy import inside `build_studio_app`)