### PR TITLE
feat: add lock-aware DiagramIR regeneration workflow

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -17,6 +17,7 @@ from rich.table import Table
 from paperbanana.core.config import Settings
 from paperbanana.core.logging import configure_logging
 from paperbanana.core.types import (
+    DiagramIR,
     DiagramType,
     GenerationInput,
     PipelineProgressEvent,
@@ -680,6 +681,184 @@ def generate(
             console.print(
                 "  [yellow]Note: Some model prices unknown; actual cost may differ[/yellow]"
             )
+
+
+@app.command("regenerate")
+def regenerate_from_ir(
+    diagram_ir: str = typer.Option(..., "--diagram-ir", help="Path to edited diagram_ir.json"),
+    input: str = typer.Option(
+        ...,
+        "--input",
+        "-i",
+        help="Path to methodology text file or PDF (.pdf requires: pip install 'paperbanana[pdf]')",
+    ),
+    caption: str = typer.Option(..., "--caption", "-c", help="Figure caption / communicative intent"),
+    config: Optional[str] = typer.Option(None, "--config", help="Path to config YAML file"),
+    vlm_provider: Optional[str] = typer.Option(None, "--vlm-provider", help="VLM provider"),
+    vlm_model: Optional[str] = typer.Option(None, "--vlm-model", help="VLM model name"),
+    image_provider: Optional[str] = typer.Option(None, "--image-provider", help="Image gen provider"),
+    image_model: Optional[str] = typer.Option(None, "--image-model", help="Image gen model name"),
+    iterations: Optional[int] = typer.Option(None, "--iterations", "-n", help="Refinement iterations"),
+    auto: bool = typer.Option(
+        False, "--auto", help="Loop until critic is satisfied (with safety cap)"
+    ),
+    max_iterations: Optional[int] = typer.Option(
+        None, "--max-iterations", help="Safety cap for --auto mode (default: 30)"
+    ),
+    aspect_ratio: Optional[str] = typer.Option(
+        None,
+        "--aspect-ratio",
+        "-ar",
+        help="Target aspect ratio: 1:1, 2:3, 3:2, 3:4, 4:3, 9:16, 16:9, 21:9",
+    ),
+    format: str = typer.Option(
+        "png",
+        "--format",
+        "-f",
+        help="Output image format (png, jpeg, or webp)",
+    ),
+    save_prompts: Optional[bool] = typer.Option(
+        None,
+        "--save-prompts/--no-save-prompts",
+        help="Save formatted prompts into the run directory (for debugging)",
+    ),
+    seed: Optional[int] = typer.Option(
+        None,
+        "--seed",
+        help="Random seed for reproducible image generation",
+    ),
+    progress_json: bool = typer.Option(
+        False,
+        "--progress-json",
+        help="Emit machine-readable JSON progress events to stdout during generation",
+    ),
+    pdf_pages: Optional[str] = typer.Option(
+        None,
+        "--pdf-pages",
+        help=("PDF input only: 1-based pages (e.g. '1-5', '3', '1-3,7,10-12'); default: all pages"),
+    ),
+    generate_caption: bool = typer.Option(
+        False,
+        "--generate-caption",
+        help="Auto-generate a publication-ready figure caption (one extra VLM call)",
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show detailed agent progress and timing"
+    ),
+):
+    """Regenerate from an edited DiagramIR, preserving locked elements."""
+    if format not in ("png", "jpeg", "webp", "svg"):
+        console.print(f"[red]Error: Format must be png, jpeg, webp, or svg. Got: {format}[/red]")
+        raise typer.Exit(1)
+
+    configure_logging(verbose=verbose)
+    overrides = {"output_format": format, "auto_refine": auto, "generate_caption": generate_caption}
+    if iterations is not None:
+        overrides["refinement_iterations"] = iterations
+    if max_iterations is not None:
+        overrides["max_iterations"] = max_iterations
+    if vlm_provider:
+        overrides["vlm_provider"] = vlm_provider
+    if vlm_model:
+        overrides["vlm_model"] = vlm_model
+    if image_provider:
+        overrides["image_provider"] = image_provider
+    if image_model:
+        overrides["image_model"] = image_model
+    if seed is not None:
+        overrides["seed"] = seed
+    if save_prompts is not None:
+        overrides["save_prompts"] = save_prompts
+
+    settings = Settings.from_yaml(config, **overrides) if config else Settings(**overrides)
+
+    input_path = Path(input)
+    if not input_path.exists():
+        console.print(f"[red]Error: Input file not found: {input}[/red]")
+        raise typer.Exit(1)
+    _check_pdf_dep(input_path)
+    from paperbanana.core.source_loader import load_methodology_source
+
+    try:
+        source_context = load_methodology_source(input_path, pdf_pages=pdf_pages)
+    except (ImportError, ValueError) as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    ir_path = Path(diagram_ir)
+    if not ir_path.exists():
+        console.print(f"[red]Error: Diagram IR not found: {diagram_ir}[/red]")
+        raise typer.Exit(1)
+    try:
+        diagram_ir_model = DiagramIR.model_validate_json(ir_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        console.print(f"[red]Error: Invalid diagram IR JSON: {e}[/red]")
+        raise typer.Exit(1)
+
+    if not progress_json:
+        lock_counts = (
+            len(diagram_ir_model.locks.locked_node_ids),
+            len(diagram_ir_model.locks.locked_edge_refs),
+            len(diagram_ir_model.locks.locked_group_ids),
+        )
+        console.print(
+            Panel.fit(
+                f"[bold]PaperBanana[/bold] - Lock-aware IR Regeneration\n\n"
+                f"VLM: {settings.vlm_provider} / {settings.effective_vlm_model}\n"
+                f"Image: {settings.image_provider} / {settings.effective_image_model}\n"
+                f"Locked nodes/edges/groups: {lock_counts[0]}/{lock_counts[1]}/{lock_counts[2]}",
+                border_style="magenta",
+            )
+        )
+
+    total_start = time.perf_counter()
+
+    async def _run_with_progress():
+        def _on_progress(event: str, payload: dict) -> None:
+            if progress_json:
+                console.print(json_mod.dumps({"event": event, **payload}), highlight=False)
+
+        pipeline = PaperBananaPipeline(
+            settings=settings,
+            progress_callback=_on_progress if progress_json else None,
+        )
+
+        def on_progress(event: PipelineProgressEvent) -> None:
+            if event.stage == PipelineProgressStage.VISUALIZER_START:
+                it = event.iteration or "?"
+                total = (event.extra or {}).get("total_iterations", "?")
+                console.print(f"  [dim]●[/dim] Generating image [{it}/{total}]...", end="")
+            elif event.stage == PipelineProgressStage.VISUALIZER_END:
+                console.print(
+                    f" [green]✓[/green] [dim]{event.seconds:.1f}s[/dim]"
+                    if event.seconds is not None
+                    else " [green]✓[/green]"
+                )
+            elif event.stage == PipelineProgressStage.CRITIC_START:
+                console.print("  [dim]●[/dim] Critic reviewing...", end="")
+            elif event.stage == PipelineProgressStage.CRITIC_END:
+                console.print(
+                    f" [green]✓[/green] [dim]{event.seconds:.1f}s[/dim]"
+                    if event.seconds is not None
+                    else " [green]✓[/green]"
+                )
+
+        return await pipeline.regenerate_from_ir(
+            diagram_ir=diagram_ir_model,
+            source_context=source_context,
+            caption=caption,
+            aspect_ratio=aspect_ratio,
+            progress_callback=on_progress if not progress_json else None,
+        )
+
+    result = asyncio.run(_run_with_progress())
+    total_elapsed = time.perf_counter() - total_start
+    console.print(
+        f"\n[green]✓ Done![/green] [dim]{total_elapsed:.1f}s total"
+        f" · {len(result.iterations)} iterations[/dim]\n"
+    )
+    console.print(f"  Output: [bold]{result.image_path}[/bold]")
+    console.print(f"  Run ID: [dim]{result.metadata.get('run_id', 'unknown')}[/dim]")
 
 
 @app.command()

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -16,6 +16,7 @@ from rich.table import Table
 
 from paperbanana.core.config import Settings
 from paperbanana.core.logging import configure_logging
+from paperbanana.core.pipeline import PaperBananaPipeline
 from paperbanana.core.types import (
     DiagramIR,
     DiagramType,
@@ -685,20 +686,38 @@ def generate(
 
 @app.command("regenerate")
 def regenerate_from_ir(
-    diagram_ir: str = typer.Option(..., "--diagram-ir", help="Path to edited diagram_ir.json"),
+    diagram_ir: str = typer.Option(
+        ...,
+        "--diagram-ir",
+        help="Path to edited diagram_ir.json",
+    ),
     input: str = typer.Option(
         ...,
         "--input",
         "-i",
         help="Path to methodology text file or PDF (.pdf requires: pip install 'paperbanana[pdf]')",
     ),
-    caption: str = typer.Option(..., "--caption", "-c", help="Figure caption / communicative intent"),
+    caption: str = typer.Option(
+        ...,
+        "--caption",
+        "-c",
+        help="Figure caption / communicative intent",
+    ),
     config: Optional[str] = typer.Option(None, "--config", help="Path to config YAML file"),
     vlm_provider: Optional[str] = typer.Option(None, "--vlm-provider", help="VLM provider"),
     vlm_model: Optional[str] = typer.Option(None, "--vlm-model", help="VLM model name"),
-    image_provider: Optional[str] = typer.Option(None, "--image-provider", help="Image gen provider"),
+    image_provider: Optional[str] = typer.Option(
+        None,
+        "--image-provider",
+        help="Image gen provider",
+    ),
     image_model: Optional[str] = typer.Option(None, "--image-model", help="Image gen model name"),
-    iterations: Optional[int] = typer.Option(None, "--iterations", "-n", help="Refinement iterations"),
+    iterations: Optional[int] = typer.Option(
+        None,
+        "--iterations",
+        "-n",
+        help="Refinement iterations",
+    ),
     auto: bool = typer.Option(
         False, "--auto", help="Loop until critic is satisfied (with safety cap)"
     ),

--- a/paperbanana/core/diagram_ir.py
+++ b/paperbanana/core/diagram_ir.py
@@ -132,6 +132,46 @@ def extract_diagram_ir(description: str, title: str = "PaperBanana Diagram") -> 
     return DiagramIR(title=title, nodes=nodes, edges=edges)
 
 
+def format_diagram_ir_for_regeneration(diagram_ir: DiagramIR) -> str:
+    """Create a lock-aware textual description from DiagramIR."""
+    locked_nodes = set(diagram_ir.locks.locked_node_ids)
+    locked_edges = set(diagram_ir.locks.locked_edge_refs)
+    locked_groups = set(diagram_ir.locks.locked_group_ids)
+
+    lines: list[str] = [f"Figure title: {diagram_ir.title}", "", "Nodes:"]
+    for node in diagram_ir.nodes:
+        lane = f" [lane={node.lane}]" if node.lane else ""
+        lock = " [LOCKED]" if node.id in locked_nodes else ""
+        lines.append(f"- {node.id}: {node.label}{lane}{lock}")
+
+    if diagram_ir.groups:
+        lines.extend(["", "Groups:"])
+        for group in diagram_ir.groups:
+            node_ids = ", ".join(group.node_ids)
+            lock = " [LOCKED]" if group.id in locked_groups else ""
+            lines.append(f"- {group.id}: {group.label} -> ({node_ids}){lock}")
+
+    lines.extend(["", "Edges:"])
+    for edge in diagram_ir.edges:
+        edge_ref = edge.id or f"{edge.source}->{edge.target}"
+        lock = " [LOCKED]" if edge_ref in locked_edges else ""
+        label = f" ({edge.label})" if edge.label else ""
+        lines.append(f"- {edge.source} -> {edge.target}{label} [ref={edge_ref}]{lock}")
+
+    if locked_nodes or locked_edges or locked_groups:
+        lines.extend(
+            [
+                "",
+                "Hard constraints:",
+                "- Preserve every element marked [LOCKED] exactly (ID, text, and connections).",
+                "- You may improve only unlocked elements for clarity and aesthetics.",
+                "- Do not remove or rename locked IDs.",
+            ]
+        )
+
+    return "\n".join(lines).strip()
+
+
 def save_svg_from_ir(diagram_ir: DiagramIR, output_path: str | Path) -> Path:
     """Render an editable SVG from DiagramIR."""
     output_path = Path(output_path)
@@ -202,6 +242,7 @@ def save_svg_from_ir(diagram_ir: DiagramIR, output_path: str | Path) -> Path:
 
     # Place nodes in columns within each lane.
     lane_nodes: dict[str, list[DiagramIRNode]] = {k: [] for k in lane_order}
+    locked_nodes = set(diagram_ir.locks.locked_node_ids)
     for node in diagram_ir.nodes:
         lane = (node.lane or "").strip() or lane_order[0]
         if lane not in lane_nodes:
@@ -217,15 +258,23 @@ def save_svg_from_ir(diagram_ir: DiagramIR, output_path: str | Path) -> Path:
         for i, node in enumerate(lane_nodes.get(lane, [])):
             x = margin_x + left_gutter + i * step_x
             node_pos[node.id] = (x, y)
+            is_locked = node.id in locked_nodes
+            stroke_color = "#2563eb" if is_locked else "#94a3b8"
             parts.append(
                 f'<rect x="{x}" y="{y}" width="{node_w}" height="{node_h}" rx="12" '
-                'fill="#f8fafc" stroke="#94a3b8" stroke-width="2"/>'
+                f'fill="#f8fafc" stroke="{stroke_color}" stroke-width="2"/>'
             )
             parts.append(
                 f'<text x="{x + 16}" y="{y + 34}" font-family="Arial, sans-serif" font-size="18" '
                 'fill="#111827">'
                 f"{html.escape(node.label)}</text>"
             )
+            if is_locked:
+                parts.append(
+                    f'<text x="{x + node_w - 50}" y="{y + 24}" '
+                    'font-family="Arial, sans-serif" font-size="12" '
+                    'font-weight="700" fill="#1d4ed8">LOCK</text>'
+                )
 
     edge_label_offsets: dict[tuple[int, int], int] = {}
     route_channel_counts: dict[tuple[int, int], int] = {}

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -22,12 +22,14 @@ from paperbanana.core.config import Settings
 from paperbanana.core.cost_tracker import CostTracker
 from paperbanana.core.diagram_ir import (
     extract_diagram_ir,
+    format_diagram_ir_for_regeneration,
     save_raster_wrapped_svg,
     save_svg_from_ir,
 )
 from paperbanana.core.prompt_recorder import PromptRecorder
 from paperbanana.core.types import (
     CritiqueResult,
+    DiagramIR,
     DiagramType,
     GenerationInput,
     GenerationOutput,
@@ -382,6 +384,235 @@ class PaperBananaPipeline:
         if mode == "external_only":
             return mapped, "external_only", [e.id for e in mapped]
         return mapped, "external_then_rerank", [e.id for e in mapped]
+
+    async def regenerate_from_ir(
+        self,
+        *,
+        diagram_ir: DiagramIR,
+        source_context: str,
+        caption: str,
+        aspect_ratio: Optional[str] = None,
+        progress_callback: Optional[Callable[[PipelineProgressEvent], None]] = None,
+    ) -> GenerationOutput:
+        """Regenerate a methodology figure from edited DiagramIR with lock hints."""
+        total_start = time.perf_counter()
+        current_description = format_diagram_ir_for_regeneration(diagram_ir)
+        iterations: list[IterationRecord] = []
+        iteration_timings: list[dict[str, float | int]] = []
+        budget_exceeded = self._check_budget("before regenerate-from-ir iterations")
+        vector_formats = ["svg", "pdf"] if self.settings.vector_export else None
+        total_iters = self.settings.max_iterations if self.settings.auto_refine else self.settings.refinement_iterations
+
+        if self.settings.save_iterations:
+            save_json(
+                {
+                    "source_context": source_context,
+                    "communicative_intent": caption,
+                    "diagram_type": DiagramType.METHODOLOGY.value,
+                    "raw_data": None,
+                    "aspect_ratio": aspect_ratio,
+                    "regeneration_mode": "diagram_ir_locked",
+                    "locked_nodes": diagram_ir.locks.locked_node_ids,
+                    "locked_edges": diagram_ir.locks.locked_edge_refs,
+                    "locked_groups": diagram_ir.locks.locked_group_ids,
+                },
+                self._run_dir / "run_input.json",
+            )
+            save_json(diagram_ir.model_dump(), self._run_dir / "diagram_ir_input.json")
+
+        for i in range(total_iters):
+            if budget_exceeded:
+                break
+            iter_index = i + 1
+
+            if self._cost_tracker:
+                self._cost_tracker.set_agent("visualizer")
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.VISUALIZER_START,
+                    message=f"Generating image (iteration {iter_index}/{total_iters})",
+                    iteration=iter_index,
+                    extra={"total_iterations": total_iters, "mode": "regenerate_ir"},
+                ),
+            )
+            visualizer_start = time.perf_counter()
+            image_path = await _call_with_retry(
+                "visualizer",
+                self.visualizer.run,
+                description=current_description,
+                diagram_type=DiagramType.METHODOLOGY,
+                raw_data=None,
+                iteration=iter_index,
+                seed=self.settings.seed,
+                aspect_ratio=aspect_ratio,
+                vector_formats=vector_formats,
+            )
+            visualizer_seconds = time.perf_counter() - visualizer_start
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.VISUALIZER_END,
+                    message=f"Visualizer iteration {iter_index} done",
+                    seconds=visualizer_seconds,
+                    iteration=iter_index,
+                ),
+            )
+
+            if self._cost_tracker:
+                self._cost_tracker.set_agent("critic")
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.CRITIC_START,
+                    message="Critic reviewing",
+                    iteration=iter_index,
+                ),
+            )
+            critic_start = time.perf_counter()
+            try:
+                critique = await _call_with_retry(
+                    "critic",
+                    self.critic.run,
+                    image_path=image_path,
+                    description=current_description,
+                    source_context=source_context,
+                    caption=caption,
+                    diagram_type=DiagramType.METHODOLOGY,
+                )
+            except Exception:
+                logger.warning(
+                    "Critic failed after retries, accepting current image",
+                    iteration=iter_index,
+                    exc_info=True,
+                )
+                critique = CritiqueResult()
+            critic_seconds = time.perf_counter() - critic_start
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.CRITIC_END,
+                    message="Critic done",
+                    seconds=critic_seconds,
+                    iteration=iter_index,
+                    extra={
+                        "needs_revision": critique.needs_revision,
+                        "summary": critique.summary,
+                        "critic_suggestions": critique.critic_suggestions[:3],
+                    },
+                ),
+            )
+
+            iteration_timings.append(
+                {
+                    "iteration": iter_index,
+                    "visualizer_seconds": visualizer_seconds,
+                    "critic_seconds": critic_seconds,
+                }
+            )
+            iterations.append(
+                IterationRecord(
+                    iteration=iter_index,
+                    description=current_description,
+                    image_path=image_path,
+                    critique=critique,
+                )
+            )
+            if self.settings.save_iterations:
+                iter_dir = ensure_dir(self._run_dir / f"iter_{iter_index}")
+                save_json(
+                    {
+                        "description": current_description,
+                        "critique": critique.model_dump(),
+                        "mode": "regenerate_ir",
+                    },
+                    iter_dir / "details.json",
+                )
+
+            if critique.needs_revision and critique.revised_description:
+                # Keep lock constraints attached to every revised prompt.
+                current_description = (
+                    critique.revised_description.strip()
+                    + "\n\n"
+                    + format_diagram_ir_for_regeneration(diagram_ir)
+                )
+            else:
+                break
+
+            if self._check_budget("between regenerate-from-ir iterations", iteration=iter_index):
+                budget_exceeded = True
+                break
+
+        output_format = getattr(self.settings, "output_format", "png").lower()
+        ext = "jpg" if output_format == "jpeg" else output_format
+        final_output_path = str(self._run_dir / f"final_output.{ext}")
+
+        if iterations:
+            final_image = iterations[-1].image_path
+            if output_format == "svg":
+                save_json(diagram_ir.model_dump(), self._run_dir / "diagram_ir.json")
+                save_svg_from_ir(diagram_ir, final_output_path)
+            else:
+                img = load_image(final_image)
+                save_image(img, final_output_path, format=output_format)
+        else:
+            final_output_path = ""
+
+        generated_caption, caption_seconds = await self._generate_caption(
+            image_path=final_output_path,
+            source_context=source_context,
+            intent=caption,
+            description=current_description,
+            diagram_type=DiagramType.METHODOLOGY,
+            progress_callback=progress_callback,
+        )
+
+        total_seconds = time.perf_counter() - total_start
+        metadata = RunMetadata(
+            run_id=self.run_id,
+            timestamp=datetime.datetime.now().isoformat(),
+            vlm_provider=getattr(self._vlm, "name", "custom"),
+            vlm_model=getattr(self._vlm, "model_name", "custom"),
+            image_provider=getattr(self._image_gen, "name", "custom"),
+            image_model=getattr(self._image_gen, "model_name", "custom"),
+            refinement_iterations=len(iterations),
+            seed=self.settings.seed,
+            config_snapshot=self.settings.model_dump(
+                exclude={"google_api_key", "openai_api_key", "openrouter_api_key"}
+            ),
+        )
+        metadata_dict = metadata.model_dump()
+        metadata_dict["timing"] = {
+            "total_seconds": total_seconds,
+            "caption_seconds": caption_seconds,
+            "iterations": iteration_timings,
+        }
+        metadata_dict["regeneration"] = {
+            "mode": "diagram_ir_locked",
+            "locked_nodes": len(diagram_ir.locks.locked_node_ids),
+            "locked_edges": len(diagram_ir.locks.locked_edge_refs),
+            "locked_groups": len(diagram_ir.locks.locked_group_ids),
+        }
+        if generated_caption is not None:
+            metadata_dict["generated_caption"] = generated_caption
+        if self._cost_tracker:
+            cost_summary = self._cost_tracker.summary()
+            cost_summary["budget_exceeded"] = budget_exceeded
+            if self.settings.budget_usd is not None:
+                cost_summary["budget_usd"] = self.settings.budget_usd
+            metadata_dict["cost"] = cost_summary
+
+        if self.settings.vector_export and self.visualizer._last_vector_paths:
+            metadata_dict["vector_output_paths"] = self.visualizer._last_vector_paths
+
+        save_json(metadata_dict, self._run_dir / "metadata.json")
+        return GenerationOutput(
+            image_path=final_output_path,
+            description=current_description,
+            iterations=iterations,
+            metadata=metadata_dict,
+            generated_caption=generated_caption,
+        )
 
     async def generate(
         self,

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -401,7 +401,11 @@ class PaperBananaPipeline:
         iteration_timings: list[dict[str, float | int]] = []
         budget_exceeded = self._check_budget("before regenerate-from-ir iterations")
         vector_formats = ["svg", "pdf"] if self.settings.vector_export else None
-        total_iters = self.settings.max_iterations if self.settings.auto_refine else self.settings.refinement_iterations
+        total_iters = (
+            self.settings.max_iterations
+            if self.settings.auto_refine
+            else self.settings.refinement_iterations
+        )
 
         if self.settings.save_iterations:
             save_json(

--- a/paperbanana/core/types.py
+++ b/paperbanana/core/types.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Supported aspect ratios for diagram/plot generation.
 SUPPORTED_ASPECT_RATIOS = {
@@ -158,11 +158,13 @@ class DiagramIRNode(BaseModel):
     id: str
     label: str
     lane: Optional[str] = None
+    shape: Optional[str] = None
 
 
 class DiagramIREdge(BaseModel):
     """A directed edge in the diagram intermediate representation."""
 
+    id: Optional[str] = None
     source: str
     target: str
     label: Optional[str] = None
@@ -176,6 +178,14 @@ class DiagramIRGroup(BaseModel):
     node_ids: list[str] = Field(default_factory=list)
 
 
+class DiagramIRLocks(BaseModel):
+    """Optional lock constraints for lock-aware regeneration."""
+
+    locked_node_ids: list[str] = Field(default_factory=list)
+    locked_edge_refs: list[str] = Field(default_factory=list)
+    locked_group_ids: list[str] = Field(default_factory=list)
+
+
 class DiagramIR(BaseModel):
     """Lightweight intermediate representation for editable exports."""
 
@@ -183,6 +193,62 @@ class DiagramIR(BaseModel):
     nodes: list[DiagramIRNode] = Field(default_factory=list)
     edges: list[DiagramIREdge] = Field(default_factory=list)
     groups: list[DiagramIRGroup] = Field(default_factory=list)
+    layout_direction: Literal["LR", "TB", "RL", "BT"] = "LR"
+    locks: DiagramIRLocks = Field(default_factory=DiagramIRLocks)
+
+    @model_validator(mode="after")
+    def validate_references(self) -> "DiagramIR":
+        """Validate IDs, cross-references, and lock targets."""
+        node_ids = [n.id for n in self.nodes]
+        if len(node_ids) != len(set(node_ids)):
+            raise ValueError("DiagramIR nodes contain duplicate IDs")
+        node_set = set(node_ids)
+
+        group_ids = [g.id for g in self.groups]
+        if len(group_ids) != len(set(group_ids)):
+            raise ValueError("DiagramIR groups contain duplicate IDs")
+        group_set = set(group_ids)
+
+        edge_ids = [e.id for e in self.edges if e.id]
+        if len(edge_ids) != len(set(edge_ids)):
+            raise ValueError("DiagramIR edges contain duplicate IDs")
+
+        edge_refs: set[str] = set()
+        for e in self.edges:
+            if e.source not in node_set or e.target not in node_set:
+                raise ValueError(
+                    f"DiagramIR edge references unknown node(s): {e.source} -> {e.target}"
+                )
+            edge_refs.add(f"{e.source}->{e.target}")
+            if e.label:
+                edge_refs.add(f"{e.source}->{e.target}:{e.label}")
+            if e.id:
+                edge_refs.add(e.id)
+
+        for g in self.groups:
+            missing_nodes = [nid for nid in g.node_ids if nid not in node_set]
+            if missing_nodes:
+                missing = ", ".join(missing_nodes)
+                raise ValueError(f"DiagramIR group '{g.id}' references unknown nodes: {missing}")
+
+        missing_locked_nodes = [nid for nid in self.locks.locked_node_ids if nid not in node_set]
+        if missing_locked_nodes:
+            raise ValueError(
+                "DiagramIR locks reference unknown nodes: " + ", ".join(missing_locked_nodes)
+            )
+
+        missing_locked_groups = [gid for gid in self.locks.locked_group_ids if gid not in group_set]
+        if missing_locked_groups:
+            raise ValueError(
+                "DiagramIR locks reference unknown groups: " + ", ".join(missing_locked_groups)
+            )
+
+        missing_locked_edges = [eref for eref in self.locks.locked_edge_refs if eref not in edge_refs]
+        if missing_locked_edges:
+            raise ValueError(
+                "DiagramIR locks reference unknown edges: " + ", ".join(missing_locked_edges)
+            )
+        return self
 
 
 VALID_WINNERS = {"Model", "Human", "Both are good", "Both are bad"}

--- a/paperbanana/core/types.py
+++ b/paperbanana/core/types.py
@@ -243,7 +243,9 @@ class DiagramIR(BaseModel):
                 "DiagramIR locks reference unknown groups: " + ", ".join(missing_locked_groups)
             )
 
-        missing_locked_edges = [eref for eref in self.locks.locked_edge_refs if eref not in edge_refs]
+        missing_locked_edges = [
+            eref for eref in self.locks.locked_edge_refs if eref not in edge_refs
+        ]
         if missing_locked_edges:
             raise ValueError(
                 "DiagramIR locks reference unknown edges: " + ", ".join(missing_locked_edges)

--- a/tests/test_cli_regenerate.py
+++ b/tests/test_cli_regenerate.py
@@ -1,0 +1,128 @@
+"""Tests for the `paperbanana regenerate` CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from paperbanana.cli import app
+from paperbanana.core.types import (
+    DiagramIR,
+    DiagramIREdge,
+    DiagramIRLocks,
+    DiagramIRNode,
+    GenerationOutput,
+)
+
+runner = CliRunner()
+
+
+def _write_valid_ir(path: Path) -> None:
+    ir = DiagramIR(
+        title="Locked figure",
+        nodes=[
+            DiagramIRNode(id="n1", label="Input"),
+            DiagramIRNode(id="n2", label="Output"),
+        ],
+        edges=[DiagramIREdge(source="n1", target="n2", label="flow")],
+        locks=DiagramIRLocks(
+            locked_node_ids=["n1"],
+            locked_edge_refs=["n1->n2", "n1->n2:flow"],
+        ),
+    )
+    path.write_text(ir.model_dump_json(indent=2), encoding="utf-8")
+
+
+def test_regenerate_rejects_missing_ir_file(tmp_path):
+    """`regenerate` exits with an error when --diagram-ir is missing."""
+    input_path = tmp_path / "input.txt"
+    input_path.write_text("Method text", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "regenerate",
+            "--diagram-ir",
+            str(tmp_path / "missing.json"),
+            "--input",
+            str(input_path),
+            "--caption",
+            "Locked caption",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Diagram IR not found" in result.output
+
+
+def test_regenerate_runs_pipeline_and_passes_locks(tmp_path, monkeypatch):
+    """`regenerate` parses DiagramIR locks and passes them to pipeline."""
+    input_path = tmp_path / "input.txt"
+    input_path.write_text("Method text", encoding="utf-8")
+    ir_path = tmp_path / "diagram_ir.json"
+    _write_valid_ir(ir_path)
+
+    captured: dict[str, object] = {}
+
+    class _FakePipeline:
+        def __init__(self, settings=None, progress_callback=None, **kwargs):
+            captured["settings"] = settings
+            captured["progress_callback"] = progress_callback
+
+        async def regenerate_from_ir(
+            self,
+            *,
+            diagram_ir,
+            source_context,
+            caption,
+            aspect_ratio,
+            progress_callback=None,
+        ):
+            captured["diagram_ir"] = diagram_ir
+            captured["source_context"] = source_context
+            captured["caption"] = caption
+            captured["aspect_ratio"] = aspect_ratio
+            captured["regenerate_progress_callback"] = progress_callback
+
+            out_path = tmp_path / "regen.png"
+            out_path.write_bytes(b"fake")
+            return GenerationOutput(
+                image_path=str(out_path),
+                description="done",
+                iterations=[],
+                metadata={"run_id": "run_regen"},
+            )
+
+    monkeypatch.setattr("paperbanana.cli.PaperBananaPipeline", _FakePipeline)
+    monkeypatch.setattr(
+        "paperbanana.core.source_loader.load_methodology_source",
+        lambda *args, **kwargs: "Loaded source context",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "regenerate",
+            "--diagram-ir",
+            str(ir_path),
+            "--input",
+            str(input_path),
+            "--caption",
+            "Locked caption",
+            "--aspect-ratio",
+            "16:9",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Lock-aware IR Regeneration" in result.output
+    assert "run_regen" in result.output
+
+    parsed_ir = captured["diagram_ir"]
+    assert isinstance(parsed_ir, DiagramIR)
+    assert parsed_ir.locks.locked_node_ids == ["n1"]
+    assert "n1->n2" in parsed_ir.locks.locked_edge_refs
+    assert captured["source_context"] == "Loaded source context"
+    assert captured["caption"] == "Locked caption"
+    assert captured["aspect_ratio"] == "16:9"

--- a/tests/test_core/test_diagram_ir_locks.py
+++ b/tests/test_core/test_diagram_ir_locks.py
@@ -1,0 +1,50 @@
+"""Tests for DiagramIR lock metadata and lock-aware formatting."""
+
+from __future__ import annotations
+
+import pytest
+
+from paperbanana.core.diagram_ir import format_diagram_ir_for_regeneration
+from paperbanana.core.types import DiagramIR, DiagramIREdge, DiagramIRLocks, DiagramIRNode
+
+
+def test_diagram_ir_locks_validate_known_references() -> None:
+    ir = DiagramIR(
+        title="Locked",
+        nodes=[
+            DiagramIRNode(id="n1", label="Input"),
+            DiagramIRNode(id="n2", label="Output"),
+        ],
+        edges=[DiagramIREdge(id="e1", source="n1", target="n2", label="flow")],
+        locks=DiagramIRLocks(
+            locked_node_ids=["n1"],
+            locked_edge_refs=["e1", "n1->n2", "n1->n2:flow"],
+        ),
+    )
+    assert ir.locks.locked_node_ids == ["n1"]
+
+
+def test_diagram_ir_locks_reject_unknown_references() -> None:
+    with pytest.raises(ValueError):
+        DiagramIR(
+            title="Bad lock",
+            nodes=[DiagramIRNode(id="n1", label="Only")],
+            edges=[],
+            locks=DiagramIRLocks(locked_node_ids=["missing"]),
+        )
+
+
+def test_format_diagram_ir_for_regeneration_includes_lock_hints() -> None:
+    ir = DiagramIR(
+        title="Format Test",
+        nodes=[
+            DiagramIRNode(id="n1", label="Encode"),
+            DiagramIRNode(id="n2", label="Decode"),
+        ],
+        edges=[DiagramIREdge(source="n1", target="n2")],
+        locks=DiagramIRLocks(locked_node_ids=["n1"], locked_edge_refs=["n1->n2"]),
+    )
+
+    text = format_diagram_ir_for_regeneration(ir)
+    assert "n1: Encode [LOCKED]" in text
+    assert "Hard constraints:" in text

--- a/tests/test_pipeline/test_regenerate_from_ir.py
+++ b/tests/test_pipeline/test_regenerate_from_ir.py
@@ -1,0 +1,146 @@
+"""Integration and smoke tests for lock-aware regeneration from DiagramIR."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PIL", reason="PIL/Pillow required for pipeline image mock")
+from PIL import Image
+
+from paperbanana.core.config import Settings
+from paperbanana.core.pipeline import PaperBananaPipeline
+from paperbanana.core.types import CritiqueResult, DiagramIR, DiagramIREdge, DiagramIRLocks, DiagramIRNode
+
+
+class _MockVLM:
+    name = "mock-vlm"
+    model_name = "mock-model"
+
+    async def generate(self, *args, **kwargs):
+        return "unused"
+
+
+class _MockImageGen:
+    name = "mock-image-gen"
+    model_name = "mock-image-model"
+
+    async def generate(self, *args, **kwargs):
+        return Image.new("RGB", (128, 128), color=(255, 255, 255))
+
+
+def _make_locked_ir() -> DiagramIR:
+    return DiagramIR(
+        title="Locked diagram",
+        nodes=[
+            DiagramIRNode(id="n1", label="Locked Input"),
+            DiagramIRNode(id="n2", label="Output"),
+        ],
+        edges=[DiagramIREdge(source="n1", target="n2", label="flow")],
+        locks=DiagramIRLocks(
+            locked_node_ids=["n1"],
+            locked_edge_refs=["n1->n2", "n1->n2:flow"],
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_regenerate_from_ir_writes_metadata_and_artifacts(tmp_path):
+    """Pipeline regeneration writes run inputs/artifacts and lock metadata."""
+    settings = Settings(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "empty_refs"),
+        refinement_iterations=1,
+        save_iterations=True,
+    )
+    pipeline = PaperBananaPipeline(
+        settings=settings,
+        vlm_client=_MockVLM(),
+        image_gen_fn=_MockImageGen(),
+    )
+    ir = _make_locked_ir()
+
+    result = await pipeline.regenerate_from_ir(
+        diagram_ir=ir,
+        source_context="Method context",
+        caption="Figure caption",
+        aspect_ratio="4:3",
+    )
+
+    assert Path(result.image_path).exists()
+    assert result.metadata["regeneration"]["mode"] == "diagram_ir_locked"
+    assert result.metadata["regeneration"]["locked_nodes"] == 1
+    assert result.metadata["regeneration"]["locked_edges"] == 2
+    assert result.description.count("[LOCKED]") >= 1
+
+    run_dir = Path(settings.output_dir) / result.metadata["run_id"]
+    assert (run_dir / "run_input.json").exists()
+    assert (run_dir / "diagram_ir_input.json").exists()
+    run_input = json.loads((run_dir / "run_input.json").read_text(encoding="utf-8"))
+    assert run_input["regeneration_mode"] == "diagram_ir_locked"
+    assert run_input["locked_nodes"] == ["n1"]
+
+
+@pytest.mark.asyncio
+async def test_regenerate_smoke_reapplies_locks_when_critic_suggests_locked_edit(
+    tmp_path, monkeypatch
+):
+    """Locked constraints remain in prompts after critic proposes conflicting edits."""
+    settings = Settings(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "empty_refs"),
+        refinement_iterations=2,
+        save_iterations=False,
+    )
+    pipeline = PaperBananaPipeline(
+        settings=settings,
+        vlm_client=_MockVLM(),
+        image_gen_fn=_MockImageGen(),
+    )
+    ir = _make_locked_ir()
+    seen_descriptions: list[str] = []
+
+    async def _fake_visualizer_run(
+        *,
+        description,
+        diagram_type,
+        raw_data,
+        iteration,
+        seed,
+        aspect_ratio,
+        vector_formats,
+    ):
+        seen_descriptions.append(description)
+        out = Path(settings.output_dir) / pipeline.run_id / f"diagram_iter_{iteration}.png"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("RGB", (64, 64), color=(120, 120, 120)).save(out)
+        return str(out)
+
+    critique_calls = {"n": 0}
+
+    async def _fake_critic_run(**kwargs):
+        critique_calls["n"] += 1
+        if critique_calls["n"] == 1:
+            return CritiqueResult(
+                critic_suggestions=["Change locked node n1 label to Hacked"],
+                revised_description="Please rename n1 to Hacked.",
+            )
+        return CritiqueResult(critic_suggestions=[], revised_description=None)
+
+    monkeypatch.setattr(pipeline.visualizer, "run", _fake_visualizer_run)
+    monkeypatch.setattr(pipeline.critic, "run", _fake_critic_run)
+
+    result = await pipeline.regenerate_from_ir(
+        diagram_ir=ir,
+        source_context="Method context",
+        caption="Figure caption",
+    )
+
+    assert Path(result.image_path).exists()
+    assert len(result.iterations) == 2
+    assert len(seen_descriptions) == 2
+    assert "n1: Locked Input [LOCKED]" in seen_descriptions[0]
+    assert "Please rename n1 to Hacked." in seen_descriptions[1]
+    assert "n1: Locked Input [LOCKED]" in seen_descriptions[1]

--- a/tests/test_pipeline/test_regenerate_from_ir.py
+++ b/tests/test_pipeline/test_regenerate_from_ir.py
@@ -6,13 +6,19 @@ import json
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 pytest.importorskip("PIL", reason="PIL/Pillow required for pipeline image mock")
-from PIL import Image
 
 from paperbanana.core.config import Settings
 from paperbanana.core.pipeline import PaperBananaPipeline
-from paperbanana.core.types import CritiqueResult, DiagramIR, DiagramIREdge, DiagramIRLocks, DiagramIRNode
+from paperbanana.core.types import (
+    CritiqueResult,
+    DiagramIR,
+    DiagramIREdge,
+    DiagramIRLocks,
+    DiagramIRNode,
+)
 
 
 class _MockVLM:


### PR DESCRIPTION
## Summary

- Adds lock semantics to DiagramIR so users can mark nodes/edges/groups as immutable during refinement.
- Introduces a new regeneration path that starts from edited IR (paperbanana regenerate) instead of redoing full planning.
- Preserves lock constraints across critic-driven revisions and records regeneration metadata/artifacts.
Closes #175 

## Motivation
Generated methodology diagrams are often close but still need precise manual edits before publication. This PR enables a human-in-the-loop workflow where users edit IR directly, lock key structure, and let PaperBanana improve only unlocked portions.

## What changed

- Core schema/validation
  - Added DiagramIRLocks (locked_node_ids, locked_edge_refs, locked_group_ids).
  - Added optional edge IDs for stable edge locking.
  - Added IR consistency validation for duplicate IDs and invalid references.
- IR utilities
  - Added lock-aware IR-to-text formatter for regeneration prompts.
  - Added visual locked-node highlighting in SVG export.
- Pipeline
  - Added PaperBananaPipeline.regenerate_from_ir(...).
  - Runs visualizer/critic loop from edited IR with lock constraints carried forward.
  - Saves regeneration-specific metadata and input IR artifacts.
- CLI
  - Added paperbanana regenerate command:
    - --diagram-ir
    - --input
    - --caption
    - standard iteration/model/aspect options
- Tests
  - Added lock-focused tests for validation and formatting.
