### PR TITLE
feat: add paperbanana references command to inspect built-in examples

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -39,6 +39,14 @@ data_app = typer.Typer(
 )
 app.add_typer(data_app, name="data")
 
+# ── References subcommand group ──────────────────────────────────
+references_app = typer.Typer(
+    name="references",
+    help="Inspect built-in reference examples (list, show, categories).",
+    no_args_is_help=True,
+)
+app.add_typer(references_app, name="references")
+
 
 def _require_pdf_dep() -> None:
     """Raise a clean error if PyMuPDF is not installed."""
@@ -2676,6 +2684,132 @@ def clear():
 
     dm.clear()
     console.print("[green]Cached reference set cleared.[/green]")
+
+
+# ── References subcommands ────────────────────────────────────────
+
+
+@references_app.command(name="list")
+def references_list(
+    category: Optional[str] = typer.Option(
+        None,
+        "--category",
+        "-c",
+        help="Filter by category (e.g. nlp_language, vision_perception).",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+):
+    """List all available reference examples."""
+    from paperbanana.reference.store import ReferenceStore
+
+    settings = Settings()
+    store = ReferenceStore.from_settings(settings)
+    examples = store.get_by_category(category) if category else store.get_all()
+
+    if not examples:
+        if category:
+            console.print(f"No references found for category [bold]{category}[/bold].")
+        else:
+            console.print("No reference examples found.")
+        raise typer.Exit(0)
+
+    if json_output:
+        rows = [
+            {
+                "id": e.id,
+                "category": e.category or "",
+                "caption": e.caption[:120],
+                "aspect_ratio": e.aspect_ratio,
+            }
+            for e in examples
+        ]
+        console.print_json(json_mod.dumps(rows))
+        return
+
+    table = Table(title=f"Reference Examples ({len(examples)})")
+    table.add_column("ID", style="cyan", no_wrap=True)
+    table.add_column("Category", style="green")
+    table.add_column("Caption", max_width=60)
+    table.add_column("AR", justify="right")
+    for e in examples:
+        caption_short = (e.caption[:57] + "...") if len(e.caption) > 60 else e.caption
+        table.add_row(
+            e.id,
+            e.category or "—",
+            caption_short,
+            f"{e.aspect_ratio:.2f}" if e.aspect_ratio else "—",
+        )
+    console.print(table)
+
+
+@references_app.command(name="show")
+def references_show(
+    example_id: str = typer.Argument(help="Reference example ID to display."),
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+):
+    """Show details of a specific reference example."""
+    from paperbanana.reference.store import ReferenceStore
+
+    settings = Settings()
+    store = ReferenceStore.from_settings(settings)
+    example = store.get_by_id(example_id)
+
+    if example is None:
+        console.print(f"[red]Error:[/red] No reference found with ID [bold]{example_id}[/bold].")
+        raise typer.Exit(1)
+
+    if json_output:
+        console.print_json(json_mod.dumps(example.model_dump(), default=str))
+        return
+
+    lines = [
+        f"[bold]ID:[/bold]           {example.id}",
+        f"[bold]Category:[/bold]     {example.category or '—'}",
+        f"[bold]Aspect Ratio:[/bold] {example.aspect_ratio or '—'}",
+        f"[bold]Image Path:[/bold]   {example.image_path}",
+        f"\n[bold]Caption:[/bold]\n{example.caption}",
+    ]
+    if example.source_context:
+        ctx = example.source_context
+        if len(ctx) > 500:
+            ctx = ctx[:500] + "…"
+        lines.append(f"\n[bold]Source Context (excerpt):[/bold]\n[dim]{ctx}[/dim]")
+
+    console.print(Panel("\n".join(lines), title=f"Reference — {example.id}", border_style="blue"))
+
+
+@references_app.command(name="categories")
+def references_categories(
+    json_output: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
+):
+    """List reference categories and example counts."""
+    from paperbanana.reference.store import ReferenceStore
+
+    settings = Settings()
+    store = ReferenceStore.from_settings(settings)
+    examples = store.get_all()
+
+    if not examples:
+        console.print("No reference examples found.")
+        raise typer.Exit(0)
+
+    counts: dict[str, int] = {}
+    for e in examples:
+        cat = e.category or "uncategorized"
+        counts[cat] = counts.get(cat, 0) + 1
+
+    if json_output:
+        console.print_json(json_mod.dumps(counts))
+        return
+
+    table = Table(title="Reference Categories")
+    table.add_column("Category", style="cyan")
+    table.add_column("Count", justify="right", style="green")
+    for cat in sorted(counts):
+        table.add_row(cat, str(counts[cat]))
+    table.add_section()
+    table.add_row("[bold]Total[/bold]", f"[bold]{sum(counts.values())}[/bold]")
+    console.print(table)
 
 
 @app.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -654,3 +654,147 @@ def test_evaluate_plot_rejects_missing_data_file(tmp_path):
     )
     assert result.exit_code == 1
     assert "Data file not found" in result.output
