### PR TITLE
feat: add manual reference selection override for diagram generation

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -178,6 +178,11 @@ def generate(
         "--auto-download-data",
         help="Auto-download curated expansion reference set on first run if not cached",
     ),
+    reference_ids: Optional[str] = typer.Option(
+        None,
+        "--reference-ids",
+        help="Comma-separated reference example IDs to use (bypasses automatic retrieval)",
+    ),
     exemplar_retrieval: bool = typer.Option(
         False,
         "--exemplar-retrieval",
@@ -455,11 +460,15 @@ def generate(
         raise typer.Exit(1)
 
     # Build generation input
+    ref_id_list = None
+    if reference_ids:
+        ref_id_list = [rid.strip() for rid in reference_ids.split(",") if rid.strip()]
     gen_input = GenerationInput(
         source_context=source_context,
         communicative_intent=caption,
         diagram_type=DiagramType.METHODOLOGY,
         aspect_ratio=aspect_ratio,
+        reference_ids=ref_id_list,
     )
 
     # Determine expected output file extension based on settings.output_format

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -521,24 +521,49 @@ class PaperBananaPipeline:
         )
         self._emit_progress("phase1_retrieval_started")
         retrieval_start = time.perf_counter()
-        candidates = self.reference_store.get_all()
-        (
-            candidates,
-            retrieval_mode,
-            external_candidate_ids,
-        ) = await self._resolve_retrieval_candidates(input, candidates)
-        if retrieval_mode == "external_only":
-            examples = candidates[: self.settings.num_retrieval_examples]
-        else:
-            examples = await _call_with_retry(
-                "retriever",
-                self.retriever.run,
-                source_context=input.source_context,
-                caption=input.communicative_intent,
-                candidates=candidates,
-                num_examples=self.settings.num_retrieval_examples,
-                diagram_type=input.diagram_type,
+
+        if input.reference_ids:
+            # Manual override: look up each ID, skip automatic retrieval
+            examples = []
+            missing_ids = []
+            for ref_id in input.reference_ids:
+                ref = self.reference_store.get_by_id(ref_id)
+                if ref is not None:
+                    examples.append(ref)
+                else:
+                    missing_ids.append(ref_id)
+            if missing_ids:
+                raise ValueError(
+                    f"Unknown reference IDs: {', '.join(missing_ids)}. "
+                    "Use 'paperbanana references list' to see available IDs."
+                )
+            retrieval_mode = "manual_override"
+            external_candidate_ids: list[str] = list(input.reference_ids)
+            logger.info(
+                "Using manual reference ID override",
+                ids=input.reference_ids,
+                resolved=len(examples),
             )
+        else:
+            candidates = self.reference_store.get_all()
+            (
+                candidates,
+                retrieval_mode,
+                external_candidate_ids,
+            ) = await self._resolve_retrieval_candidates(input, candidates)
+            if retrieval_mode == "external_only":
+                examples = candidates[: self.settings.num_retrieval_examples]
+            else:
+                examples = await _call_with_retry(
+                    "retriever",
+                    self.retriever.run,
+                    source_context=input.source_context,
+                    caption=input.communicative_intent,
+                    candidates=candidates,
+                    num_examples=self.settings.num_retrieval_examples,
+                    diagram_type=input.diagram_type,
+                )
+
         retrieval_seconds = time.perf_counter() - retrieval_start
         _emit_progress(
             progress_callback,

--- a/paperbanana/core/types.py
+++ b/paperbanana/core/types.py
@@ -73,6 +73,14 @@ class GenerationInput(BaseModel):
             "If None, uses provider default."
         ),
     )
+    reference_ids: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Explicit reference example IDs to use, bypassing automatic retrieval. "
+            "When provided, the RetrieverAgent is skipped and these examples are "
+            "looked up directly from the ReferenceStore."
+        ),
+    )
 
     @field_validator("aspect_ratio")
     @classmethod

--- a/paperbanana/studio/app.py
+++ b/paperbanana/studio/app.py
@@ -220,6 +220,11 @@ def build_studio_app(
                     choices=ASPECT_RATIO_CHOICES,
                     value="default",
                 )
+                ref_ids = gr.Textbox(
+                    label="Reference IDs (optional)",
+                    placeholder="Comma-separated IDs, e.g. 2404.15806v1,2312.00001v1",
+                    info="Leave empty to use automatic retrieval",
+                )
                 d_log = gr.Textbox(label="Progress log", lines=18)
                 d_img = gr.Image(label="Final diagram", type="filepath")
                 d_gal = gr.Gallery(
@@ -248,6 +253,7 @@ def build_studio_app(
                     file,
                     caption,
                     aspect,
+                    ref_ids_str,
                 ):
                     _dotenv()
                     try:
@@ -258,7 +264,12 @@ def build_studio_app(
                         if not (caption or "").strip():
                             return "Caption is required.", None, []
                         log, img, gal, err = run_methodology(
-                            st, ctx, caption, aspect, verbose_logging=False
+                            st,
+                            ctx,
+                            caption,
+                            aspect,
+                            reference_ids=ref_ids_str or None,
+                            verbose_logging=False,
                         )
                         if err:
                             return log, None, gal
@@ -286,6 +297,7 @@ def build_studio_app(
                         ctx_file,
                         cap,
                         ar,
+                        ref_ids,
                     ],
                     outputs=[d_log, d_img, d_gal],
                 )

--- a/paperbanana/studio/runner.py
+++ b/paperbanana/studio/runner.py
@@ -188,6 +188,7 @@ def run_methodology(
     source_context: str,
     caption: str,
     aspect_ratio_label: str,
+    reference_ids: Optional[str] = None,
     verbose_logging: bool = False,
 ) -> tuple[str, Optional[str], list[tuple[str, str]], str]:
     """Run methodology diagram generation. Returns (log, final_path, gallery, error)."""
@@ -196,11 +197,15 @@ def run_methodology(
     log.append("Starting methodology diagram pipeline…")
     err = ""
     try:
+        ref_id_list = None
+        if reference_ids:
+            ref_id_list = [rid.strip() for rid in reference_ids.split(",") if rid.strip()]
         gen_in = GenerationInput(
             source_context=source_context,
             communicative_intent=caption.strip(),
             diagram_type=DiagramType.METHODOLOGY,
             aspect_ratio=_aspect_ratio_value(aspect_ratio_label),
+            reference_ids=ref_id_list,
         )
 
         async def _go():


### PR DESCRIPTION
## Summary
- Add `reference_ids` field to `GenerationInput` for explicit reference example selection
- CLI: `--reference-ids ref_001,ref_014` on the `generate` command
- Pipeline: skip `RetrieverAgent` when `reference_ids` is provided, look up each ID via `ReferenceStore.get_by_id()`, raise clear error for unknown IDs
- Studio: add "Reference IDs" textbox in Diagram tab, wired through runner

## Test plan
- [x] Run `paperbanana generate --reference-ids 2404.15806v1 ...` and verify retrieval is skipped and the specified example is used
- [x] Run with an invalid ID (e.g. `--reference-ids nonexistent`) and verify a clear error is raised
- [x] Run without `--reference-ids` and verify automatic retrieval still works unchanged
- [x] Open Studio, leave Reference IDs empty, generate — verify normal flow
- [x] Open Studio, enter comma-separated IDs, generate — verify manual override

Closes #162