### PR TITLE
feat: Add `--reference-category` filter to the generate command

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -256,6 +256,16 @@ def generate(
         "--generate-caption",
         help="Auto-generate a publication-ready figure caption (one extra VLM call)",
     ),
+    reference_category: Optional[str] = typer.Option(
+        None,
+        "--reference-category",
+        help=(
+            "Filter reference examples by category (comma-separated). "
+            "Valid: agent_reasoning, generative_learning, healthcare_medical, "
+            "multimodal_fusion, nlp_language, optimization_theory, robotics_control, "
+            "science_applications, systems_networking, vision_perception"
+        ),
+    ),
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Show detailed agent progress and timing"
     ),
@@ -286,6 +296,29 @@ def generate(
             "[red]Error: --pdf-pages cannot be used with --continue or --continue-run[/red]"
         )
         raise typer.Exit(1)
+
+    _valid_categories = {
+        "agent_reasoning",
+        "generative_learning",
+        "healthcare_medical",
+        "multimodal_fusion",
+        "nlp_language",
+        "optimization_theory",
+        "robotics_control",
+        "science_applications",
+        "systems_networking",
+        "vision_perception",
+    }
+    parsed_categories: Optional[list[str]] = None
+    if reference_category:
+        parsed_categories = [c.strip() for c in reference_category.split(",") if c.strip()]
+        unknown = [c for c in parsed_categories if c not in _valid_categories]
+        if unknown:
+            console.print(
+                f"[red]Error: Unknown reference category: {', '.join(unknown)}.\n"
+                f"Valid categories: {', '.join(sorted(_valid_categories))}[/red]"
+            )
+            raise typer.Exit(1)
 
     configure_logging(verbose=verbose)
 
@@ -338,6 +371,8 @@ def generate(
         overrides["prompt_dir"] = prompt_dir
     if generate_caption:
         overrides["generate_caption"] = True
+    if parsed_categories:
+        overrides["reference_category"] = parsed_categories
 
     if config:
         settings = Settings.from_yaml(config, **overrides)

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -83,6 +83,7 @@ class Settings(BaseSettings):
 
     # Reference settings
     reference_set_path: str = "data/reference_sets"
+    reference_category: Optional[list[str]] = None
     guidelines_path: str = "data/guidelines"
 
     # Cache settings
@@ -268,6 +269,7 @@ def _flatten_yaml(config: dict, prefix: str = "") -> dict:
         "pipeline.exemplar_retrieval_timeout_seconds": "exemplar_retrieval_timeout_seconds",
         "pipeline.exemplar_retrieval_max_retries": "exemplar_retrieval_max_retries",
         "reference.path": "reference_set_path",
+        "reference.category": "reference_category",
         "reference.guidelines_path": "guidelines_path",
         "pipeline.venue": "venue",
         "pipeline.vector_export": "vector_export",

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -680,7 +680,17 @@ class PaperBananaPipeline:
                 resolved=len(examples),
             )
         else:
