### PR TITLE
refactor: extract _build_final_output() helper in pipeline (#154)

### DIFF
--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -921,9 +921,7 @@ class PaperBananaPipeline:
                 save_json(diagram_ir.model_dump(), self._run_dir / "diagram_ir.json")
                 save_svg_from_ir(diagram_ir, final_output_path)
             else:
-                save_raster_wrapped_svg(
-                    iterations[-1].image_path, final_output_path
-                )
+                save_raster_wrapped_svg(iterations[-1].image_path, final_output_path)
 
         # ── Caption Generation (optional) ─────────────────────────────
         generated_caption, caption_seconds = await self._generate_caption(
@@ -1278,9 +1276,7 @@ class PaperBananaPipeline:
                 save_json(diagram_ir.model_dump(), run_dir / "diagram_ir.json")
                 save_svg_from_ir(diagram_ir, final_output_path)
             else:
-                save_raster_wrapped_svg(
-                    iterations[-1].image_path, final_output_path
-                )
+                save_raster_wrapped_svg(iterations[-1].image_path, final_output_path)
 
         # ── Caption Generation (optional) ─────────────────────────────
         generated_caption, caption_seconds = await self._generate_caption(

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -345,6 +345,37 @@ class PaperBananaPipeline:
         )
         return generated_caption, caption_seconds
 
+    def _build_final_output(
+        self,
+        iterations: list[IterationRecord],
+        run_dir: Path,
+        empty_warning: str,
+    ) -> str:
+        """Derive the final output image path from the last iteration.
+
+        Resolves the output format and file extension, constructs the
+        output path, and — for raster formats — loads the last
+        iteration's image and saves it in the requested format.  SVG
+        output requires caller-side handling after this method returns.
+
+        Returns:
+            The output file path, or ``""`` when *iterations* is empty.
+        """
+        output_format = getattr(self.settings, "output_format", "png").lower()
+        ext = "jpg" if output_format == "jpeg" else output_format
+        final_output_path = str(run_dir / f"final_output.{ext}")
+
+        if iterations:
+            if output_format != "svg":
+                final_image = iterations[-1].image_path
+                img = load_image(final_image)
+                save_image(img, final_output_path, format=output_format)
+        else:
+            final_output_path = ""
+            logger.warning(empty_warning, run_id=self.run_id)
+
+        return final_output_path
+
     async def _resolve_retrieval_candidates(
         self, input: GenerationInput, candidates: list[ReferenceExample]
     ) -> tuple[list[ReferenceExample], str, list[str]]:
@@ -858,49 +889,41 @@ class PaperBananaPipeline:
 
         # Final output
         output_format = getattr(self.settings, "output_format", "png").lower()
-        ext = "jpg" if output_format == "jpeg" else output_format
-        final_output_path = str(self._run_dir / f"final_output.{ext}")
+        final_output_path = self._build_final_output(
+            iterations,
+            self._run_dir,
+            "No iterations completed — budget exceeded during planning phases",
+        )
         ir_planner_status: str | None = None
         ir_planner_error: str | None = None
 
-        if iterations:
-            final_image = iterations[-1].image_path
-            if output_format == "svg":
-                if input.diagram_type == DiagramType.METHODOLOGY:
-                    try:
-                        diagram_ir = await self.ir_planner.run(
-                            source_context=input.source_context,
-                            caption=input.communicative_intent,
-                            styled_description=current_description,
-                        )
-                        ir_planner_status = "success"
-                        logger.info("IR planner produced structured diagram IR")
-                    except Exception as e:
-                        ir_planner_status = "fallback"
-                        ir_planner_error = str(e)
-                        logger.warning(
-                            "IR planner failed; falling back to heuristic IR",
-                            error=str(e),
-                        )
-                        diagram_ir = extract_diagram_ir(
-                            current_description,
-                            title=input.communicative_intent or "Methodology Diagram",
-                        )
-                    save_json(diagram_ir.model_dump(), self._run_dir / "diagram_ir.json")
-                    save_svg_from_ir(diagram_ir, final_output_path)
-                else:
-                    save_raster_wrapped_svg(final_image, final_output_path)
+        if iterations and output_format == "svg":
+            if input.diagram_type == DiagramType.METHODOLOGY:
+                try:
+                    diagram_ir = await self.ir_planner.run(
+                        source_context=input.source_context,
+                        caption=input.communicative_intent,
+                        styled_description=current_description,
+                    )
+                    ir_planner_status = "success"
+                    logger.info("IR planner produced structured diagram IR")
+                except Exception as e:
+                    ir_planner_status = "fallback"
+                    ir_planner_error = str(e)
+                    logger.warning(
+                        "IR planner failed; falling back to heuristic IR",
+                        error=str(e),
+                    )
+                    diagram_ir = extract_diagram_ir(
+                        current_description,
+                        title=input.communicative_intent or "Methodology Diagram",
+                    )
+                save_json(diagram_ir.model_dump(), self._run_dir / "diagram_ir.json")
+                save_svg_from_ir(diagram_ir, final_output_path)
             else:
-                # Load and save in desired format (handles PNG→JPEG/WebP conversion)
-                img = load_image(final_image)
-                save_image(img, final_output_path, format=output_format)
-        else:
-            # Budget exceeded before any iteration could complete
-            final_output_path = ""
-            logger.warning(
-                "No iterations completed — budget exceeded during planning phases",
-                run_id=self.run_id,
-            )
+                save_raster_wrapped_svg(
+                    iterations[-1].image_path, final_output_path
+                )
 
         # ── Caption Generation (optional) ─────────────────────────────
         generated_caption, caption_seconds = await self._generate_caption(
@@ -1223,48 +1246,41 @@ class PaperBananaPipeline:
 
         # Final output
         output_format = getattr(self.settings, "output_format", "png").lower()
-        ext = "jpg" if output_format == "jpeg" else output_format
-        final_output_path = str(run_dir / f"final_output.{ext}")
+        final_output_path = self._build_final_output(
+            iterations,
+            run_dir,
+            "No iterations completed — budget exceeded before first iteration",
+        )
         ir_planner_status: str | None = None
         ir_planner_error: str | None = None
 
-        if iterations:
-            final_image = iterations[-1].image_path
-            if output_format == "svg":
-                if resume_state.diagram_type == DiagramType.METHODOLOGY:
-                    try:
-                        diagram_ir = await self.ir_planner.run(
-                            source_context=resume_state.source_context,
-                            caption=resume_state.communicative_intent,
-                            styled_description=current_description,
-                        )
-                        ir_planner_status = "success"
-                        logger.info("IR planner produced structured diagram IR")
-                    except Exception as e:
-                        ir_planner_status = "fallback"
-                        ir_planner_error = str(e)
-                        logger.warning(
-                            "IR planner failed; falling back to heuristic IR",
-                            error=str(e),
-                        )
-                        diagram_ir = extract_diagram_ir(
-                            current_description,
-                            title=resume_state.communicative_intent or "Methodology Diagram",
-                        )
-                    save_json(diagram_ir.model_dump(), run_dir / "diagram_ir.json")
-                    save_svg_from_ir(diagram_ir, final_output_path)
-                else:
-                    save_raster_wrapped_svg(final_image, final_output_path)
+        if iterations and output_format == "svg":
+            if resume_state.diagram_type == DiagramType.METHODOLOGY:
+                try:
+                    diagram_ir = await self.ir_planner.run(
+                        source_context=resume_state.source_context,
+                        caption=resume_state.communicative_intent,
+                        styled_description=current_description,
+                    )
+                    ir_planner_status = "success"
+                    logger.info("IR planner produced structured diagram IR")
+                except Exception as e:
+                    ir_planner_status = "fallback"
+                    ir_planner_error = str(e)
+                    logger.warning(
+                        "IR planner failed; falling back to heuristic IR",
+                        error=str(e),
+                    )
+                    diagram_ir = extract_diagram_ir(
+                        current_description,
+                        title=resume_state.communicative_intent or "Methodology Diagram",
+                    )
+                save_json(diagram_ir.model_dump(), run_dir / "diagram_ir.json")
+                save_svg_from_ir(diagram_ir, final_output_path)
             else:
-                img = load_image(final_image)
-                save_image(img, final_output_path, format=output_format)
-        else:
-            # Budget exceeded before any iteration could complete
-            final_output_path = ""
-            logger.warning(
-                "No iterations completed — budget exceeded before first iteration",
-                run_id=self.run_id,
-            )
+                save_raster_wrapped_svg(
+                    iterations[-1].image_path, final_output_path
+                )
 
         # ── Caption Generation (optional) ─────────────────────────────
         generated_caption, caption_seconds = await self._generate_caption(

--- a/tests/test_pipeline/test_build_final_output.py
+++ b/tests/test_pipeline/test_build_final_output.py
@@ -1,0 +1,240 @@
+"""Tests for _build_final_output() helper (issue #154)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from paperbanana.core.config import Settings
+from paperbanana.core.pipeline import PaperBananaPipeline
+from paperbanana.core.types import CritiqueResult, IterationRecord
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+class _StubVLM:
+    name = "stub-vlm"
+    model_name = "stub-model"
+
+    async def generate(self, *args, **kwargs):
+        return "stub"
+
+
+class _StubImageGen:
+    name = "stub-image-gen"
+    model_name = "stub-image-model"
+
+    async def generate(self, *args, **kwargs):
+        return Image.new("RGB", (64, 64), color=(0, 0, 0))
+
+
+def _make_pipeline(tmp_path: Path, output_format: str = "png") -> PaperBananaPipeline:
+    settings = Settings(
+        reference_set_path=str(tmp_path / "refs"),
+        output_dir=str(tmp_path / "out"),
+        refinement_iterations=1,
+        save_iterations=False,
+        output_format=output_format,
+    )
+    return PaperBananaPipeline(
+        settings=settings,
+        vlm_client=_StubVLM(),
+        image_gen_fn=_StubImageGen(),
+    )
+
+
+def _create_source_image(path: Path) -> str:
+    """Create a minimal PNG on disk and return its string path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (32, 32), color=(128, 128, 128)).save(str(path))
+    return str(path)
+
+
+def _make_iteration(image_path: str, iteration: int = 1) -> IterationRecord:
+    return IterationRecord(
+        iteration=iteration,
+        description="test description",
+        image_path=image_path,
+        critique=CritiqueResult(critic_suggestions=[], revised_description=None),
+    )
+
+
+# ── Tests: return value & file creation ─────────────────────────────
+
+
+def test_returns_png_path_and_creates_file(tmp_path):
+    """With iterations and default format, returns .png path and writes file."""
+    pipeline = _make_pipeline(tmp_path, output_format="png")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    src = _create_source_image(run_dir / "iter_1.png")
+
+    result = pipeline._build_final_output(
+        [_make_iteration(src)],
+        run_dir,
+        "should not appear",
+    )
+
+    assert result == str(run_dir / "final_output.png")
+    assert Path(result).exists()
+
+
+def test_jpeg_format_uses_jpg_extension(tmp_path):
+    """output_format='jpeg' produces a .jpg extension."""
+    pipeline = _make_pipeline(tmp_path, output_format="jpeg")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    src = _create_source_image(run_dir / "iter_1.png")
+
+    result = pipeline._build_final_output(
+        [_make_iteration(src)],
+        run_dir,
+        "should not appear",
+    )
+
+    assert result.endswith(".jpg")
+    assert Path(result).exists()
+
+
+def test_webp_format(tmp_path):
+    """output_format='webp' produces a .webp file."""
+    pipeline = _make_pipeline(tmp_path, output_format="webp")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    src = _create_source_image(run_dir / "iter_1.png")
+
+    result = pipeline._build_final_output(
+        [_make_iteration(src)],
+        run_dir,
+        "should not appear",
+    )
+
+    assert result.endswith(".webp")
+    assert Path(result).exists()
+
+
+def test_uses_last_iteration_image(tmp_path):
+    """When multiple iterations exist, the *last* one is used."""
+    pipeline = _make_pipeline(tmp_path, output_format="png")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    # Two source images with different colours so we can distinguish them.
+    img1_path = run_dir / "iter_1.png"
+    Image.new("RGB", (32, 32), color=(255, 0, 0)).save(str(img1_path))
+    img2_path = run_dir / "iter_2.png"
+    Image.new("RGB", (32, 32), color=(0, 255, 0)).save(str(img2_path))
+
+    result = pipeline._build_final_output(
+        [
+            _make_iteration(str(img1_path), iteration=1),
+            _make_iteration(str(img2_path), iteration=2),
+        ],
+        run_dir,
+        "should not appear",
+    )
+
+    # Verify the final output matches the second image's colour.
+    final_img = Image.open(result)
+    r, g, b = final_img.getpixel((0, 0))
+    assert g > r  # green channel dominant — from iter_2
+
+
+# ── Tests: empty iterations ─────────────────────────────────────────
+
+
+def test_empty_iterations_returns_empty_string(tmp_path):
+    """No iterations → returns empty string."""
+    pipeline = _make_pipeline(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    result = pipeline._build_final_output([], run_dir, "budget warning")
+
+    assert result == ""
+
+
+def test_empty_iterations_logs_warning(tmp_path, capsys):
+    """No iterations → warning message is logged."""
+    pipeline = _make_pipeline(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    pipeline._build_final_output([], run_dir, "budget exceeded during test")
+
+    captured = capsys.readouterr()
+    assert "budget exceeded during test" in captured.out
+
+
+# ── Tests: SVG format skips raster save ─────────────────────────────
+
+
+def test_svg_format_skips_raster_save(tmp_path):
+    """output_format='svg' returns the path but does NOT write a raster file."""
+    pipeline = _make_pipeline(tmp_path, output_format="png")
+    # SVG bypasses the Settings validator; set it post-construction like the
+    # existing SVG tests in test_output_format.py do.
+    pipeline.settings.output_format = "svg"
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    src = _create_source_image(run_dir / "iter_1.png")
+
+    result = pipeline._build_final_output(
+        [_make_iteration(src)],
+        run_dir,
+        "should not appear",
+    )
+
+    assert result.endswith(".svg")
+    # Helper must NOT write the file — SVG saving is caller's responsibility.
+    assert not Path(result).exists()
+
+
+# ── Tests: run_dir is respected ─────────────────────────────────────
+
+
+def test_output_written_to_given_run_dir(tmp_path):
+    """The file is created inside the provided run_dir, not elsewhere."""
+    pipeline = _make_pipeline(tmp_path, output_format="png")
+    custom_dir = tmp_path / "custom" / "dir"
+    custom_dir.mkdir(parents=True)
+    src = _create_source_image(custom_dir / "source.png")
+
+    result = pipeline._build_final_output(
+        [_make_iteration(src)],
+        custom_dir,
+        "should not appear",
+    )
+
+    assert Path(result).parent == custom_dir
+    assert Path(result).exists()
+
+
+# ── Tests: signature matches issue #154 ─────────────────────────────
+
+
+def test_method_is_synchronous(tmp_path):
+    """_build_final_output is a regular method, not async."""
+    pipeline = _make_pipeline(tmp_path)
+    import inspect
+
+    assert not inspect.iscoroutinefunction(pipeline._build_final_output)
+
+
+def test_return_type_is_str(tmp_path):
+    """Return value is a plain str, not a tuple or other type."""
+    pipeline = _make_pipeline(tmp_path)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    src = _create_source_image(run_dir / "iter_1.png")
+
+    result = pipeline._build_final_output(
+        [_make_iteration(src)],
+        run_dir,
+        "warn",
+    )
+
+    assert isinstance(result, str)

--- a/tests/test_pipeline/test_build_final_output.py
+++ b/tests/test_pipeline/test_build_final_output.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 from PIL import Image
 
 from paperbanana.core.config import Settings
 from paperbanana.core.pipeline import PaperBananaPipeline
 from paperbanana.core.types import CritiqueResult, IterationRecord
-
 
 # ── Helpers ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Extract `_build_final_output()` helper in `PaperBananaPipeline` to eliminate duplicated final-output logic between `generate()` and `continue_run()`. Fixes #154

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Reference dataset addition
- [ ] Documentation update
- [x] Refactor (no functional change)
- [ ] New provider support

## Changes made

- Add `_build_final_output(self, iterations, run_dir, empty_warning) -> str` private helper that resolves output format, maps `jpeg` → `.jpg` extension, constructs the output path, performs raster image conversion (PNG/JPEG/WebP), and handles the empty-iterations fallback
- Replace duplicated final-output blocks in `generate()` and `continue_run()` with calls to the new helper
- SVG-specific logic (IR planner, raster-wrapped SVG) remains inline at each call site since it requires `async` and context-specific parameters
- Add 10 unit tests in `tests/test_pipeline/test_build_final_output.py` covering all branches: PNG/JPEG/WebP creation, last-iteration selection, empty-iterations warning, SVG skip behavior, `run_dir` isolation, and signature contract (synchronous, returns `str`)

## How to test

1. `uv run pytest tests/test_pipeline/test_build_final_output.py -v` — 10 new tests pass
2. `uv run pytest tests/ -v` — full suite passes (538 passed, 3 skipped, no behavioral changes)

## Checklist

- [x] `pytest tests/ -v` passes
- [x] `ruff check paperbanana/ mcp_server/ tests/ scripts/` passes
- [x] I've added/updated tests for new functionality (if applicable)
- [ ] I've updated documentation (if applicable)
- [ ] For reference dataset additions: verified methodology text matches diagram, aspect ratio is within [1.5, 2.5], metadata.json is complete
