### PR TITLE
feat: add sweep-report command to render sweep_report.json as Markdown or HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,16 @@ paperbanana batch-report --batch-id batch_20250109_123456_abc --format html --ou
 
 Diagram batch reports include `batch_kind: methodology`; plot batches use `batch_kind: statistical_plot`. Human-readable reports (`paperbanana batch-report`) show the batch kind when present.
 
+**Sweep reports** produced by `paperbanana sweep` can be rendered the same way:
+
+```bash
+paperbanana sweep-report --sweep-dir outputs/sweep_20250109_123456_abc --format html
+# or by sweep ID
+paperbanana sweep-report --sweep-id sweep_20250109_123456_abc --format markdown
+```
+
+Rendered sweep reports include a summary, a top-5 ranked table, the full variants table (with per-variant provider/model, iterations, critic-suggestion count, proxy score, and output path), and the `quality_proxy_score` note. Dry-run reports render a simplified "Planned Variants" section.
+
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--manifest` | `-m` | Path to manifest file (required) |

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -1349,6 +1349,68 @@ def batch_report(
         raise typer.Exit(1)
 
 
+@app.command("sweep-report")
+def sweep_report(
+    sweep_dir: Optional[str] = typer.Option(
+        None,
+        "--sweep-dir",
+        "-s",
+        help="Path to sweep run directory (e.g. outputs/sweep_20250109_123456_abc)",
+    ),
+    sweep_id: Optional[str] = typer.Option(
+        None,
+        "--sweep-id",
+        help="Sweep ID (e.g. sweep_20250109_123456_abc); resolved under --output-dir",
+    ),
+    output_dir: str = typer.Option(
+        "outputs",
+        "--output-dir",
+        "-o",
+        help="Parent directory for sweep runs (used with --sweep-id)",
+    ),
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        help="Output path for the report file (default: <sweep_dir>/sweep_report.<md|html>)",
+    ),
+    format: str = typer.Option(
+        "markdown",
+        "--format",
+        "-f",
+        help="Report format: markdown or html",
+    ),
+):
+    """Generate a human-readable report from an existing sweep run (sweep_report.json)."""
+    if format not in ("markdown", "html", "md"):
+        console.print(f"[red]Error: Format must be markdown or html. Got: {format}[/red]")
+        raise typer.Exit(1)
+    if sweep_dir is None and sweep_id is None:
+        console.print("[red]Error: Provide either --sweep-dir or --sweep-id[/red]")
+        raise typer.Exit(1)
+    if sweep_dir is not None and sweep_id is not None:
+        console.print("[red]Error: Provide only one of --sweep-dir or --sweep-id[/red]")
+        raise typer.Exit(1)
+
+    from paperbanana.core.sweep import write_sweep_report
+
+    if sweep_dir is not None:
+        path = Path(sweep_dir)
+    else:
+        path = Path(output_dir) / sweep_id
+
+    output_path = Path(output) if output else None
+    fmt = "markdown" if format == "md" else format
+    try:
+        written = write_sweep_report(path, output_path=output_path, format=fmt)
+        console.print(f"[green]Report written to:[/green] [bold]{written}[/bold]")
+    except FileNotFoundError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+
 @app.command()
 def composite(
     images: list[str] = typer.Argument(..., help="Paths to images to compose into a single figure"),

--- a/paperbanana/core/sweep.py
+++ b/paperbanana/core/sweep.py
@@ -3,9 +3,17 @@
 from __future__ import annotations
 
 import itertools
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from statistics import mean
-from typing import Any
+from typing import Any, Literal
+
+import structlog
+
+logger = structlog.get_logger()
+
+SWEEP_REPORT_FILENAME = "sweep_report.json"
 
 # Heuristic used to rank successful variants in CLI sweep reports (not a human-judgment score).
 QUALITY_PROXY_MAX = 100.0
@@ -188,3 +196,372 @@ def summarize_sweep(results: list[dict[str, Any]]) -> dict[str, Any]:
             else None
         ),
     }
+
+
+# ── Report rendering ────────────────────────────────────────────────
+
+
+def load_sweep_report(sweep_dir: Path) -> dict[str, Any]:
+    """Load sweep_report.json from a sweep output directory.
+
+    Args:
+        sweep_dir: Path to the sweep run directory (e.g. outputs/sweep_20250109_123456_abc).
+
+    Returns:
+        The report dict (sweep_id, status, results or preview, etc.).
+
+    Raises:
+        FileNotFoundError: If sweep_dir or sweep_report.json does not exist.
+        ValueError: If the JSON is invalid or missing required keys.
+    """
+    sweep_dir = Path(sweep_dir).resolve()
+    report_path = sweep_dir / SWEEP_REPORT_FILENAME
+    if not sweep_dir.exists() or not sweep_dir.is_dir():
+        raise FileNotFoundError(f"Sweep directory not found: {sweep_dir}")
+    if not report_path.exists():
+        raise FileNotFoundError(f"No {SWEEP_REPORT_FILENAME} in {sweep_dir}. Run a sweep first.")
+    raw = report_path.read_text(encoding="utf-8")
+    data = json.loads(raw)
+    if not isinstance(data, dict) or "sweep_id" not in data:
+        raise ValueError(f"Invalid report: expected dict with 'sweep_id'. Got: {type(data)}")
+    status = data.get("status")
+    if status == "dry_run":
+        if "preview" not in data:
+            raise ValueError("Dry-run report missing 'preview' key")
+    elif "results" not in data:
+        raise ValueError("Completed sweep report missing 'results' key")
+    return data
+
+
+def _provider_cell(item: dict[str, Any], which: Literal["vlm", "image"]) -> str:
+    """Format a provider/model pair into a short display string."""
+    provider = item.get(f"{which}_provider") or "—"
+    model = item.get(f"{which}_model")
+    return f"{provider} / {model}" if model else str(provider)
+
+
+def _relative_output(out: str, sweep_dir: Path) -> str:
+    """Convert an absolute output_path to a sweep-dir-relative path when possible."""
+    if not out:
+        return ""
+    p = Path(out)
+    if not p.is_absolute():
+        return out
+    try:
+        return p.relative_to(sweep_dir).as_posix()
+    except ValueError:
+        return out
+
+
+def generate_sweep_report_md(report: dict[str, Any], sweep_dir: Path) -> str:
+    """Generate a Markdown report from a sweep report dict."""
+    sweep_dir = Path(sweep_dir).resolve()
+    sweep_id = report.get("sweep_id", "sweep")
+    status = report.get("status", "completed")
+    caption = report.get("caption", "")
+    input_path = report.get("input", "")
+
+    lines = [f"# Sweep Report: {sweep_id}", ""]
+    if input_path:
+        lines.append(f"- **Input:** `{input_path}`")
+    if caption:
+        lines.append(f"- **Caption:** {caption}")
+    lines.append(f"- **Status:** {status}")
+
+    if status == "dry_run":
+        total = report.get("total_variants", len(report.get("preview", [])))
+        lines.extend(
+            [
+                f"- **Planned variants:** {total}",
+                "",
+                "## Planned Variants (preview)",
+                "",
+                "| Variant | VLM | Image | Iters | Optimize | Auto-refine |",
+                "|---------|-----|-------|-------|----------|-------------|",
+            ]
+        )
+        for item in report.get("preview", []):
+            lines.append(
+                f"| {item.get('variant_id', '—')} "
+                f"| {_provider_cell(item, 'vlm').replace('|', '\\|')} "
+                f"| {_provider_cell(item, 'image').replace('|', '\\|')} "
+                f"| {item.get('refinement_iterations', '—')} "
+                f"| {item.get('optimize_inputs', '—')} "
+                f"| {item.get('auto_refine', '—')} |"
+            )
+        return "\n".join(lines)
+
+    summary = report.get("summary") or {}
+    total_seconds = float(report.get("total_seconds") or 0.0)
+    best_score = summary.get("best_quality_proxy_score")
+    mean_score = summary.get("mean_quality_proxy_score")
+    lines.extend(
+        [
+            f"- **Completed:** {summary.get('completed', 0)}",
+            f"- **Failed:** {summary.get('failed', 0)}",
+            f"- **Best variant:** {summary.get('best_variant') or '—'}",
+            f"- **Best score:** {best_score if best_score is not None else '—'}",
+            f"- **Mean score:** {mean_score if mean_score is not None else '—'}",
+            f"- **Total seconds:** {total_seconds:.1f}",
+        ]
+    )
+
+    ranked = report.get("ranked_results") or []
+    top_n = ranked[: min(5, len(ranked))]
+    if top_n:
+        lines.extend(
+            [
+                "",
+                "## Top Variants (ranked)",
+                "",
+                "| Rank | Variant | VLM | Image | Iters | Suggestions | Score | Seconds |",
+                "|------|---------|-----|-------|-------|-------------|-------|---------|",
+            ]
+        )
+        for rank, item in enumerate(top_n, start=1):
+            lines.append(
+                f"| {rank} "
+                f"| {item.get('variant_id', '—')} "
+                f"| {_provider_cell(item, 'vlm').replace('|', '\\|')} "
+                f"| {_provider_cell(item, 'image').replace('|', '\\|')} "
+                f"| {item.get('iterations_used', '—')} "
+                f"| {item.get('critic_suggestions', '—')} "
+                f"| {item.get('quality_proxy_score', '—')} "
+                f"| {item.get('total_seconds', '—')} |"
+            )
+
+    header = (
+        "| Variant | VLM | Image | Status | Iters | Suggestions | "
+        "Score | Seconds | Output / Error |"
+    )
+    divider = (
+        "|---------|-----|-------|--------|-------|-------------|"
+        "-------|---------|----------------|"
+    )
+    lines.extend(["", "## All Variants", "", header, divider])
+    for item in report.get("results", []):
+        vid = item.get("variant_id", "—")
+        vlm = _provider_cell(item, "vlm").replace("|", "\\|")
+        img = _provider_cell(item, "image").replace("|", "\\|")
+        if item.get("status") == "success":
+            status_cell = "✓ Success"
+            iters = item.get("iterations_used", "—")
+            suggestions = item.get("critic_suggestions", "—")
+            score = item.get("quality_proxy_score", "—")
+            seconds = item.get("total_seconds", "—")
+            out = _relative_output(item.get("output_path") or "", sweep_dir)
+            out_cell = f"`{out.replace('|', '\\|')}`" if out else "—"
+            lines.append(
+                f"| {vid} | {vlm} | {img} | {status_cell} | {iters} "
+                f"| {suggestions} | {score} | {seconds} | {out_cell} |"
+            )
+        else:
+            status_cell = "✗ Failed"
+            err = (item.get("error") or "unknown").replace("|", "\\|")[:80]
+            lines.append(f"| {vid} | {vlm} | {img} | {status_cell} | — | — | — | — | {err} |")
+
+    note = report.get("quality_proxy_note")
+    if note:
+        lines.extend(["", f"> **Note:** {note}"])
+
+    return "\n".join(lines)
+
+
+def generate_sweep_report_html(report: dict[str, Any], sweep_dir: Path) -> str:
+    """Generate an HTML report from a sweep report dict."""
+    sweep_dir = Path(sweep_dir).resolve()
+    sweep_id = report.get("sweep_id", "sweep")
+    status = report.get("status", "completed")
+    caption = report.get("caption", "")
+    input_path = report.get("input", "")
+
+    def escape(s: str) -> str:
+        return (
+            str(s)
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+        )
+
+    style = """
+    body { font-family: system-ui, sans-serif; margin: 1rem 2rem; max-width: 1100px; }
+    h1 { font-size: 1.25rem; color: #333; }
+    h2 { font-size: 1.05rem; color: #444; margin-top: 1.5rem; }
+    .meta { color: #666; margin-bottom: 1rem; }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 1rem; }
+    th, td {
+      border: 1px solid #ddd; padding: 0.4rem 0.6rem;
+      text-align: left; font-size: 0.9rem;
+    }
+    th { background: #f5f5f5; font-weight: 600; }
+    .status.success { color: #0a0; font-weight: 600; }
+    .status.fail { color: #c00; font-weight: 600; }
+    .note {
+      color: #555; background: #fafafa; padding: 0.5rem 0.75rem;
+      border-left: 3px solid #ccc;
+    }
+    a { color: #06c; }
+    """
+
+    meta_lines = []
+    if input_path:
+        meta_lines.append(f"Input: <code>{escape(input_path)}</code>")
+    if caption:
+        meta_lines.append(f"Caption: {escape(caption)}")
+    meta_lines.append(f"Status: <strong>{escape(status)}</strong>")
+
+    if status == "dry_run":
+        total = report.get("total_variants", len(report.get("preview", [])))
+        meta_lines.append(f"Planned variants: <strong>{escape(str(total))}</strong>")
+        rows = []
+        for item in report.get("preview", []):
+            rows.append(
+                f"<tr><td>{escape(item.get('variant_id', '—'))}</td>"
+                f"<td>{escape(_provider_cell(item, 'vlm'))}</td>"
+                f"<td>{escape(_provider_cell(item, 'image'))}</td>"
+                f"<td>{escape(str(item.get('refinement_iterations', '—')))}</td>"
+                f"<td>{escape(str(item.get('optimize_inputs', '—')))}</td>"
+                f"<td>{escape(str(item.get('auto_refine', '—')))}</td></tr>"
+            )
+        preview_body = "\n".join(rows)
+        body = f"""
+  <h2>Planned Variants (preview)</h2>
+  <table>
+    <thead><tr><th>Variant</th><th>VLM</th><th>Image</th><th>Iters</th><th>Optimize</th>
+    <th>Auto-refine</th></tr></thead>
+    <tbody>
+{preview_body}
+    </tbody>
+  </table>
+"""
+    else:
+        summary = report.get("summary") or {}
+        total_seconds = float(report.get("total_seconds") or 0.0)
+        best_variant = summary.get("best_variant") or "—"
+        mean_score = summary.get("mean_quality_proxy_score") or "—"
+        meta_lines.extend(
+            [
+                f"Completed: <strong>{escape(str(summary.get('completed', 0)))}</strong>",
+                f"Failed: <strong>{escape(str(summary.get('failed', 0)))}</strong>",
+                f"Best variant: <strong>{escape(str(best_variant))}</strong>",
+                f"Mean score: <strong>{escape(str(mean_score))}</strong>",
+                f"Total seconds: <strong>{total_seconds:.1f}</strong>",
+            ]
+        )
+
+        ranked = report.get("ranked_results") or []
+        top_n = ranked[: min(5, len(ranked))]
+        top_rows = []
+        for rank, item in enumerate(top_n, start=1):
+            top_rows.append(
+                f"<tr><td>{rank}</td><td>{escape(item.get('variant_id', '—'))}</td>"
+                f"<td>{escape(_provider_cell(item, 'vlm'))}</td>"
+                f"<td>{escape(_provider_cell(item, 'image'))}</td>"
+                f"<td>{escape(str(item.get('iterations_used', '—')))}</td>"
+                f"<td>{escape(str(item.get('critic_suggestions', '—')))}</td>"
+                f"<td>{escape(str(item.get('quality_proxy_score', '—')))}</td>"
+                f"<td>{escape(str(item.get('total_seconds', '—')))}</td></tr>"
+            )
+
+        result_rows = []
+        for item in report.get("results", []):
+            vid = escape(item.get("variant_id", "—"))
+            vlm = escape(_provider_cell(item, "vlm"))
+            img = escape(_provider_cell(item, "image"))
+            if item.get("status") == "success":
+                status_cell = '<span class="status success">Success</span>'
+                iters = escape(str(item.get("iterations_used", "—")))
+                suggestions = escape(str(item.get("critic_suggestions", "—")))
+                score = escape(str(item.get("quality_proxy_score", "—")))
+                seconds = escape(str(item.get("total_seconds", "—")))
+                out = _relative_output(item.get("output_path") or "", sweep_dir)
+                out_cell = f'<a href="{escape(out)}">{escape(out)}</a>' if out else "—"
+                result_rows.append(
+                    f"<tr><td>{vid}</td><td>{vlm}</td><td>{img}</td><td>{status_cell}</td>"
+                    f"<td>{iters}</td><td>{suggestions}</td><td>{score}</td><td>{seconds}</td>"
+                    f"<td>{out_cell}</td></tr>"
+                )
+            else:
+                status_cell = '<span class="status fail">Failed</span>'
+                err = escape((item.get("error") or "unknown")[:200])
+                result_rows.append(
+                    f"<tr><td>{vid}</td><td>{vlm}</td><td>{img}</td><td>{status_cell}</td>"
+                    f'<td colspan="5">{err}</td></tr>'
+                )
+
+        top_html = ""
+        if top_rows:
+            top_body = "\n".join(top_rows)
+            top_html = f"""
+  <h2>Top Variants (ranked)</h2>
+  <table>
+    <thead><tr><th>Rank</th><th>Variant</th><th>VLM</th><th>Image</th><th>Iters</th>
+    <th>Suggestions</th><th>Score</th><th>Seconds</th></tr></thead>
+    <tbody>
+{top_body}
+    </tbody>
+  </table>
+"""
+
+        note = report.get("quality_proxy_note")
+        note_html = f'<p class="note">{escape(note)}</p>' if note else ""
+        result_body = "\n".join(result_rows)
+
+        body = f"""{top_html}
+  <h2>All Variants</h2>
+  <table>
+    <thead><tr><th>Variant</th><th>VLM</th><th>Image</th><th>Status</th><th>Iters</th>
+    <th>Suggestions</th><th>Score</th><th>Seconds</th><th>Output / Error</th></tr></thead>
+    <tbody>
+{result_body}
+    </tbody>
+  </table>
+{note_html}
+"""
+
+    meta_html = "<br>\n  ".join(meta_lines)
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Sweep Report — {escape(sweep_id)}</title>
+  <style>{style}</style>
+</head>
+<body>
+  <h1>Sweep Report: {escape(sweep_id)}</h1>
+  <p class="meta">{meta_html}</p>
+{body}</body>
+</html>
+"""
+
+
+def write_sweep_report(
+    sweep_dir: Path,
+    output_path: Path | None = None,
+    format: Literal["markdown", "html", "md"] = "markdown",
+) -> Path:
+    """Load the sweep report from sweep_dir, generate a report, and write it to disk.
+
+    Args:
+        sweep_dir: Path to the sweep run directory.
+        output_path: Where to write the report. If None, writes to sweep_dir/sweep_report.{md|html}.
+        format: Report format: markdown, html, or md (alias for markdown).
+
+    Returns:
+        The path where the report was written.
+    """
+    sweep_dir = Path(sweep_dir).resolve()
+    report = load_sweep_report(sweep_dir)
+    ext = "html" if format == "html" else "md"
+    if output_path is None:
+        output_path = sweep_dir / f"sweep_report.{ext}"
+    output_path = Path(output_path).resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if format == "html":
+        content = generate_sweep_report_html(report, sweep_dir)
+    else:
+        content = generate_sweep_report_md(report, sweep_dir)
+    output_path.write_text(content, encoding="utf-8")
+    logger.info("Wrote sweep report", path=str(output_path), format=format)
+    return output_path

--- a/paperbanana/core/sweep.py
+++ b/paperbanana/core/sweep.py
@@ -240,6 +240,14 @@ def _provider_cell(item: dict[str, Any], which: Literal["vlm", "image"]) -> str:
     return f"{provider} / {model}" if model else str(provider)
 
 
+_MD_PIPE_ESCAPE = "\\|"
+
+
+def _md_escape(value: Any) -> str:
+    """Escape pipe characters for Markdown table cells."""
+    return str(value).replace("|", _MD_PIPE_ESCAPE)
+
+
 def _relative_output(out: str, sweep_dir: Path) -> str:
     """Convert an absolute output_path to a sweep-dir-relative path when possible."""
     if not out:
@@ -281,10 +289,12 @@ def generate_sweep_report_md(report: dict[str, Any], sweep_dir: Path) -> str:
             ]
         )
         for item in report.get("preview", []):
+            vlm = _md_escape(_provider_cell(item, "vlm"))
+            img = _md_escape(_provider_cell(item, "image"))
             lines.append(
                 f"| {item.get('variant_id', '—')} "
-                f"| {_provider_cell(item, 'vlm').replace('|', '\\|')} "
-                f"| {_provider_cell(item, 'image').replace('|', '\\|')} "
+                f"| {vlm} "
+                f"| {img} "
                 f"| {item.get('refinement_iterations', '—')} "
                 f"| {item.get('optimize_inputs', '—')} "
                 f"| {item.get('auto_refine', '—')} |"
@@ -319,11 +329,13 @@ def generate_sweep_report_md(report: dict[str, Any], sweep_dir: Path) -> str:
             ]
         )
         for rank, item in enumerate(top_n, start=1):
+            vlm = _md_escape(_provider_cell(item, "vlm"))
+            img = _md_escape(_provider_cell(item, "image"))
             lines.append(
                 f"| {rank} "
                 f"| {item.get('variant_id', '—')} "
-                f"| {_provider_cell(item, 'vlm').replace('|', '\\|')} "
-                f"| {_provider_cell(item, 'image').replace('|', '\\|')} "
+                f"| {vlm} "
+                f"| {img} "
                 f"| {item.get('iterations_used', '—')} "
                 f"| {item.get('critic_suggestions', '—')} "
                 f"| {item.get('quality_proxy_score', '—')} "
@@ -341,8 +353,8 @@ def generate_sweep_report_md(report: dict[str, Any], sweep_dir: Path) -> str:
     lines.extend(["", "## All Variants", "", header, divider])
     for item in report.get("results", []):
         vid = item.get("variant_id", "—")
-        vlm = _provider_cell(item, "vlm").replace("|", "\\|")
-        img = _provider_cell(item, "image").replace("|", "\\|")
+        vlm = _md_escape(_provider_cell(item, "vlm"))
+        img = _md_escape(_provider_cell(item, "image"))
         if item.get("status") == "success":
             status_cell = "✓ Success"
             iters = item.get("iterations_used", "—")
@@ -350,14 +362,14 @@ def generate_sweep_report_md(report: dict[str, Any], sweep_dir: Path) -> str:
             score = item.get("quality_proxy_score", "—")
             seconds = item.get("total_seconds", "—")
             out = _relative_output(item.get("output_path") or "", sweep_dir)
-            out_cell = f"`{out.replace('|', '\\|')}`" if out else "—"
+            out_cell = f"`{_md_escape(out)}`" if out else "—"
             lines.append(
                 f"| {vid} | {vlm} | {img} | {status_cell} | {iters} "
                 f"| {suggestions} | {score} | {seconds} | {out_cell} |"
             )
         else:
             status_cell = "✗ Failed"
-            err = (item.get("error") or "unknown").replace("|", "\\|")[:80]
+            err = _md_escape(item.get("error") or "unknown")[:80]
             lines.append(f"| {vid} | {vlm} | {img} | {status_cell} | — | — | — | — | {err} |")
 
     note = report.get("quality_proxy_note")

--- a/tests/test_core/test_sweep.py
+++ b/tests/test_core/test_sweep.py
@@ -2,15 +2,23 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from paperbanana.core.sweep import (
+    SWEEP_REPORT_FILENAME,
     build_sweep_variants,
+    generate_sweep_report_html,
+    generate_sweep_report_md,
+    load_sweep_report,
     parse_csv_bools,
     parse_csv_ints,
     quality_proxy_score,
     rank_sweep_results,
     summarize_sweep,
+    write_sweep_report,
 )
 
 
@@ -79,3 +87,322 @@ def test_rank_and_summarize_sweep_results() -> None:
     assert summary["completed"] == 2
     assert summary["failed"] == 1
     assert summary["best_variant"] == "c"
+
+
+# ---------------------------------------------------------------------------
+# load_sweep_report
+# ---------------------------------------------------------------------------
+
+
+def _completed_report_payload(sweep_dir: Path) -> dict:
+    return {
+        "sweep_id": "sweep_test",
+        "status": "completed",
+        "input": "paper.pdf",
+        "caption": "Figure 1",
+        "total_seconds": 12.5,
+        "summary": {
+            "completed": 2,
+            "failed": 1,
+            "best_variant": "variant_002",
+            "best_quality_proxy_score": 87.5,
+            "mean_quality_proxy_score": 81.25,
+            "mean_total_seconds": 6.0,
+        },
+        "results": [
+            {
+                "status": "success",
+                "variant_id": "variant_001",
+                "vlm_provider": "gemini",
+                "vlm_model": "gemini-2.5-flash",
+                "image_provider": "google_imagen",
+                "image_model": None,
+                "iterations_used": 2,
+                "critic_suggestions": 2,
+                "quality_proxy_score": 75.0,
+                "total_seconds": 5.5,
+                "output_path": str(sweep_dir / "variant_001" / "out.png"),
+            },
+            {
+                "status": "success",
+                "variant_id": "variant_002",
+                "vlm_provider": "openai",
+                "vlm_model": "gpt-4o",
+                "image_provider": "openai_imagen",
+                "image_model": None,
+                "iterations_used": 3,
+                "critic_suggestions": 1,
+                "quality_proxy_score": 87.5,
+                "total_seconds": 6.5,
+                "output_path": str(sweep_dir / "variant_002" / "out.png"),
+            },
+            {
+                "status": "failed",
+                "variant_id": "variant_003",
+                "vlm_provider": "gemini",
+                "vlm_model": None,
+                "image_provider": "google_imagen",
+                "image_model": None,
+                "error": "Provider timeout after 30s",
+            },
+        ],
+        "ranked_results": [
+            {
+                "variant_id": "variant_002",
+                "vlm_provider": "openai",
+                "vlm_model": "gpt-4o",
+                "image_provider": "openai_imagen",
+                "image_model": None,
+                "iterations_used": 3,
+                "critic_suggestions": 1,
+                "quality_proxy_score": 87.5,
+                "total_seconds": 6.5,
+            },
+            {
+                "variant_id": "variant_001",
+                "vlm_provider": "gemini",
+                "vlm_model": "gemini-2.5-flash",
+                "image_provider": "google_imagen",
+                "image_model": None,
+                "iterations_used": 2,
+                "critic_suggestions": 2,
+                "quality_proxy_score": 75.0,
+                "total_seconds": 5.5,
+            },
+        ],
+        "quality_proxy_note": (
+            "quality_proxy_score = max(0, 100 - 12.5 * N) where N is critic suggestion "
+            "count on the final iteration"
+        ),
+    }
+
+
+def _dry_run_payload() -> dict:
+    return {
+        "sweep_id": "sweep_dry",
+        "status": "dry_run",
+        "total_variants": 2,
+        "preview": [
+            {
+                "variant_id": "variant_001",
+                "vlm_provider": "gemini",
+                "vlm_model": None,
+                "image_provider": "google_imagen",
+                "image_model": None,
+                "refinement_iterations": 2,
+                "optimize_inputs": False,
+                "auto_refine": False,
+            },
+            {
+                "variant_id": "variant_002",
+                "vlm_provider": "openai",
+                "vlm_model": "gpt-4o",
+                "image_provider": "openai_imagen",
+                "image_model": None,
+                "refinement_iterations": 3,
+                "optimize_inputs": True,
+                "auto_refine": True,
+            },
+        ],
+    }
+
+
+def test_load_sweep_report_success(tmp_path: Path) -> None:
+    payload = _completed_report_payload(tmp_path)
+    (tmp_path / SWEEP_REPORT_FILENAME).write_text(json.dumps(payload), encoding="utf-8")
+    loaded = load_sweep_report(tmp_path)
+    assert loaded["sweep_id"] == "sweep_test"
+    assert len(loaded["results"]) == 3
+
+
+def test_load_sweep_report_dry_run(tmp_path: Path) -> None:
+    (tmp_path / SWEEP_REPORT_FILENAME).write_text(json.dumps(_dry_run_payload()), encoding="utf-8")
+    loaded = load_sweep_report(tmp_path)
+    assert loaded["status"] == "dry_run"
+    assert len(loaded["preview"]) == 2
+
+
+def test_load_sweep_report_dir_not_found() -> None:
+    with pytest.raises(FileNotFoundError, match="Sweep directory not found"):
+        load_sweep_report(Path("/nonexistent/sweep_dir"))
+
+
+def test_load_sweep_report_json_not_found(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="No sweep_report.json"):
+        load_sweep_report(tmp_path)
+
+
+def test_load_sweep_report_invalid_json(tmp_path: Path) -> None:
+    (tmp_path / SWEEP_REPORT_FILENAME).write_text("not json", encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        load_sweep_report(tmp_path)
+
+
+def test_load_sweep_report_missing_sweep_id(tmp_path: Path) -> None:
+    (tmp_path / SWEEP_REPORT_FILENAME).write_text('{"status": "completed"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="Invalid report"):
+        load_sweep_report(tmp_path)
+
+
+def test_load_sweep_report_completed_missing_results(tmp_path: Path) -> None:
+    (tmp_path / SWEEP_REPORT_FILENAME).write_text(
+        '{"sweep_id": "x", "status": "completed"}', encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="missing 'results'"):
+        load_sweep_report(tmp_path)
+
+
+def test_load_sweep_report_dry_run_missing_preview(tmp_path: Path) -> None:
+    (tmp_path / SWEEP_REPORT_FILENAME).write_text(
+        '{"sweep_id": "x", "status": "dry_run"}', encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="missing 'preview'"):
+        load_sweep_report(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# generate_sweep_report_md / html — completed
+# ---------------------------------------------------------------------------
+
+
+def test_generate_sweep_report_md_completed(tmp_path: Path) -> None:
+    report = _completed_report_payload(tmp_path)
+    md = generate_sweep_report_md(report, tmp_path)
+    assert "# Sweep Report: sweep_test" in md
+    assert "Figure 1" in md
+    assert "Best variant" in md
+    assert "variant_002" in md
+    assert "Top Variants (ranked)" in md
+    assert "All Variants" in md
+    assert "✓ Success" in md
+    assert "✗ Failed" in md
+    assert "Provider timeout" in md
+    assert "gemini / gemini-2.5-flash" in md
+    assert "quality_proxy_score" in md
+    assert "`variant_001/out.png`" in md
+
+
+def test_generate_sweep_report_md_dry_run(tmp_path: Path) -> None:
+    md = generate_sweep_report_md(_dry_run_payload(), tmp_path)
+    assert "# Sweep Report: sweep_dry" in md
+    assert "Planned variants" in md
+    assert "variant_001" in md
+    assert "variant_002" in md
+    assert "Top Variants" not in md
+    assert "All Variants" not in md
+
+
+def test_generate_sweep_report_html_completed(tmp_path: Path) -> None:
+    report = _completed_report_payload(tmp_path)
+    html = generate_sweep_report_html(report, tmp_path)
+    assert "<!DOCTYPE html>" in html
+    assert "Sweep Report: sweep_test" in html
+    assert "variant_002" in html
+    assert "Top Variants (ranked)" in html
+    assert "All Variants" in html
+    assert "Success" in html
+    assert "Failed" in html
+    assert 'href="variant_001/out.png"' in html
+    assert "quality_proxy_score" in html
+
+
+def test_generate_sweep_report_html_escapes_caption(tmp_path: Path) -> None:
+    report = _completed_report_payload(tmp_path)
+    report["caption"] = "<script>alert('x')</script>"
+    html = generate_sweep_report_html(report, tmp_path)
+    assert "<script>alert" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_generate_sweep_report_html_dry_run(tmp_path: Path) -> None:
+    html = generate_sweep_report_html(_dry_run_payload(), tmp_path)
+    assert "Planned Variants (preview)" in html
+    assert "Top Variants" not in html
+    assert "All Variants" not in html
+
+
+# ---------------------------------------------------------------------------
+# write_sweep_report
+# ---------------------------------------------------------------------------
+
+
+def test_write_sweep_report_markdown(tmp_path: Path) -> None:
+    payload = _completed_report_payload(tmp_path)
+    (tmp_path / SWEEP_REPORT_FILENAME).write_text(json.dumps(payload), encoding="utf-8")
+    out_path = tmp_path / "report.md"
+    written = write_sweep_report(tmp_path, output_path=out_path, format="markdown")
+    assert written == out_path
+    assert out_path.exists()
+    assert "Sweep Report: sweep_test" in out_path.read_text(encoding="utf-8")
+
+
+def test_write_sweep_report_html_default_path(tmp_path: Path) -> None:
+    payload = _completed_report_payload(tmp_path)
+    (tmp_path / SWEEP_REPORT_FILENAME).write_text(json.dumps(payload), encoding="utf-8")
+    written = write_sweep_report(tmp_path, format="html")
+    assert written == tmp_path / "sweep_report.html"
+    assert written.exists()
+    assert "<!DOCTYPE html>" in written.read_text(encoding="utf-8")
+
+
+def test_write_sweep_report_md_alias(tmp_path: Path) -> None:
+    payload = _completed_report_payload(tmp_path)
+    (tmp_path / SWEEP_REPORT_FILENAME).write_text(json.dumps(payload), encoding="utf-8")
+    written = write_sweep_report(tmp_path, format="md")
+    assert written == tmp_path / "sweep_report.md"
+    assert written.exists()
+
+
+# ---------------------------------------------------------------------------
+# edge cases: empty ranked, sibling-dir paths, no quality note
+# ---------------------------------------------------------------------------
+
+
+def test_generate_sweep_report_md_skips_top_section_when_no_ranked(tmp_path: Path) -> None:
+    report = _completed_report_payload(tmp_path)
+    report["ranked_results"] = []
+    md = generate_sweep_report_md(report, tmp_path)
+    assert "Top Variants (ranked)" not in md
+    assert "All Variants" in md
+
+
+def test_generate_sweep_report_html_skips_top_section_when_no_ranked(tmp_path: Path) -> None:
+    report = _completed_report_payload(tmp_path)
+    report["ranked_results"] = []
+    html = generate_sweep_report_html(report, tmp_path)
+    assert "Top Variants (ranked)" not in html
+    assert "All Variants" in html
+
+
+def test_generate_sweep_report_output_path_outside_sweep_dir_stays_absolute(
+    tmp_path: Path,
+) -> None:
+    report = _completed_report_payload(tmp_path)
+    report["results"][0]["output_path"] = "/elsewhere/out.png"
+    md = generate_sweep_report_md(report, tmp_path)
+    assert "/elsewhere/out.png" in md
+
+
+def test_generate_sweep_report_sibling_dir_path_not_collapsed(tmp_path: Path) -> None:
+    """Path comparison must not collapse a sibling-dir match (startswith bug)."""
+    sweep_dir = tmp_path / "sweep_abc"
+    sibling = tmp_path / "sweep_abc_other" / "out.png"
+    sweep_dir.mkdir()
+    report = _completed_report_payload(sweep_dir)
+    report["results"][0]["output_path"] = str(sibling)
+    md = generate_sweep_report_md(report, sweep_dir)
+    assert str(sibling) in md
+
+
+def test_generate_sweep_report_md_without_quality_note(tmp_path: Path) -> None:
+    report = _completed_report_payload(tmp_path)
+    report.pop("quality_proxy_note")
+    md = generate_sweep_report_md(report, tmp_path)
+    assert "**Note:**" not in md
+
+
+def test_generate_sweep_report_html_without_quality_note(tmp_path: Path) -> None:
+    report = _completed_report_payload(tmp_path)
+    report.pop("quality_proxy_note")
+    html = generate_sweep_report_html(report, tmp_path)
+    assert 'class="note"' not in html


### PR DESCRIPTION
Closes #172

## Summary

Adds `paperbanana sweep-report`, symmetric to the already-merged `batch-report` (#85), so sweep runs can be shared as a human-readable digest without hand-rolling a renderer or piping through `jq`.

```bash
paperbanana sweep-report --sweep-dir outputs/sweep_20250109_123456_abc --format html
paperbanana sweep-report --sweep-id sweep_20250109_123456_abc --format markdown
```

Rendered reports include:
- Summary header (input, caption, completed/failed, best variant, mean score, total seconds)
- Top-5 ranked table (uses existing `ranked_results` field)
- Full variants table (provider/model, iterations, critic-suggestion count, quality proxy score, seconds, output path / error)
- The `quality_proxy_note` so readers know what the score means
- A simplified "Planned Variants" view for dry-run (`status == "dry_run"`) reports, which have `preview` instead of `results`

## Implementation

- `paperbanana/core/sweep.py` — new helpers mirroring the batch pattern in `paperbanana/core/batch.py:191–567`: `load_sweep_report`, `generate_sweep_report_md`, `generate_sweep_report_html`, `write_sweep_report`.
- `paperbanana/cli.py` — `sweep-report` command mirroring `batch-report` (same flag names, same error handling).
- `tests/test_core/test_sweep.py` — 22 new tests covering load, render (completed + dry-run), write, HTML escaping, empty-ranked edge case, paths outside the sweep dir, sibling-dir paths, and quality-note-omitted cases. All 27 tests in the file pass.
- `README.md` — short section alongside the existing `batch-report` docs.

Zero changes to the sweep runner — this is pure rendering over the existing JSON schema.

One small correctness win over the batch-report pattern: `_relative_output` uses `Path.relative_to` with a `ValueError` branch rather than `str.startswith`, so a sibling directory like `sweep_abc_other` is not mis-collapsed when the sweep dir is `sweep_abc`. Covered by `test_generate_sweep_report_sibling_dir_path_not_collapsed`.

## Test plan

- [x] `pytest tests/test_core/test_sweep.py -v` — 27 tests pass
- [x] Full suite: 478 pass, 1 pre-existing unrelated failure in `test_utils.py::TestCompressForApi::test_large_image_compressed`, 1 gradio-missing skip
- [x] `ruff check paperbanana/ tests/` — clean
- [x] `ruff format --check paperbanana/ tests/` — clean
- [x] `paperbanana sweep-report --help` — renders as expected

cc @dippatel1994 for review.