### PR TITLE
feat: add show-config command to print resolved settings (#165)

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -2741,6 +2741,54 @@ def studio(
     )
 
 
+@app.command("show-config")
+def show_config(
+    json_output: bool = typer.Option(False, "--json", help="Emit resolved config as JSON"),
+    config: Optional[str] = typer.Option(None, "--config", help="Path to config YAML file"),
+) -> None:
+    """Print the fully resolved settings (env + config file) without running generation."""
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    if config:
+        settings = Settings.from_yaml(config)
+    else:
+        settings = Settings()
+
+    # Fields containing sensitive secrets that should be masked
+    _secret_fields = {
+        "google_api_key",
+        "openrouter_api_key",
+        "openai_api_key",
+        "anthropic_api_key",
+    }
+
+    data = settings.model_dump()
+    # Mask sensitive values
+    for key in _secret_fields:
+        val = data.get(key)
+        if val:
+            data[key] = val[:4] + "****" + val[-4:] if len(val) > 8 else "****"
+
+    # Add effective (resolved) models for clarity
+    data["_effective_vlm_model"] = settings.effective_vlm_model
+    data["_effective_image_model"] = settings.effective_image_model
+
+    if json_output:
+        console.print_json(json_mod.dumps(data, indent=2, default=str))
+    else:
+        table = Table(title="Resolved PaperBanana Settings", show_lines=True)
+        table.add_column("Setting", style="cyan", no_wrap=True)
+        table.add_column("Value", style="green")
+
+        for key, value in data.items():
+            display = str(value) if value is not None else "[dim]None[/dim]"
+            table.add_row(key, display)
+
+        console.print(table)
+
+
 @app.command()
 def doctor(
     json_output: bool = typer.Option(

--- a/tests/test_show_config.py
+++ b/tests/test_show_config.py
@@ -1,0 +1,57 @@
+"""Tests for paperbanana show-config command."""
+
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from paperbanana.cli import app
+
+runner = CliRunner()
+
+
+def test_show_config_table_output():
+    result = runner.invoke(app, ["show-config"])
+    assert result.exit_code == 0
+    assert "Resolved PaperBanana Settings" in result.output
+    assert "vlm_provider" in result.output
+    assert "image_provider" in result.output
+
+
+def test_show_config_json_output():
+    result = runner.invoke(app, ["show-config", "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert "vlm_provider" in parsed
+    assert "image_provider" in parsed
+    assert "_effective_vlm_model" in parsed
+    assert "_effective_image_model" in parsed
+
+
+def test_show_config_masks_api_keys(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "sk-test-secret-key-value")
+    result = runner.invoke(app, ["show-config", "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["google_api_key"] == "sk-t****alue"
+    assert "sk-test-secret-key-value" not in result.output
+
+
+def test_show_config_masks_short_api_keys(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "short")
+    result = runner.invoke(app, ["show-config", "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["google_api_key"] == "****"
+    assert "short" not in result.output
+
+
+def test_show_config_with_yaml_config(tmp_path):
+    cfg = tmp_path / "test.yaml"
+    cfg.write_text("vlm:\n  provider: openai\n  model: gpt-4o\n")
+    result = runner.invoke(app, ["show-config", "--config", str(cfg), "--json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["vlm_provider"] == "openai"
+    assert parsed["vlm_model"] == "gpt-4o"


### PR DESCRIPTION
## Summary
- Add `paperbanana show-config` command that prints fully resolved settings (env + config file) without running generation
- Support `--json` flag for machine-readable output and `--config` for custom YAML config paths
- Mask API keys in output, with safe handling for short key values

## Test plan
- [x] `paperbanana show-config` displays a Rich table with all resolved settings
- [x] `paperbanana show-config --json` outputs valid JSON with `_effective_vlm_model` and `_effective_image_model`
- [x] API keys are masked as `first4****last4` (keys > 8 chars) or `****` (short keys)
- [x] `paperbanana show-config --config path/to/config.yaml` loads settings from the specified file
- [x] Run `pytest tests/test_show_config.py -v` — all 5 tests pass

Closes #165