### PR TITLE
refactor: extract _check_budget() helper in pipeline (#153)

### DIFF
--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -252,6 +252,19 @@ class PaperBananaPipeline:
             except Exception:
                 logger.warning("Progress callback raised", progress_event=event)
 
+    def _check_budget(self, context: str, iteration: int | None = None) -> bool:
+        """Return True if the cost tracker is over budget, logging a warning."""
+        if not (self._cost_tracker and self._cost_tracker.is_over_budget):
+            return False
+        if iteration is not None:
+            logger.warning(
+                f"Budget exceeded {context}, stopping early",
+                iteration=iteration,
+            )
+        else:
+            logger.warning(f"Budget exceeded {context}, skipping iterations")
+        return True
+
     @property
     def _run_dir(self) -> Path:
         """Directory for this run's outputs."""
@@ -600,12 +613,8 @@ class PaperBananaPipeline:
         else:
             total_iters = self.settings.refinement_iterations
 
-        budget_exceeded = False
-
         # Check budget after pre-iteration phases (retriever, planner, stylist)
-        if self._cost_tracker and self._cost_tracker.is_over_budget:
-            logger.warning("Budget exceeded after planning phases, skipping iterations")
-            budget_exceeded = True
+        budget_exceeded = self._check_budget("after planning phases")
 
         for i in range(total_iters):
             if budget_exceeded:
@@ -774,11 +783,7 @@ class PaperBananaPipeline:
             )
 
             # Check budget between iterations
-            if self._cost_tracker and self._cost_tracker.is_over_budget:
-                logger.warning(
-                    "Budget exceeded between iterations, stopping early",
-                    iteration=iter_index,
-                )
+            if self._check_budget("between iterations", iteration=iter_index):
                 budget_exceeded = True
                 break
 
@@ -1095,11 +1100,7 @@ class PaperBananaPipeline:
             )
 
             # Check budget between iterations
-            if self._cost_tracker and self._cost_tracker.is_over_budget:
-                logger.warning(
-                    "Budget exceeded between iterations, stopping early",
-                    iteration=iter_num,
-                )
+            if self._check_budget("between iterations", iteration=iter_num):
                 budget_exceeded = True
                 break
 

--- a/tests/test_pipeline/test_check_budget.py
+++ b/tests/test_pipeline/test_check_budget.py
@@ -1,0 +1,35 @@
+"""Unit tests for PaperBananaPipeline._check_budget helper (issue #153)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from paperbanana.core.pipeline import PaperBananaPipeline
+
+
+def _call(cost_tracker, context: str, iteration: int | None = None) -> bool:
+    """Invoke the unbound helper with a minimal stub self."""
+    stub = SimpleNamespace(_cost_tracker=cost_tracker)
+    return PaperBananaPipeline._check_budget(stub, context, iteration=iteration)
+
+
+class TestCheckBudget:
+    def test_no_tracker_returns_false(self):
+        assert _call(None, "after planning phases") is False
+
+    def test_under_budget_returns_false(self):
+        tracker = SimpleNamespace(is_over_budget=False)
+        assert _call(tracker, "between iterations", iteration=2) is False
+
+    def test_over_budget_returns_true_without_iteration(self, capsys):
+        tracker = SimpleNamespace(is_over_budget=True)
+        assert _call(tracker, "after planning phases") is True
+        out = capsys.readouterr().out
+        assert "Budget exceeded after planning phases, skipping iterations" in out
+
+    def test_over_budget_returns_true_with_iteration(self, capsys):
+        tracker = SimpleNamespace(is_over_budget=True)
+        assert _call(tracker, "between iterations", iteration=3) is True
+        out = capsys.readouterr().out
+        assert "Budget exceeded between iterations, stopping early" in out
+        assert "iteration=3" in out


### PR DESCRIPTION
## What does this PR do?

Extract a `_check_budget()` helper method in `pipeline.py` to eliminate duplicated budget-validation logic across three call sites. Fixes #153

## Type of change

- [x] Refactor (no functional change)

## Changes made

- Added `_check_budget(context, iteration=None)` private method on `PaperBananaPipeline` that encapsulates the budget guard check and structured log warning
- Replaced 3 identical inline budget-check blocks (lines ~606, ~777, ~1098) with calls to the new helper
- Removed dead `budget_exceeded = False` initialization that was immediately overwritten
- Added 4 unit tests in `tests/test_pipeline/test_check_budget.py` covering: no tracker, under budget, over budget without iteration, over budget with iteration

## How to test

1. `pytest tests/test_pipeline/test_check_budget.py -v` — runs the 4 new dedicated unit tests
2. `pytest tests/ -v` — full suite passes (490 passed, 3 skipped)
3. `ruff check paperbanana/ mcp_server/ tests/ scripts/` — all checks passed
4. Verify log messages are identical to the originals by inspecting the helper output format

## Checklist

- [x] `pytest tests/ -v` passes
- [x] `ruff check paperbanana/ mcp_server/ tests/ scripts/` passes
- [x] I've added/updated tests for new functionality (if applicable)
- [ ] I've updated documentation (if applicable)
- [ ] For reference dataset additions: verified methodology text matches diagram, aspect ratio is within [1.5, 2.5], metadata.json is complete