-            candidates = self.reference_store.get_all()
+            if self.settings.reference_category:
+                candidates = self.reference_store.get_by_categories(
+                    self.settings.reference_category
+                )
+                logger.info(
+                    "Filtered candidates by category",
+                    categories=self.settings.reference_category,
+                    count=len(candidates),
+                )
+            else:
+                candidates = self.reference_store.get_all()
             (
                 candidates,
                 retrieval_mode,

--- a/paperbanana/reference/store.py
+++ b/paperbanana/reference/store.py
@@ -69,6 +69,17 @@ class ReferenceStore:
         self._load()
         return [e for e in self._examples if e.category == category]
 
+    def get_by_categories(self, categories: list[str]) -> list[ReferenceExample]:
+        """Get reference examples filtered by multiple categories."""
+        self._load()
+        cat_set = set(categories)
+        return [e for e in self._examples if e.category in cat_set]
+
+    def available_categories(self) -> list[str]:
+        """Return sorted list of distinct categories in the store."""
+        self._load()
+        return sorted({e.category for e in self._examples if e.category})
+
     def get_by_id(self, example_id: str) -> Optional[ReferenceExample]:
         """Get a specific reference example by ID."""
         self._load()

--- a/paperbanana/studio/app.py
+++ b/paperbanana/studio/app.py
@@ -11,6 +11,7 @@ from paperbanana.studio import runs as runs_mod
 from paperbanana.studio.runner import (
     ASPECT_RATIO_CHOICES,
     IMAGE_PROVIDER_CHOICES,
+    REFERENCE_CATEGORY_CHOICES,
     VLM_PROVIDER_CHOICES,
     build_settings,
     merge_context,
@@ -220,6 +221,13 @@ def build_studio_app(
                     choices=ASPECT_RATIO_CHOICES,
                     value="default",
                 )
+                ref_cat = gr.Dropdown(
+                    label="Reference category filter",
+                    choices=REFERENCE_CATEGORY_CHOICES,
+                    value="",
+                    multiselect=True,
+                    info="Constrain retrieval to specific domains (empty = all)",
+                )
                 ref_ids = gr.Textbox(
                     label="Reference IDs (optional)",
                     placeholder="Comma-separated IDs, e.g. 2404.15806v1,2312.00001v1",
@@ -253,11 +261,15 @@ def build_studio_app(
                     file,
                     caption,
                     aspect,
+                    ref_cats,
                     ref_ids_str,
                 ):
                     _dotenv()
                     try:
+                        cats = [x for x in (ref_cats or []) if x]
                         st = _settings(od, c, vp, vm, ip, im, fo, it, au, mx, op, sp, sd)
+                        if cats:
+                            st.reference_category = cats
                         ctx = merge_context(text, _upload_path(file))
                         if not ctx.strip():
                             return "Context is empty.", None, []
@@ -297,6 +309,7 @@ def build_studio_app(
                         ctx_file,
                         cap,
                         ar,
+                        ref_cat,
                         ref_ids,
                     ],
                     outputs=[d_log, d_img, d_gal],

--- a/paperbanana/studio/runner.py
+++ b/paperbanana/studio/runner.py
@@ -52,6 +52,19 @@ ASPECT_RATIO_CHOICES = [
     "16:9",
     "21:9",
 ]
+REFERENCE_CATEGORY_CHOICES = [
+    "",
+    "agent_reasoning",
+    "generative_learning",
+    "healthcare_medical",
+    "multimodal_fusion",
+    "nlp_language",
+    "optimization_theory",
+    "robotics_control",
+    "science_applications",
+    "systems_networking",
+    "vision_perception",
+]
 
 
 def read_text_file(path: str | None, max_chars: int = 500_000) -> str:
@@ -90,6 +103,7 @@ def build_settings(
     optimize_inputs: bool,
     save_prompts: bool,
     seed: Optional[int] = None,
+    reference_category: Optional[list[str]] = None,
 ) -> Settings:
     """Merge YAML config (optional), environment, and Studio overrides."""
     base_defaults = Settings()
@@ -111,6 +125,8 @@ def build_settings(
             overrides["seed"] = int(seed)
         except ValueError:
             pass
+    if reference_category:
+        overrides["reference_category"] = reference_category
 
     if config_path and str(config_path).strip():
         return Settings.from_yaml(Path(config_path).expanduser(), **overrides)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -413,6 +413,126 @@ def test_sweep_writes_report_with_mocked_pipeline(tmp_path, monkeypatch):
     assert ranked[0]["quality_proxy_score"] > ranked[1]["quality_proxy_score"]
 
 
+def test_generate_rejects_unknown_reference_category():
+    """--reference-category exits 1 with a helpful error for unknown values."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("Sample methodology text for testing.")
+        input_path = f.name
+
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--input",
+                input_path,
+                "--caption",
+                "test",
+                "--dry-run",
+                "--reference-category",
+                "bogus_category",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Unknown reference category" in result.output
+        assert "bogus_category" in result.output
+        # Error should list valid categories to help the user recover.
+        assert "vision_perception" in result.output
+        assert "nlp_language" in result.output
+    finally:
+        Path(input_path).unlink(missing_ok=True)
+
+
+def test_generate_rejects_mixed_valid_and_invalid_reference_categories():
+    """One invalid token in a comma-separated list fails validation."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("Sample methodology text for testing.")
+        input_path = f.name
+
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--input",
+                input_path,
+                "--caption",
+                "test",
+                "--dry-run",
+                "--reference-category",
+                "vision_perception,not_a_category",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "not_a_category" in result.output
+        assert "Unknown reference category" in result.output
+    finally:
+        Path(input_path).unlink(missing_ok=True)
+
+
+def test_generate_accepts_valid_reference_category():
+    """Single valid category passes validation and reaches dry-run output."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("Sample methodology text for testing.")
+        input_path = f.name
+
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--input",
+                input_path,
+                "--caption",
+                "test",
+                "--dry-run",
+                "--reference-category",
+                "vision_perception",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Dry Run" in result.output
+    finally:
+        Path(input_path).unlink(missing_ok=True)
+
+
+def test_generate_accepts_multiple_valid_reference_categories(monkeypatch):
+    """Comma-separated categories parse into a list and propagate to Settings."""
+    import paperbanana.core.config as config_mod
+
+    captured: dict[str, object] = {}
+    real_init = config_mod.Settings.__init__
+
+    def _spy_init(self, **kwargs):
+        captured["reference_category"] = kwargs.get("reference_category")
+        real_init(self, **kwargs)
+
+    monkeypatch.setattr(config_mod.Settings, "__init__", _spy_init)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("Sample methodology text for testing.")
+        input_path = f.name
+
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--input",
+                input_path,
+                "--caption",
+                "test",
+                "--dry-run",
+                "--reference-category",
+                "vision_perception, nlp_language",  # whitespace must be tolerated
+            ],
+        )
+        assert result.exit_code == 0
+        assert captured["reference_category"] == ["vision_perception", "nlp_language"]
+    finally:
+        Path(input_path).unlink(missing_ok=True)
+
+
 def test_generate_accepts_vector_flag():
     """--vector flag is accepted by the CLI in dry-run mode."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:

--- a/tests/test_pipeline/test_reference_store.py
+++ b/tests/test_pipeline/test_reference_store.py
@@ -78,6 +78,154 @@ def test_get_by_category():
         assert len(agents) == 2
 
 
+def test_get_by_categories_multiple():
+    """get_by_categories returns examples matching any of the supplied categories."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data = {
+            "examples": [
+                {
+                    "id": "r1",
+                    "source_context": "c1",
+                    "caption": "c1",
+                    "image_path": "i1",
+                    "category": "agent_reasoning",
+                },
+                {
+                    "id": "r2",
+                    "source_context": "c2",
+                    "caption": "c2",
+                    "image_path": "i2",
+                    "category": "vision_perception",
+                },
+                {
+                    "id": "r3",
+                    "source_context": "c3",
+                    "caption": "c3",
+                    "image_path": "i3",
+                    "category": "nlp_language",
+                },
+            ],
+        }
+        Path(tmpdir, "index.json").write_text(json.dumps(data))
+
+        store = ReferenceStore(tmpdir)
+        selected = store.get_by_categories(["agent_reasoning", "nlp_language"])
+        assert {e.id for e in selected} == {"r1", "r3"}
+
+
+def test_get_by_categories_empty_returns_empty():
+    """get_by_categories([]) yields no matches because the filter excludes every category."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data = {
+            "examples": [
+                {
+                    "id": "r1",
+                    "source_context": "c1",
+                    "caption": "c1",
+                    "image_path": "i1",
+                    "category": "agent_reasoning",
+                }
+            ],
+        }
+        Path(tmpdir, "index.json").write_text(json.dumps(data))
+
+        store = ReferenceStore(tmpdir)
+        assert store.get_by_categories([]) == []
+
+
+def test_get_by_categories_unknown_category():
+    """Unknown categories are silently ignored and produce no matches."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data = {
+            "examples": [
+                {
+                    "id": "r1",
+                    "source_context": "c1",
+                    "caption": "c1",
+                    "image_path": "i1",
+                    "category": "agent_reasoning",
+                }
+            ],
+        }
+        Path(tmpdir, "index.json").write_text(json.dumps(data))
+
+        store = ReferenceStore(tmpdir)
+        assert store.get_by_categories(["not_a_real_category"]) == []
+
+
+def test_get_by_categories_skips_examples_without_category():
+    """Examples whose category is None must not be matched by any filter."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data = {
+            "examples": [
+                {
+                    "id": "r1",
+                    "source_context": "c1",
+                    "caption": "c1",
+                    "image_path": "i1",
+                },  # no category field
+                {
+                    "id": "r2",
+                    "source_context": "c2",
+                    "caption": "c2",
+                    "image_path": "i2",
+                    "category": "vision_perception",
+                },
+            ],
+        }
+        Path(tmpdir, "index.json").write_text(json.dumps(data))
+
+        store = ReferenceStore(tmpdir)
+        selected = store.get_by_categories(["vision_perception"])
+        assert [e.id for e in selected] == ["r2"]
+
+
+def test_available_categories_returns_sorted_unique():
+    """available_categories returns a sorted, de-duplicated list of non-null categories."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data = {
+            "examples": [
+                {
+                    "id": "r1",
+                    "source_context": "c1",
+                    "caption": "c1",
+                    "image_path": "i1",
+                    "category": "vision_perception",
+                },
+                {
+                    "id": "r2",
+                    "source_context": "c2",
+                    "caption": "c2",
+                    "image_path": "i2",
+                    "category": "agent_reasoning",
+                },
+                {
+                    "id": "r3",
+                    "source_context": "c3",
+                    "caption": "c3",
+                    "image_path": "i3",
+                    "category": "vision_perception",
+                },
+                {
+                    "id": "r4",
+                    "source_context": "c4",
+                    "caption": "c4",
+                    "image_path": "i4",
+                },  # no category
+            ],
+        }
+        Path(tmpdir, "index.json").write_text(json.dumps(data))
+
+        store = ReferenceStore(tmpdir)
+        assert store.available_categories() == ["agent_reasoning", "vision_perception"]
+
+
+def test_available_categories_empty_store():
+    """available_categories on an empty store returns an empty list."""
+    store = ReferenceStore("/nonexistent/path")
+    assert store.available_categories() == []
+
+
 def test_get_by_id():
     """Test getting a specific example by ID."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Closes #163

### Summary
- Add `--reference-category` CLI option to `generate` command, accepting comma-separated category names (e.g. `--reference-category agent_reasoning,vision_perception`)
- Add `reference_category` field to `Settings` and YAML config support (`reference.category`)
- Filter the candidate pool in the pipeline retrieval phase using `get_by_categories()` instead of `get_all()` when categories are specified
- Add multi-select "Reference category filter" dropdown to the Studio Diagram tab
- Validate category names at the CLI level with a clear error listing valid options
- Add `get_by_categories()` and `available_categories()` helpers to `ReferenceStore`

### Valid categories
`agent_reasoning`, `generative_learning`, `healthcare_medical`, `multimodal_fusion`, `nlp_language`, `optimization_theory`, `robotics_control`, `science_applications`, `systems_networking`, `vision_perception`

### Test plan
- [x] Run `paperbanana generate --reference-category agent_reasoning -c "test" -i input.txt` and verify retrieval is scoped to that category
- [x] Run with multiple categories: `--reference-category agent_reasoning,vision_perception`
- [x] Run with an invalid category and verify the error message lists valid options
- [x] Run without `--reference-category` and verify default behavior is unchanged
- [x] Verify Studio Diagram tab shows the new dropdown and passes selection through to the pipeline