+
+
+# ── References subcommand tests ──────────────────────────────────
+
+
+def _build_reference_store(tmp_path, examples=None):
+    """Create a minimal reference store for testing."""
+    store_dir = tmp_path / "ref_store"
+    store_dir.mkdir()
+    (store_dir / "images").mkdir()
+
+    if examples is None:
+        examples = [
+            {
+                "id": "2404.00001v1",
+                "source_context": "Methodology section text.",
+                "caption": "Overview of our model architecture.",
+                "image_path": "images/2404.00001v1.jpg",
+                "category": "nlp_language",
+                "aspect_ratio": 1.5,
+            },
+            {
+                "id": "2404.00002v1",
+                "source_context": "Another methodology section.",
+                "caption": "Training pipeline for the vision model.",
+                "image_path": "images/2404.00002v1.jpg",
+                "category": "vision_perception",
+                "aspect_ratio": 2.0,
+            },
+            {
+                "id": "2404.00003v1",
+                "source_context": "Third methodology section.",
+                "caption": "Agent reasoning framework.",
+                "image_path": "images/2404.00003v1.jpg",
+                "category": "nlp_language",
+                "aspect_ratio": 1.0,
+            },
+        ]
+
+    data = {
+        "metadata": {
+            "name": "test",
+            "version": "1.0.0",
+            "categories": list({e["category"] for e in examples}),
+            "total_examples": len(examples),
+        },
+        "examples": examples,
+    }
+    (store_dir / "index.json").write_text(json.dumps(data), encoding="utf-8")
+    return store_dir
+
+
+def test_references_list(tmp_path, monkeypatch):
+    """references list prints a table with all examples."""
+    store_dir = _build_reference_store(tmp_path)
+    monkeypatch.setenv("REFERENCE_SET_PATH", str(store_dir))
+
+    result = runner.invoke(app, ["references", "list"])
+    assert result.exit_code == 0
+    assert "2404.00001v1" in result.output
+    assert "2404.00002v1" in result.output
+    assert "2404.00003v1" in result.output
+    assert "3" in result.output  # count in title
+
+
+def test_references_list_filter_by_category(tmp_path, monkeypatch):
+    """references list --category filters correctly."""
+    store_dir = _build_reference_store(tmp_path)
+    monkeypatch.setenv("REFERENCE_SET_PATH", str(store_dir))
+
+    result = runner.invoke(app, ["references", "list", "--category", "vision_perception"])
+    assert result.exit_code == 0
+    assert "2404.00002v1" in result.output
+    assert "2404.00001v1" not in result.output
+
+
+def test_references_list_json(tmp_path, monkeypatch):
+    """references list --json emits valid JSON."""
+    store_dir = _build_reference_store(tmp_path)
+    monkeypatch.setenv("REFERENCE_SET_PATH", str(store_dir))
+
+    result = runner.invoke(app, ["references", "list", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 3
+    assert all("id" in item for item in data)
+
+
+def test_references_show(tmp_path, monkeypatch):
+    """references show displays details for a specific example."""
+    store_dir = _build_reference_store(tmp_path)
+    monkeypatch.setenv("REFERENCE_SET_PATH", str(store_dir))
+
+    result = runner.invoke(app, ["references", "show", "2404.00001v1"])
+    assert result.exit_code == 0
+    assert "2404.00001v1" in result.output
+    assert "nlp_language" in result.output
+    assert "Overview of our model architecture" in result.output
+
+
+def test_references_show_not_found(tmp_path, monkeypatch):
+    """references show exits 1 for unknown ID."""
+    store_dir = _build_reference_store(tmp_path)
+    monkeypatch.setenv("REFERENCE_SET_PATH", str(store_dir))
+
+    result = runner.invoke(app, ["references", "show", "nonexistent"])
+    assert result.exit_code == 1
+    assert "No reference found" in result.output
+
+
+def test_references_show_json(tmp_path, monkeypatch):
+    """references show --json emits valid JSON."""
+    store_dir = _build_reference_store(tmp_path)
+    monkeypatch.setenv("REFERENCE_SET_PATH", str(store_dir))
+
+    result = runner.invoke(app, ["references", "show", "2404.00001v1", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["id"] == "2404.00001v1"
+    assert data["category"] == "nlp_language"
+
+
+def test_references_categories(tmp_path, monkeypatch):
+    """references categories shows category counts."""
+    store_dir = _build_reference_store(tmp_path)
+    monkeypatch.setenv("REFERENCE_SET_PATH", str(store_dir))
+
+    result = runner.invoke(app, ["references", "categories"])
+    assert result.exit_code == 0
+    assert "nlp_language" in result.output
+    assert "vision_perception" in result.output
+    assert "3" in result.output  # total
+
+
+def test_references_categories_json(tmp_path, monkeypatch):
+    """references categories --json emits valid JSON with counts."""
+    store_dir = _build_reference_store(tmp_path)
+    monkeypatch.setenv("REFERENCE_SET_PATH", str(store_dir))
+
+    result = runner.invoke(app, ["references", "categories", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["nlp_language"] == 2
+    assert data["vision_perception"] == 1


### PR DESCRIPTION
## Summary
- Add `paperbanana references` CLI command group with three subcommands: `list`, `show <id>`, and `categories`
- All subcommands support `--json` for machine-readable output
- `list` supports `--category`/`-c` to filter by category
- Add 8 tests covering all subcommands, filters, JSON output, and error handling

## Test plan
- [x] Run `paperbanana references list` and verify table output with all examples
- [x] Run `paperbanana references list --category nlp_language` and verify filtered results
- [x] Run `paperbanana references list --json` and verify valid JSON output
- [x] Run `paperbanana references show <id>` and verify detail panel
- [x] Run `paperbanana references show nonexistent` and verify error exit
- [x] Run `paperbanana references categories` and verify category counts
- [x] Run `pytest tests/test_cli.py -k references` to verify all 8 new tests pass

Closes #161