### PR TITLE
Feat/mcp orchestrate batch workflows

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -10,6 +10,18 @@ MCP server that exposes PaperBanana's diagram and plot generation as tools for C
 | `generate_plot` | Generate a statistical plot from JSON data + intent description |
 | `evaluate_diagram` | Compare a generated diagram against a human reference (4 dimensions) |
 | `evaluate_plot` | Compare a generated statistical plot against a human reference (4 dimensions) |
+| `download_references` | Download the expanded reference set for stronger retrieval |
+| `orchestrate_figures` | Plan / generate a full-paper figure package (same workflow as `paperbanana orchestrate`); returns JSON paths and status |
+| `batch_diagrams` | Run a methodology batch from a manifest path (`paperbanana batch`) |
+| `batch_plots` | Run a statistical plot batch from a manifest path (`paperbanana plot-batch`) |
+
+### Batch and orchestration tools
+
+These tools return **pretty-printed JSON** with absolute paths to `batch_report.json`, `figure_package.json`, `orchestration_plan.json`, `figures.tex`, `captions.md`, and per-item summaries. Use `dry_run=True` on `orchestrate_figures` to plan only (no generation API calls).
+
+Long runs execute in a **worker thread** so they do not block the MCP server event loop; progress lines are logged via structlog (`mcp_orchestrate`, `mcp_batch_diagrams`, `mcp_batch_plots`).
+
+On validation errors (missing manifest, bad flags), the JSON body includes `"error"` and `"strict_success": false`.
 
 ## Installation
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -9,6 +9,9 @@ Tools:
     evaluate_diagram    — Evaluate a generated diagram against a reference
     evaluate_plot       — Evaluate a generated plot against a reference
     download_references — Download expanded reference set (~294 examples)
+    orchestrate_figures — Full-paper figure package (plan + optional generation)
+    batch_diagrams      — Batch methodology diagrams from a YAML/JSON manifest
+    batch_plots         — Batch statistical plots from a YAML/JSON manifest
 
 Usage:
     paperbanana-mcp          # stdio transport (default)
@@ -16,6 +19,7 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from io import BytesIO
@@ -30,6 +34,11 @@ from paperbanana.core.config import Settings
 from paperbanana.core.pipeline import PaperBananaPipeline
 from paperbanana.core.types import DiagramType, GenerationInput
 from paperbanana.core.utils import detect_image_mime_type, find_prompt_dir
+from paperbanana.core.workflow_runner import (
+    run_methodology_batch,
+    run_orchestration_package,
+    run_plot_batch,
+)
 from paperbanana.evaluation.judge import VLMJudge
 from paperbanana.providers.registry import ProviderRegistry
 
@@ -402,6 +411,205 @@ async def download_references(
         f"Cached to: {dm.reference_dir}\n"
         f"The Retriever agent will now use these for better diagram generation."
     )
+
+
+def _json_result(payload: dict) -> str:
+    return json.dumps(payload, indent=2)
+
+
+@mcp.tool
+async def orchestrate_figures(
+    paper: str | None = None,
+    resume_orchestrate: str | None = None,
+    output_dir: str = "outputs",
+    data_dir: str | None = None,
+    max_method_figures: int = 4,
+    max_plot_figures: int = 4,
+    pdf_pages: str | None = None,
+    dry_run: bool = False,
+    config: str | None = None,
+    vlm_provider: str | None = None,
+    vlm_model: str | None = None,
+    image_provider: str | None = None,
+    image_model: str | None = None,
+    iterations: int | None = None,
+    auto: bool = False,
+    max_iterations: int | None = None,
+    optimize: bool = False,
+    format: str = "png",
+    save_prompts: bool | None = None,
+    venue: str | None = None,
+    retry_failed: bool = False,
+    max_retries: int = 0,
+    concurrency: int = 1,
+) -> str:
+    """Plan and optionally generate a multi-figure publication package from a paper.
+
+    Mirrors ``paperbanana orchestrate``. Use ``dry_run=True`` to write
+    ``orchestration_plan.json`` only (no API generation). For continuation,
+    pass ``resume_orchestrate`` with an orchestration id or package directory path.
+
+    Returns:
+        JSON string with orchestration_id, paths to ``figure_package.json``,
+        ``figures.tex``, ``captions.md``, ``orchestration_plan.json``, counts,
+        ``strict_success``, and ``failures`` when applicable.
+    """
+
+    def _run() -> dict:
+        return run_orchestration_package(
+            paper=paper,
+            resume_orchestrate=resume_orchestrate,
+            output_dir=Path(output_dir),
+            data_dir=data_dir,
+            max_method_figures=max_method_figures,
+            max_plot_figures=max_plot_figures,
+            pdf_pages=pdf_pages,
+            dry_run=dry_run,
+            config=config,
+            vlm_provider=vlm_provider,
+            vlm_model=vlm_model,
+            image_provider=image_provider,
+            image_model=image_model,
+            iterations=iterations,
+            auto=auto,
+            max_iterations=max_iterations,
+            optimize=optimize,
+            format=format,
+            save_prompts=save_prompts,
+            venue=venue,
+            retry_failed=retry_failed,
+            max_retries=max_retries,
+            concurrency=concurrency,
+            progress_callback=lambda m: logger.info("mcp_orchestrate", message=m),
+        )
+
+    try:
+        result = await asyncio.to_thread(_run)
+    except (FileNotFoundError, ValueError, ImportError, RuntimeError) as e:
+        return _json_result({"error": str(e), "strict_success": False})
+    return _json_result(result)
+
+
+@mcp.tool
+async def batch_diagrams(
+    manifest_path: str,
+    output_dir: str = "outputs",
+    config: str | None = None,
+    vlm_provider: str | None = None,
+    vlm_model: str | None = None,
+    image_provider: str | None = None,
+    image_model: str | None = None,
+    iterations: int | None = None,
+    auto: bool = False,
+    max_iterations: int | None = None,
+    optimize: bool = False,
+    format: str = "png",
+    save_prompts: bool | None = None,
+    venue: str | None = None,
+    auto_download_data: bool = False,
+    resume_batch: str | None = None,
+    retry_failed: bool = False,
+    max_retries: int = 0,
+    concurrency: int = 1,
+) -> str:
+    """Run methodology diagram batch from a manifest (YAML or JSON).
+
+    Each manifest item needs ``input`` (text or PDF path) and ``caption``.
+    Paths are resolved relative to the manifest file directory.
+    Returns JSON with ``batch_dir``, ``batch_report_path``, per-item summary,
+    ``composite_path`` when configured, and ``strict_success`` (false if any item failed).
+    """
+
+    def _run() -> dict:
+        return run_methodology_batch(
+            manifest_path=Path(manifest_path),
+            output_dir=Path(output_dir),
+            config=config,
+            vlm_provider=vlm_provider,
+            vlm_model=vlm_model,
+            image_provider=image_provider,
+            image_model=image_model,
+            iterations=iterations,
+            auto=auto,
+            max_iterations=max_iterations,
+            optimize=optimize,
+            format=format,
+            save_prompts=save_prompts,
+            venue=venue,
+            auto_download_data=auto_download_data,
+            resume_batch=resume_batch,
+            retry_failed=retry_failed,
+            max_retries=max_retries,
+            concurrency=concurrency,
+            progress_callback=lambda m: logger.info("mcp_batch_diagrams", message=m),
+        )
+
+    try:
+        result = await asyncio.to_thread(_run)
+    except (FileNotFoundError, ValueError, RuntimeError) as e:
+        return _json_result({"error": str(e), "strict_success": False})
+    return _json_result(result)
+
+
+@mcp.tool
+async def batch_plots(
+    manifest_path: str,
+    output_dir: str = "outputs",
+    config: str | None = None,
+    vlm_provider: str | None = None,
+    vlm_model: str | None = None,
+    image_provider: str | None = None,
+    image_model: str | None = None,
+    iterations: int | None = None,
+    auto: bool = False,
+    max_iterations: int | None = None,
+    optimize: bool = False,
+    format: str = "png",
+    save_prompts: bool | None = None,
+    venue: str | None = None,
+    aspect_ratio: str | None = None,
+    resume_batch: str | None = None,
+    retry_failed: bool = False,
+    max_retries: int = 0,
+    concurrency: int = 1,
+) -> str:
+    """Run statistical plot batch from a manifest (YAML or JSON).
+
+    Each item needs ``data`` (CSV or JSON path) and ``intent``. When
+    ``vlm_provider`` is omitted, defaults to ``gemini`` (same as CLI plot-batch).
+    Returns JSON with ``batch_dir``, ``batch_report_path``, item summary, and
+    ``strict_success``.
+    """
+
+    def _run() -> dict:
+        return run_plot_batch(
+            manifest_path=Path(manifest_path),
+            output_dir=Path(output_dir),
+            config=config,
+            vlm_provider=vlm_provider,
+            vlm_model=vlm_model,
+            image_provider=image_provider,
+            image_model=image_model,
+            iterations=iterations,
+            auto=auto,
+            max_iterations=max_iterations,
+            optimize=optimize,
+            format=format,
+            save_prompts=save_prompts,
+            venue=venue,
+            aspect_ratio=aspect_ratio,
+            resume_batch=resume_batch,
+            retry_failed=retry_failed,
+            max_retries=max_retries,
+            concurrency=concurrency,
+            progress_callback=lambda m: logger.info("mcp_batch_plots", message=m),
+        )
+
+    try:
+        result = await asyncio.to_thread(_run)
+    except (FileNotFoundError, ValueError, RuntimeError) as e:
+        return _json_result({"error": str(e), "strict_success": False})
+    return _json_result(result)
 
 
 def main():

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -1055,205 +1055,79 @@ def batch(
         console.print(f"[red]Error: Manifest not found: {manifest}[/red]")
         raise typer.Exit(1)
 
-    from paperbanana.core.batch import (
-        checkpoint_progress,
-        generate_batch_id,
-        init_or_load_checkpoint,
-        load_batch_manifest_with_composite,
-        mark_item_failure,
-        mark_item_running,
-        mark_item_success,
-        select_items_for_run,
-    )
-    from paperbanana.core.utils import ensure_dir
+    from paperbanana.core.batch import load_batch_manifest_with_composite
+    from paperbanana.core.workflow_runner import run_methodology_batch
 
     try:
-        items, composite_config = load_batch_manifest_with_composite(manifest_path)
+        items, _composite = load_batch_manifest_with_composite(manifest_path)
     except (ValueError, FileNotFoundError, RuntimeError) as e:
         console.print(f"[red]Error loading manifest: {e}[/red]")
         raise typer.Exit(1)
 
     if any(str(item.get("input", "")).lower().endswith(".pdf") for item in items):
-        _require_pdf_dep()
-
-    is_resume = bool(resume_batch)
-    if is_resume:
-        resume_ref = Path(resume_batch)
-        if resume_ref.is_dir():
-            batch_dir = resume_ref.resolve()
-            batch_id = batch_dir.name
-        else:
-            batch_id = resume_batch.strip()
-            batch_dir = (Path(output_dir) / batch_id).resolve()
-    else:
-        batch_id = generate_batch_id()
-        batch_dir = (Path(output_dir) / batch_id).resolve()
-    ensure_dir(batch_dir)
-
-    overrides = {"output_dir": str(batch_dir), "output_format": format}
-    if vlm_provider:
-        overrides["vlm_provider"] = vlm_provider
-    if vlm_model:
-        overrides["vlm_model"] = vlm_model
-    if image_provider:
-        overrides["image_provider"] = image_provider
-    if image_model:
-        overrides["image_model"] = image_model
-    if iterations is not None:
-        overrides["refinement_iterations"] = iterations
-    if auto:
-        overrides["auto_refine"] = True
-    if max_iterations is not None:
-        overrides["max_iterations"] = max_iterations
-    if optimize:
-        overrides["optimize_inputs"] = True
-    if save_prompts is not None:
-        overrides["save_prompts"] = save_prompts
-    if venue:
-        overrides["venue"] = venue
-
-    if config:
-        settings = Settings.from_yaml(config, **overrides)
-    else:
-        from dotenv import load_dotenv
-
-        load_dotenv()
-        settings = Settings(**overrides)
-
-    if auto_download_data:
-        from paperbanana.data.manager import DatasetManager
-
-        dm = DatasetManager(cache_dir=settings.cache_dir)
-        if not dm.is_downloaded():
-            console.print("  [dim]Downloading curated expansion set...[/dim]")
-            try:
-                dm.download(dataset="curated")
-            except Exception as e:
-                console.print(f"  [yellow]Download failed: {e}, using built-in set[/yellow]")
+        try:
+            _require_pdf_dep()
+        except typer.Exit:
+            raise
 
     console.print(
         Panel.fit(
-            f"[bold]PaperBanana[/bold] — {'Resume ' if is_resume else ''}Batch Generation\n\n"
+            f"[bold]PaperBanana[/bold] — {'Resume ' if resume_batch else ''}Batch Generation\n\n"
             f"Manifest: {manifest_path.name}\n"
             f"Items: {len(items)}\n"
-            f"Output: {batch_dir}\n"
+            f"Output parent: {Path(output_dir).resolve()}\n"
             f"Concurrency: {concurrency}",
             border_style="blue",
         )
     )
     console.print()
 
-    from paperbanana.core.pipeline import PaperBananaPipeline
-    from paperbanana.core.source_loader import load_methodology_source
-
     try:
-        state = init_or_load_checkpoint(
-            batch_dir=batch_dir,
-            batch_id=batch_id,
+        result = run_methodology_batch(
             manifest_path=manifest_path,
-            batch_kind="methodology",
-            items=items,
-            resume=is_resume,
+            output_dir=Path(output_dir),
+            config=config,
+            vlm_provider=vlm_provider,
+            vlm_model=vlm_model,
+            image_provider=image_provider,
+            image_model=image_model,
+            iterations=iterations,
+            auto=auto,
+            max_iterations=max_iterations,
+            optimize=optimize,
+            format=format,
+            save_prompts=save_prompts,
+            venue=venue,
+            auto_download_data=auto_download_data,
+            resume_batch=resume_batch,
+            retry_failed=retry_failed,
+            max_retries=max_retries,
+            concurrency=concurrency,
+            progress_callback=console.print,
         )
-    except (FileNotFoundError, ValueError) as e:
+    except (ValueError, FileNotFoundError, RuntimeError) as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)
 
-    total_start = time.perf_counter()
-    planned = select_items_for_run(state, retry_failed=retry_failed)
-    if not planned:
-        checkpoint_progress(batch_dir=batch_dir, state=state, mark_complete=True)
+    batch_dir = Path(result["batch_dir"])
+    report_path = Path(result["batch_report_path"])
+    if not result.get("had_work", True):
         console.print("[yellow]Nothing to run: all items already completed.[/yellow]")
-        console.print(f"  Report: [bold]{batch_dir / 'batch_report.json'}[/bold]")
+        console.print(f"  Report: [bold]{report_path}[/bold]")
         return
 
-    async def _run_all() -> None:
-        sem = asyncio.Semaphore(concurrency)
-
-        async def _run_one(idx: int, item: dict[str, object]) -> None:
-            item_key = str(item["_item_key"])
-            item_id = str(item["id"])
-            async with sem:
-                for attempt in range(max_retries + 1):
-                    mark_item_running(state, item_key)
-                    checkpoint_progress(
-                        batch_dir=batch_dir,
-                        state=state,
-                        total_seconds=time.perf_counter() - total_start,
-                    )
-                    input_path = Path(str(item["input"]))
-                    if not input_path.exists():
-                        mark_item_failure(state, item_key, "input file not found")
-                        checkpoint_progress(
-                            batch_dir=batch_dir,
-                            state=state,
-                            total_seconds=time.perf_counter() - total_start,
-                        )
-                        console.print(
-                            f"[red]Item {idx + 1}/{len(items)} {item_id}: input missing[/red]"
-                        )
-                        return
-                    try:
-                        source_context = load_methodology_source(
-                            input_path, pdf_pages=item.get("pdf_pages")
-                        )
-                        gen_input = GenerationInput(
-                            source_context=source_context,
-                            communicative_intent=str(item["caption"]),
-                            diagram_type=DiagramType.METHODOLOGY,
-                        )
-                        result = await PaperBananaPipeline(settings=settings).generate(gen_input)
-                        mark_item_success(
-                            state,
-                            item_key,
-                            result.metadata.get("run_id"),
-                            result.image_path,
-                            len(result.iterations),
-                        )
-                        checkpoint_progress(
-                            batch_dir=batch_dir,
-                            state=state,
-                            total_seconds=time.perf_counter() - total_start,
-                        )
-                        console.print(
-                            f"[green]Item {idx + 1}/{len(items)} {item_id}: ok[/green] "
-                            f"[dim]{result.image_path}[/dim]"
-                        )
-                        return
-                    except Exception as e:
-                        mark_item_failure(state, item_key, str(e))
-                        checkpoint_progress(
-                            batch_dir=batch_dir,
-                            state=state,
-                            total_seconds=time.perf_counter() - total_start,
-                        )
-                        if attempt < max_retries:
-                            console.print(
-                                f"[yellow]Item {item_id}: retry {attempt + 1}/{max_retries} "
-                                f"after {e}[/yellow]"
-                            )
-                            continue
-                        console.print(
-                            f"[red]Item {idx + 1}/{len(items)} {item_id}: failed - {e}[/red]"
-                        )
-                        return
-
-        await asyncio.gather(*[_run_one(idx, item) for idx, item, _ in planned])
-
-    asyncio.run(_run_all())
-
-    total_elapsed = time.perf_counter() - total_start
-    report = checkpoint_progress(
-        batch_dir=batch_dir,
-        state=state,
-        total_seconds=total_elapsed,
-        mark_complete=True,
-    )
-    report_path = batch_dir / "batch_report.json"
-    ri = report["items"]
-    succeeded = sum(1 for x in ri if x.get("status") == "success")
-    failed = sum(1 for x in ri if x.get("status") == "failed")
-    skipped = len(ri) - succeeded - failed
+    succeeded = int(result["succeeded"])
+    failed = int(result["failed"])
+    skipped = int(result["skipped"])
+    total_elapsed = 0.0
+    report_file = batch_dir / "batch_report.json"
+    if report_file.exists():
+        try:
+            report = json_mod.loads(report_file.read_text(encoding="utf-8"))
+            total_elapsed = float(report.get("total_seconds") or 0.0)
+        except Exception:
+            pass
+    ri = result.get("items_summary", [])
     console.print(
         f"[green]Batch complete.[/green] [dim]{total_elapsed:.1f}s · "
         f"{succeeded} succeeded · {failed} failed · {skipped} skipped[/dim]"
@@ -1281,27 +1155,9 @@ def batch(
     if failed > 0:
         raise typer.Exit(1)
 
-    # Auto-composite if manifest has a composite section
-    if composite_config is not None:
-        output_paths = [x["output_path"] for x in report["items"] if x.get("output_path")]
-        if output_paths:
-            from paperbanana.core.composite import compose_images
-
-            comp_output = composite_config.get("output") or "composite.png"
-            comp_path = batch_dir / comp_output
-            try:
-                compose_images(
-                    image_paths=output_paths,
-                    layout=composite_config.get("layout", "auto"),
-                    labels=composite_config.get("labels"),
-                    auto_label=composite_config.get("auto_label", True),
-                    spacing=composite_config.get("spacing", 20),
-                    label_position=composite_config.get("label_position", "bottom"),
-                    output_path=comp_path,
-                )
-                console.print(f"  Composite: [bold]{comp_path}[/bold]")
-            except Exception as e:
-                console.print(f"  [yellow]Composite failed: {e}[/yellow]")
+    comp_path = result.get("composite_path")
+    if comp_path:
+        console.print(f"  Composite: [bold]{comp_path}[/bold]")
 
 
 @app.command("batch-report")
@@ -1556,111 +1412,71 @@ def orchestrate(
 
     configure_logging(verbose=verbose)
 
-    from paperbanana.core.orchestrate import (
-        init_or_load_orchestration_checkpoint,
-        prepare_orchestration_plan,
-        run_orchestration,
-    )
+    from paperbanana.core.workflow_runner import run_orchestration_package
+
+    def _orchestration_header_panel(summary: dict) -> None:
+        orch_dir = Path(summary["orchestrate_dir"])
+        paper_display = Path(str(summary.get("paper_path") or "paper")).name
+        header = "Resume " if summary.get("resumed") else ""
+        console.print(
+            Panel.fit(
+                f"[bold]PaperBanana[/bold] — {header}Figure Package Orchestration\n\n"
+                f"Paper: {paper_display}\n"
+                f"Planned methodology figures: {summary['methodology_items_planned']}\n"
+                f"Planned plot figures: {summary['plot_items_planned']}\n"
+                f"Package dir: {orch_dir}",
+                border_style="magenta",
+            )
+        )
 
     try:
-        orchestration_id, orchestrate_dir, plan, plan_path, is_resume = prepare_orchestration_plan(
+        result = run_orchestration_package(
             paper=paper,
             resume_orchestrate=resume_orchestrate,
-            output_dir=output_dir,
+            output_dir=Path(output_dir),
             data_dir=data_dir,
             max_method_figures=max_method_figures,
             max_plot_figures=max_plot_figures,
             pdf_pages=pdf_pages,
+            dry_run=dry_run,
+            config=config,
+            vlm_provider=vlm_provider,
+            vlm_model=vlm_model,
+            image_provider=image_provider,
+            image_model=image_model,
+            iterations=iterations,
+            auto=auto,
+            max_iterations=max_iterations,
+            optimize=optimize,
+            format=format,
+            save_prompts=save_prompts,
+            venue=venue,
+            retry_failed=retry_failed,
+            max_retries=max_retries,
+            concurrency=concurrency,
+            progress_callback=console.print,
+            after_plan_callback=_orchestration_header_panel,
         )
-    except (FileNotFoundError, ValueError, ImportError) as e:
+    except (FileNotFoundError, ValueError, ImportError, RuntimeError) as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)
 
-    if not is_resume:
-        _check_pdf_dep(Path(str(plan.get("paper_path", ""))))
-
-    ensure_dir(orchestrate_dir)
-    runs_dir = ensure_dir(orchestrate_dir / "runs")
-
-    _orch_header = "Resume " if is_resume else ""
-    console.print(
-        Panel.fit(
-            f"[bold]PaperBanana[/bold] — {_orch_header}Figure Package Orchestration\n\n"
-            f"Paper: {Path(str(plan.get('paper_path', 'paper'))).name}\n"
-            f"Planned methodology figures: {len(plan['methodology_items'])}\n"
-            f"Planned plot figures: {len(plan['plot_items'])}\n"
-            f"Package dir: {orchestrate_dir}",
-            border_style="magenta",
-        )
-    )
+    orchestrate_dir = Path(result["orchestrate_dir"])
+    plan_path = Path(result["orchestration_plan_path"])
     if dry_run:
         console.print("[green]Dry run complete.[/green] Orchestration plan:")
         console.print(f"  [bold]{plan_path}[/bold]")
         return
 
-    overrides: dict[str, object] = {
-        "output_dir": str(runs_dir),
-        "output_format": format,
-        "optimize_inputs": optimize,
-        "auto_refine": auto,
-    }
-    if vlm_provider:
-        overrides["vlm_provider"] = vlm_provider
-    if vlm_model:
-        overrides["vlm_model"] = vlm_model
-    if image_provider:
-        overrides["image_provider"] = image_provider
-    if image_model:
-        overrides["image_model"] = image_model
-    if iterations is not None:
-        overrides["refinement_iterations"] = iterations
-    if max_iterations is not None:
-        overrides["max_iterations"] = max_iterations
-    if save_prompts is not None:
-        overrides["save_prompts"] = save_prompts
-    if venue:
-        overrides["venue"] = venue
-
-    if config:
-        settings = Settings.from_yaml(config, **overrides)
-    else:
-        from dotenv import load_dotenv
-
-        load_dotenv()
-        settings = Settings(**overrides)
-
-    try:
-        state = init_or_load_orchestration_checkpoint(
-            orchestrate_dir=orchestrate_dir,
-            orchestration_id=orchestration_id,
-            plan_path=plan_path,
-            plan=plan,
-            resume=is_resume,
-        )
-    except (FileNotFoundError, ValueError) as e:
-        console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1)
-
-    report, had_work = run_orchestration(
-        state=state,
-        plan=plan,
-        settings=settings,
-        orchestrate_dir=orchestrate_dir,
-        retry_failed=retry_failed,
-        max_retries=max_retries,
-        concurrency=concurrency,
-        progress_callback=console.print,
-    )
-
-    if not had_work:
+    if not result.get("had_work", True):
         console.print("[yellow]Nothing to run: all tasks already completed.[/yellow]")
         console.print(f"  Package: [bold]{orchestrate_dir / 'figure_package.json'}[/bold]")
         return
 
-    total_seconds = float(report.get("total_seconds") or 0.0)
-    success_count = len(report.get("generated_items", []))
-    fail_count = len(report.get("failures", []))
-    package_manifest_path = orchestrate_dir / "figure_package.json"
+    total_seconds = float(result.get("total_seconds") or 0.0)
+    success_count = int(result.get("generated_count", 0))
+    fail_count = int(result.get("failed_count", 0))
+    package_manifest_path = Path(result["figure_package_path"])
     console.print(
         f"[green]Orchestration complete.[/green] [dim]{success_count} generated · "
         f"{fail_count} failed · {total_seconds:.1f}s[/dim]"
@@ -1819,18 +1635,8 @@ def plot_batch(
         console.print(f"[red]Error: Manifest not found: {manifest}[/red]")
         raise typer.Exit(1)
 
-    from paperbanana.core.batch import (
-        checkpoint_progress,
-        generate_batch_id,
-        init_or_load_checkpoint,
-        load_plot_batch_manifest,
-        mark_item_failure,
-        mark_item_running,
-        mark_item_success,
-        select_items_for_run,
-    )
-    from paperbanana.core.plot_data import load_statistical_plot_payload
-    from paperbanana.core.utils import ensure_dir
+    from paperbanana.core.batch import load_plot_batch_manifest
+    from paperbanana.core.workflow_runner import run_plot_batch
 
     try:
         items = load_plot_batch_manifest(manifest_path)
@@ -1838,171 +1644,62 @@ def plot_batch(
         console.print(f"[red]Error loading manifest: {e}[/red]")
         raise typer.Exit(1)
 
-    is_resume = bool(resume_batch)
-    if is_resume:
-        resume_ref = Path(resume_batch)
-        if resume_ref.is_dir():
-            batch_dir = resume_ref.resolve()
-            batch_id = batch_dir.name
-        else:
-            batch_id = resume_batch.strip()
-            batch_dir = (Path(output_dir) / batch_id).resolve()
-    else:
-        batch_id = generate_batch_id()
-        batch_dir = (Path(output_dir) / batch_id).resolve()
-    ensure_dir(batch_dir)
-
-    overrides: dict = {
-        "output_dir": str(batch_dir),
-        "output_format": format,
-        "optimize_inputs": optimize,
-        "auto_refine": auto,
-    }
-    if vlm_provider:
-        overrides["vlm_provider"] = vlm_provider
-    if vlm_model:
-        overrides["vlm_model"] = vlm_model
-    if image_provider:
-        overrides["image_provider"] = image_provider
-    if image_model:
-        overrides["image_model"] = image_model
-    if iterations is not None:
-        overrides["refinement_iterations"] = iterations
-    if max_iterations is not None:
-        overrides["max_iterations"] = max_iterations
-    overrides["save_prompts"] = True if save_prompts is None else save_prompts
-    if venue:
-        overrides["venue"] = venue
-    if not vlm_provider:
-        overrides.setdefault("vlm_provider", "gemini")
-
-    if config:
-        settings = Settings.from_yaml(config, **overrides)
-    else:
-        from dotenv import load_dotenv
-
-        load_dotenv()
-        settings = Settings(**overrides)
-
+    _pb = "Resume " if resume_batch else ""
     console.print(
         Panel.fit(
-            f"[bold]PaperBanana[/bold] — {'Resume ' if is_resume else ''}Batch Plot Generation\n\n"
+            f"[bold]PaperBanana[/bold] — {_pb}Batch Plot Generation\n\n"
             f"Manifest: {manifest_path.name}\n"
             f"Items: {len(items)}\n"
-            f"Output: {batch_dir}\n"
+            f"Output parent: {Path(output_dir).resolve()}\n"
             f"Concurrency: {concurrency}",
             border_style="green",
         )
     )
     console.print()
 
-    from paperbanana.core.pipeline import PaperBananaPipeline
-
     try:
-        state = init_or_load_checkpoint(
-            batch_dir=batch_dir,
-            batch_id=batch_id,
+        result = run_plot_batch(
             manifest_path=manifest_path,
-            batch_kind="statistical_plot",
-            items=items,
-            resume=is_resume,
+            output_dir=Path(output_dir),
+            config=config,
+            vlm_provider=vlm_provider,
+            vlm_model=vlm_model,
+            image_provider=image_provider,
+            image_model=image_model,
+            iterations=iterations,
+            auto=auto,
+            max_iterations=max_iterations,
+            optimize=optimize,
+            format=format,
+            save_prompts=save_prompts,
+            venue=venue,
+            aspect_ratio=aspect_ratio,
+            resume_batch=resume_batch,
+            retry_failed=retry_failed,
+            max_retries=max_retries,
+            concurrency=concurrency,
+            progress_callback=console.print,
         )
-    except (FileNotFoundError, ValueError) as e:
+    except (ValueError, FileNotFoundError, RuntimeError) as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)
-    total_start = time.perf_counter()
-    planned = select_items_for_run(state, retry_failed=retry_failed)
-    if not planned:
-        checkpoint_progress(batch_dir=batch_dir, state=state, mark_complete=True)
+
+    batch_dir = Path(result["batch_dir"])
+    report_path = Path(result["batch_report_path"])
+    if not result.get("had_work", True):
         console.print("[yellow]Nothing to run: all items already completed.[/yellow]")
-        console.print(f"  Report: [bold]{batch_dir / 'batch_report.json'}[/bold]")
+        console.print(f"  Report: [bold]{report_path}[/bold]")
         return
 
-    async def _run_all() -> None:
-        sem = asyncio.Semaphore(concurrency)
-
-        async def _run_one(idx: int, item: dict[str, object]) -> None:
-            item_key = str(item["_item_key"])
-            item_id = str(item["id"])
-            async with sem:
-                for attempt in range(max_retries + 1):
-                    mark_item_running(state, item_key)
-                    checkpoint_progress(
-                        batch_dir=batch_dir,
-                        state=state,
-                        total_seconds=time.perf_counter() - total_start,
-                    )
-                    data_path = Path(str(item["data"]))
-                    if not data_path.exists():
-                        mark_item_failure(state, item_key, "data file not found")
-                        checkpoint_progress(
-                            batch_dir=batch_dir,
-                            state=state,
-                            total_seconds=time.perf_counter() - total_start,
-                        )
-                        console.print(
-                            f"[red]Item {idx + 1}/{len(items)} {item_id}: data missing[/red]"
-                        )
-                        return
-                    try:
-                        source_context, raw_data = load_statistical_plot_payload(data_path)
-                        ar = item.get("aspect_ratio") or aspect_ratio
-                        gen_input = GenerationInput(
-                            source_context=source_context,
-                            communicative_intent=str(item["intent"]),
-                            diagram_type=DiagramType.STATISTICAL_PLOT,
-                            raw_data={"data": raw_data},
-                            aspect_ratio=ar,
-                        )
-                        result = await PaperBananaPipeline(settings=settings).generate(gen_input)
-                        mark_item_success(
-                            state,
-                            item_key,
-                            result.metadata.get("run_id"),
-                            result.image_path,
-                            len(result.iterations),
-                        )
-                        checkpoint_progress(
-                            batch_dir=batch_dir,
-                            state=state,
-                            total_seconds=time.perf_counter() - total_start,
-                        )
-                        console.print(
-                            f"[green]Item {idx + 1}/{len(items)} {item_id}: ok[/green] "
-                            f"[dim]{result.image_path}[/dim]"
-                        )
-                        return
-                    except Exception as e:
-                        mark_item_failure(state, item_key, str(e))
-                        checkpoint_progress(
-                            batch_dir=batch_dir,
-                            state=state,
-                            total_seconds=time.perf_counter() - total_start,
-                        )
-                        if attempt < max_retries:
-                            console.print(
-                                f"[yellow]Item {item_id}: retry {attempt + 1}/{max_retries} "
-                                f"after {e}[/yellow]"
-                            )
-                            continue
-                        console.print(
-                            f"[red]Item {idx + 1}/{len(items)} {item_id}: failed - {e}[/red]"
-                        )
-                        return
-
-        await asyncio.gather(*[_run_one(idx, item) for idx, item, _ in planned])
-
-    asyncio.run(_run_all())
-
-    total_elapsed = time.perf_counter() - total_start
-    report = checkpoint_progress(
-        batch_dir=batch_dir,
-        state=state,
-        total_seconds=total_elapsed,
-        mark_complete=True,
-    )
-    report_path = batch_dir / "batch_report.json"
-    succeeded = sum(1 for x in report["items"] if x.get("output_path"))
+    succeeded = int(result["succeeded"])
+    total_elapsed = 0.0
+    report_file = batch_dir / "batch_report.json"
+    if report_file.exists():
+        try:
+            report = json_mod.loads(report_file.read_text(encoding="utf-8"))
+            total_elapsed = float(report.get("total_seconds") or 0.0)
+        except Exception:
+            pass
     console.print(
         f"[green]Plot batch complete.[/green] [dim]{total_elapsed:.1f}s · "
         f"{succeeded}/{len(items)} succeeded[/dim]"

--- a/paperbanana/core/workflow_runner.py
+++ b/paperbanana/core/workflow_runner.py
@@ -1,0 +1,686 @@
+"""Shared batch and orchestration execution for CLI and MCP (no Typer / Rich)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import structlog
+
+from paperbanana.core.batch import (
+    checkpoint_progress,
+    generate_batch_id,
+    init_or_load_checkpoint,
+    load_batch_manifest_with_composite,
+    load_plot_batch_manifest,
+    mark_item_failure,
+    mark_item_running,
+    mark_item_success,
+    select_items_for_run,
+)
+from paperbanana.core.config import Settings
+from paperbanana.core.orchestrate import (
+    init_or_load_orchestration_checkpoint,
+    prepare_orchestration_plan,
+    run_orchestration,
+)
+from paperbanana.core.plot_data import load_statistical_plot_payload
+from paperbanana.core.source_loader import load_methodology_source
+from paperbanana.core.types import DiagramType, GenerationInput
+from paperbanana.core.utils import ensure_dir
+
+logger = structlog.get_logger()
+
+
+def _require_pdf_dep() -> None:
+    try:
+        import fitz  # noqa: F401
+    except ImportError as e:
+        raise RuntimeError(
+            "PDF input requires PyMuPDF. Install with: pip install 'paperbanana[pdf]'"
+        ) from e
+
+
+def _check_pdf_dep(path: Path) -> None:
+    if path.suffix.lower() == ".pdf":
+        _require_pdf_dep()
+
+
+def _load_settings(
+    *,
+    config: str | None,
+    overrides: dict[str, Any],
+) -> Settings:
+    if config:
+        return Settings.from_yaml(config, **overrides)
+    from dotenv import load_dotenv
+
+    load_dotenv()
+    return Settings(**overrides)
+
+
+def run_methodology_batch(
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    config: str | None = None,
+    vlm_provider: str | None = None,
+    vlm_model: str | None = None,
+    image_provider: str | None = None,
+    image_model: str | None = None,
+    iterations: int | None = None,
+    auto: bool = False,
+    max_iterations: int | None = None,
+    optimize: bool = False,
+    format: str = "png",
+    save_prompts: bool | None = None,
+    venue: str | None = None,
+    auto_download_data: bool = False,
+    resume_batch: str | None = None,
+    retry_failed: bool = False,
+    max_retries: int = 0,
+    concurrency: int = 1,
+    progress_callback: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Run methodology batch; mirrors ``paperbanana batch``."""
+    from paperbanana.core.pipeline import PaperBananaPipeline
+    from paperbanana.data.manager import DatasetManager
+
+    manifest_path = Path(manifest_path).resolve()
+    if format not in ("png", "jpeg", "webp"):
+        raise ValueError(f"Format must be png, jpeg, or webp. Got: {format}")
+    if venue and venue.lower() not in ("neurips", "icml", "acl", "ieee", "custom"):
+        raise ValueError(f"venue must be neurips, icml, acl, ieee, or custom. Got: {venue}")
+    if max_retries < 0:
+        raise ValueError("max_retries must be >= 0")
+    if concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+
+    items, composite_config = load_batch_manifest_with_composite(manifest_path)
+    if any(str(item.get("input", "")).lower().endswith(".pdf") for item in items):
+        _require_pdf_dep()
+
+    is_resume = bool(resume_batch)
+    if is_resume:
+        resume_ref = Path(resume_batch)
+        if resume_ref.is_dir():
+            batch_dir = resume_ref.resolve()
+            batch_id = batch_dir.name
+        else:
+            batch_id = resume_batch.strip()
+            batch_dir = (Path(output_dir) / batch_id).resolve()
+    else:
+        batch_id = generate_batch_id()
+        batch_dir = (Path(output_dir) / batch_id).resolve()
+    ensure_dir(batch_dir)
+
+    overrides: dict[str, Any] = {"output_dir": str(batch_dir), "output_format": format}
+    if vlm_provider:
+        overrides["vlm_provider"] = vlm_provider
+    if vlm_model:
+        overrides["vlm_model"] = vlm_model
+    if image_provider:
+        overrides["image_provider"] = image_provider
+    if image_model:
+        overrides["image_model"] = image_model
+    if iterations is not None:
+        overrides["refinement_iterations"] = iterations
+    if auto:
+        overrides["auto_refine"] = True
+    if max_iterations is not None:
+        overrides["max_iterations"] = max_iterations
+    if optimize:
+        overrides["optimize_inputs"] = True
+    if save_prompts is not None:
+        overrides["save_prompts"] = save_prompts
+    if venue:
+        overrides["venue"] = venue
+
+    settings = _load_settings(config=config, overrides=overrides)
+
+    if auto_download_data:
+        dm = DatasetManager(cache_dir=settings.cache_dir)
+        if not dm.is_downloaded():
+            try:
+                dm.download(dataset="curated")
+            except Exception as e:
+                logger.warning("curated_download_failed", error=str(e))
+
+    state = init_or_load_checkpoint(
+        batch_dir=batch_dir,
+        batch_id=batch_id,
+        manifest_path=manifest_path,
+        batch_kind="methodology",
+        items=items,
+        resume=is_resume,
+    )
+
+    def emit(msg: str) -> None:
+        if progress_callback:
+            progress_callback(msg)
+        else:
+            logger.info("workflow_batch", message=msg)
+
+    total_start = time.perf_counter()
+    planned = select_items_for_run(state, retry_failed=retry_failed)
+    if not planned:
+        checkpoint_progress(batch_dir=batch_dir, state=state, mark_complete=True)
+        report_path = batch_dir / "batch_report.json"
+        emit(f"Nothing to run; report at {report_path}")
+        return {
+            "batch_dir": str(batch_dir),
+            "batch_id": batch_id,
+            "batch_report_path": str(report_path),
+            "had_work": False,
+            "succeeded": 0,
+            "failed": 0,
+            "skipped": len(state.get("items", {})),
+            "composite_path": None,
+            "strict_success": True,
+        }
+
+    async def _run_all() -> None:
+        sem = asyncio.Semaphore(concurrency)
+
+        async def _run_one(idx: int, item: dict[str, object]) -> None:
+            item_key = str(item["_item_key"])
+            item_id = str(item["id"])
+            async with sem:
+                for attempt in range(max_retries + 1):
+                    mark_item_running(state, item_key)
+                    checkpoint_progress(
+                        batch_dir=batch_dir,
+                        state=state,
+                        total_seconds=time.perf_counter() - total_start,
+                    )
+                    input_path = Path(str(item["input"]))
+                    if not input_path.exists():
+                        mark_item_failure(state, item_key, "input file not found")
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        emit(f"Item {idx + 1}/{len(items)} {item_id}: input missing")
+                        return
+                    try:
+                        source_context = load_methodology_source(
+                            input_path, pdf_pages=item.get("pdf_pages")
+                        )
+                        gen_input = GenerationInput(
+                            source_context=source_context,
+                            communicative_intent=str(item["caption"]),
+                            diagram_type=DiagramType.METHODOLOGY,
+                        )
+                        result = await PaperBananaPipeline(settings=settings).generate(gen_input)
+                        mark_item_success(
+                            state,
+                            item_key,
+                            result.metadata.get("run_id"),
+                            result.image_path,
+                            len(result.iterations),
+                        )
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        emit(f"Item {idx + 1}/{len(items)} {item_id}: ok -> {result.image_path}")
+                        return
+                    except Exception as e:
+                        mark_item_failure(state, item_key, str(e))
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        if attempt < max_retries:
+                            emit(f"Item {item_id}: retry {attempt + 1}/{max_retries} after {e}")
+                            continue
+                        emit(f"Item {idx + 1}/{len(items)} {item_id}: failed - {e}")
+                        return
+
+        await asyncio.gather(*[_run_one(idx, item) for idx, item, _ in planned])
+
+    asyncio.run(_run_all())
+
+    total_elapsed = time.perf_counter() - total_start
+    report = checkpoint_progress(
+        batch_dir=batch_dir,
+        state=state,
+        total_seconds=total_elapsed,
+        mark_complete=True,
+    )
+    report_path = batch_dir / "batch_report.json"
+    ri = report["items"]
+    succeeded = sum(1 for x in ri if x.get("status") == "success")
+    failed = sum(1 for x in ri if x.get("status") == "failed")
+    skipped = len(ri) - succeeded - failed
+
+    composite_path: str | None = None
+    if composite_config is not None:
+        output_paths = [x["output_path"] for x in report["items"] if x.get("output_path")]
+        if output_paths:
+            from paperbanana.core.composite import compose_images
+
+            comp_output = composite_config.get("output") or "composite.png"
+            comp_path = batch_dir / str(comp_output)
+            try:
+                compose_images(
+                    image_paths=output_paths,
+                    layout=composite_config.get("layout", "auto"),
+                    labels=composite_config.get("labels"),
+                    auto_label=composite_config.get("auto_label", True),
+                    spacing=composite_config.get("spacing", 20),
+                    label_position=composite_config.get("label_position", "bottom"),
+                    output_path=comp_path,
+                )
+                composite_path = str(comp_path)
+                emit(f"Composite: {composite_path}")
+            except Exception as e:
+                logger.warning("composite_failed", error=str(e))
+
+    return {
+        "batch_dir": str(batch_dir),
+        "batch_id": batch_id,
+        "batch_report_path": str(report_path),
+        "had_work": True,
+        "succeeded": succeeded,
+        "failed": failed,
+        "skipped": skipped,
+        "composite_path": composite_path,
+        "strict_success": failed == 0,
+        "items_summary": [
+            {
+                "id": x.get("id"),
+                "status": x.get("status"),
+                "output_path": x.get("output_path"),
+                "error": x.get("error"),
+            }
+            for x in ri
+        ],
+    }
+
+
+def run_plot_batch(
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    config: str | None = None,
+    vlm_provider: str | None = None,
+    vlm_model: str | None = None,
+    image_provider: str | None = None,
+    image_model: str | None = None,
+    iterations: int | None = None,
+    auto: bool = False,
+    max_iterations: int | None = None,
+    optimize: bool = False,
+    format: str = "png",
+    save_prompts: bool | None = None,
+    venue: str | None = None,
+    aspect_ratio: str | None = None,
+    resume_batch: str | None = None,
+    retry_failed: bool = False,
+    max_retries: int = 0,
+    concurrency: int = 1,
+    progress_callback: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Run statistical plot batch; mirrors ``paperbanana plot-batch``."""
+    from paperbanana.core.pipeline import PaperBananaPipeline
+
+    manifest_path = Path(manifest_path).resolve()
+    if format not in ("png", "jpeg", "webp"):
+        raise ValueError(f"Format must be png, jpeg, or webp. Got: {format}")
+    if venue and venue.lower() not in ("neurips", "icml", "acl", "ieee", "custom"):
+        raise ValueError(f"venue must be neurips, icml, acl, ieee, or custom. Got: {venue}")
+    if max_retries < 0:
+        raise ValueError("max_retries must be >= 0")
+    if concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+
+    items = load_plot_batch_manifest(manifest_path)
+
+    is_resume = bool(resume_batch)
+    if is_resume:
+        resume_ref = Path(resume_batch)
+        if resume_ref.is_dir():
+            batch_dir = resume_ref.resolve()
+            batch_id = batch_dir.name
+        else:
+            batch_id = resume_batch.strip()
+            batch_dir = (Path(output_dir) / batch_id).resolve()
+    else:
+        batch_id = generate_batch_id()
+        batch_dir = (Path(output_dir) / batch_id).resolve()
+    ensure_dir(batch_dir)
+
+    overrides: dict[str, Any] = {
+        "output_dir": str(batch_dir),
+        "output_format": format,
+        "optimize_inputs": optimize,
+        "auto_refine": auto,
+    }
+    if vlm_provider:
+        overrides["vlm_provider"] = vlm_provider
+    if vlm_model:
+        overrides["vlm_model"] = vlm_model
+    if image_provider:
+        overrides["image_provider"] = image_provider
+    if image_model:
+        overrides["image_model"] = image_model
+    if iterations is not None:
+        overrides["refinement_iterations"] = iterations
+    if max_iterations is not None:
+        overrides["max_iterations"] = max_iterations
+    overrides["save_prompts"] = True if save_prompts is None else save_prompts
+    if venue:
+        overrides["venue"] = venue
+    if not vlm_provider:
+        overrides.setdefault("vlm_provider", "gemini")
+
+    settings = _load_settings(config=config, overrides=overrides)
+
+    state = init_or_load_checkpoint(
+        batch_dir=batch_dir,
+        batch_id=batch_id,
+        manifest_path=manifest_path,
+        batch_kind="statistical_plot",
+        items=items,
+        resume=is_resume,
+    )
+
+    def emit(msg: str) -> None:
+        if progress_callback:
+            progress_callback(msg)
+        else:
+            logger.info("workflow_plot_batch", message=msg)
+
+    total_start = time.perf_counter()
+    planned = select_items_for_run(state, retry_failed=retry_failed)
+    if not planned:
+        checkpoint_progress(batch_dir=batch_dir, state=state, mark_complete=True)
+        report_path = batch_dir / "batch_report.json"
+        emit(f"Nothing to run; report at {report_path}")
+        return {
+            "batch_dir": str(batch_dir),
+            "batch_id": batch_id,
+            "batch_report_path": str(report_path),
+            "had_work": False,
+            "succeeded": 0,
+            "failed": 0,
+            "skipped": len(state.get("items", {})),
+            "strict_success": True,
+        }
+
+    async def _run_all() -> None:
+        sem = asyncio.Semaphore(concurrency)
+
+        async def _run_one(idx: int, item: dict[str, object]) -> None:
+            item_key = str(item["_item_key"])
+            item_id = str(item["id"])
+            async with sem:
+                for attempt in range(max_retries + 1):
+                    mark_item_running(state, item_key)
+                    checkpoint_progress(
+                        batch_dir=batch_dir,
+                        state=state,
+                        total_seconds=time.perf_counter() - total_start,
+                    )
+                    data_path = Path(str(item["data"]))
+                    if not data_path.exists():
+                        mark_item_failure(state, item_key, "data file not found")
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        emit(f"Item {idx + 1}/{len(items)} {item_id}: data missing")
+                        return
+                    try:
+                        source_context, raw_data = load_statistical_plot_payload(data_path)
+                        ar = item.get("aspect_ratio") or aspect_ratio
+                        gen_input = GenerationInput(
+                            source_context=source_context,
+                            communicative_intent=str(item["intent"]),
+                            diagram_type=DiagramType.STATISTICAL_PLOT,
+                            raw_data={"data": raw_data},
+                            aspect_ratio=ar,
+                        )
+                        result = await PaperBananaPipeline(settings=settings).generate(gen_input)
+                        mark_item_success(
+                            state,
+                            item_key,
+                            result.metadata.get("run_id"),
+                            result.image_path,
+                            len(result.iterations),
+                        )
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        emit(f"Item {idx + 1}/{len(items)} {item_id}: ok -> {result.image_path}")
+                        return
+                    except Exception as e:
+                        mark_item_failure(state, item_key, str(e))
+                        checkpoint_progress(
+                            batch_dir=batch_dir,
+                            state=state,
+                            total_seconds=time.perf_counter() - total_start,
+                        )
+                        if attempt < max_retries:
+                            emit(f"Item {item_id}: retry {attempt + 1}/{max_retries} after {e}")
+                            continue
+                        emit(f"Item {idx + 1}/{len(items)} {item_id}: failed - {e}")
+                        return
+
+        await asyncio.gather(*[_run_one(idx, item) for idx, item, _ in planned])
+
+    asyncio.run(_run_all())
+
+    total_elapsed = time.perf_counter() - total_start
+    report = checkpoint_progress(
+        batch_dir=batch_dir,
+        state=state,
+        total_seconds=total_elapsed,
+        mark_complete=True,
+    )
+    report_path = batch_dir / "batch_report.json"
+    ri = report["items"]
+    succeeded = sum(1 for x in ri if x.get("status") == "success")
+    failed = sum(1 for x in ri if x.get("status") == "failed")
+    skipped = len(ri) - succeeded - failed
+
+    return {
+        "batch_dir": str(batch_dir),
+        "batch_id": batch_id,
+        "batch_report_path": str(report_path),
+        "had_work": True,
+        "succeeded": succeeded,
+        "failed": failed,
+        "skipped": skipped,
+        "strict_success": failed == 0,
+        "items_summary": [
+            {
+                "id": x.get("id"),
+                "status": x.get("status"),
+                "output_path": x.get("output_path"),
+                "error": x.get("error"),
+            }
+            for x in ri
+        ],
+    }
+
+
+def run_orchestration_package(
+    *,
+    paper: str | None,
+    resume_orchestrate: str | None,
+    output_dir: Path,
+    data_dir: str | None,
+    max_method_figures: int,
+    max_plot_figures: int,
+    pdf_pages: str | None,
+    dry_run: bool,
+    config: str | None,
+    vlm_provider: str | None,
+    vlm_model: str | None,
+    image_provider: str | None,
+    image_model: str | None,
+    iterations: int | None,
+    auto: bool,
+    max_iterations: int | None,
+    optimize: bool,
+    format: str,
+    save_prompts: bool | None,
+    venue: str | None,
+    retry_failed: bool,
+    max_retries: int,
+    concurrency: int,
+    progress_callback: Callable[[str], None] | None = None,
+    after_plan_callback: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """Plan and/or run figure-package orchestration; mirrors ``paperbanana orchestrate``."""
+    is_resume = bool(resume_orchestrate)
+    if format not in ("png", "jpeg", "webp"):
+        raise ValueError(f"Format must be png, jpeg, or webp. Got: {format}")
+    if venue and venue.lower() not in ("neurips", "icml", "acl", "ieee", "custom"):
+        raise ValueError(f"venue must be neurips, icml, acl, ieee, or custom. Got: {venue}")
+    if max_method_figures < 1:
+        raise ValueError("max_method_figures must be >= 1")
+    if max_plot_figures < 0:
+        raise ValueError("max_plot_figures must be >= 0")
+    if concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+    if max_retries < 0:
+        raise ValueError("max_retries must be >= 0")
+    if is_resume and paper:
+        raise ValueError("Provide only one of paper or resume_orchestrate")
+    if not is_resume and not paper:
+        raise ValueError("paper is required for new orchestrations")
+    if is_resume and data_dir:
+        raise ValueError("data_dir is only valid for new orchestrations")
+    if is_resume and pdf_pages:
+        raise ValueError("pdf_pages is only valid for new orchestrations")
+
+    orchestration_id, orchestrate_dir, plan, plan_path, resumed = prepare_orchestration_plan(
+        paper=paper,
+        resume_orchestrate=resume_orchestrate,
+        output_dir=str(output_dir),
+        data_dir=data_dir,
+        max_method_figures=max_method_figures,
+        max_plot_figures=max_plot_figures,
+        pdf_pages=pdf_pages,
+    )
+
+    if not resumed:
+        _check_pdf_dep(Path(str(plan.get("paper_path", ""))))
+
+    ensure_dir(orchestrate_dir)
+    runs_dir = ensure_dir(orchestrate_dir / "runs")
+
+    plan_header: dict[str, Any] = {
+        "orchestration_id": orchestration_id,
+        "orchestrate_dir": str(orchestrate_dir),
+        "orchestration_plan_path": str(plan_path),
+        "paper_path": str(plan.get("paper_path", "")),
+        "paper_title": str(plan.get("paper_title", "")),
+        "methodology_items_planned": len(plan.get("methodology_items", [])),
+        "plot_items_planned": len(plan.get("plot_items", [])),
+        "resumed": resumed,
+    }
+    if after_plan_callback is not None:
+        after_plan_callback(plan_header)
+
+    if dry_run:
+        return {
+            **plan_header,
+            "dry_run": True,
+            "strict_success": True,
+        }
+
+    overrides: dict[str, Any] = {
+        "output_dir": str(runs_dir),
+        "output_format": format,
+        "optimize_inputs": optimize,
+        "auto_refine": auto,
+    }
+    if vlm_provider:
+        overrides["vlm_provider"] = vlm_provider
+    if vlm_model:
+        overrides["vlm_model"] = vlm_model
+    if image_provider:
+        overrides["image_provider"] = image_provider
+    if image_model:
+        overrides["image_model"] = image_model
+    if iterations is not None:
+        overrides["refinement_iterations"] = iterations
+    if max_iterations is not None:
+        overrides["max_iterations"] = max_iterations
+    if save_prompts is not None:
+        overrides["save_prompts"] = save_prompts
+    if venue:
+        overrides["venue"] = venue
+
+    settings = _load_settings(config=config, overrides=overrides)
+
+    state = init_or_load_orchestration_checkpoint(
+        orchestrate_dir=orchestrate_dir,
+        orchestration_id=orchestration_id,
+        plan_path=plan_path,
+        plan=plan,
+        resume=resumed,
+    )
+
+    def emit(msg: str) -> None:
+        if progress_callback:
+            progress_callback(msg)
+        else:
+            logger.info("workflow_orchestrate", message=msg)
+
+    report, had_work = run_orchestration(
+        state=state,
+        plan=plan,
+        settings=settings,
+        orchestrate_dir=orchestrate_dir,
+        retry_failed=retry_failed,
+        max_retries=max_retries,
+        concurrency=concurrency,
+        progress_callback=emit,
+    )
+
+    package_path = orchestrate_dir / "figure_package.json"
+    figures_tex = orchestrate_dir / "figures.tex"
+    captions_md = orchestrate_dir / "captions.md"
+    fail_count = len(report.get("failures", []))
+    success_count = len(report.get("generated_items", []))
+
+    base: dict[str, Any] = {
+        "orchestration_id": orchestration_id,
+        "orchestrate_dir": str(orchestrate_dir),
+        "orchestration_plan_path": str(plan_path),
+        "figure_package_path": str(package_path),
+        "figures_tex_path": str(figures_tex),
+        "captions_md_path": str(captions_md),
+        "runs_dir": str(runs_dir),
+        "dry_run": False,
+        "had_work": had_work,
+        "paper_path": str(report.get("paper_path") or plan.get("paper_path", "")),
+        "paper_title": str(report.get("paper_title") or plan.get("paper_title", "")),
+        "methodology_items_planned": len(plan.get("methodology_items", [])),
+        "plot_items_planned": len(plan.get("plot_items", [])),
+        "generated_count": success_count,
+        "failed_count": fail_count,
+        "total_seconds": report.get("total_seconds"),
+        "strict_success": fail_count == 0,
+        "failures": report.get("failures", []),
+    }
+    if not had_work:
+        base["note"] = "All tasks already completed; package manifest refreshed."
+    return base

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -1,0 +1,56 @@
+"""Smoke tests for workflow_runner (no live API calls)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paperbanana.core.workflow_runner import run_orchestration_package
+
+
+def test_orchestration_dry_run_writes_plan(tmp_path: Path) -> None:
+    paper = tmp_path / "paper.txt"
+    paper.write_text(
+        "A Short Paper Title\n\n1 Introduction\nWe motivate the problem.\n\n2 Method\nDetails.\n",
+        encoding="utf-8",
+    )
+    result = run_orchestration_package(
+        paper=str(paper),
+        resume_orchestrate=None,
+        output_dir=tmp_path,
+        data_dir=None,
+        max_method_figures=2,
+        max_plot_figures=0,
+        pdf_pages=None,
+        dry_run=True,
+        config=None,
+        vlm_provider=None,
+        vlm_model=None,
+        image_provider=None,
+        image_model=None,
+        iterations=None,
+        auto=False,
+        max_iterations=None,
+        optimize=False,
+        format="png",
+        save_prompts=None,
+        venue=None,
+        retry_failed=False,
+        max_retries=0,
+        concurrency=1,
+    )
+    assert result["dry_run"] is True
+    assert result["strict_success"] is True
+    plan_path = Path(result["orchestration_plan_path"])
+    assert plan_path.is_file()
+
+
+def test_methodology_batch_missing_manifest_raises() -> None:
+    from paperbanana.core.workflow_runner import run_methodology_batch
+
+    with pytest.raises(FileNotFoundError):
+        run_methodology_batch(
+            manifest_path=Path("/nonexistent/manifest.yaml"),
+            output_dir=Path("."),
+        )


### PR DESCRIPTION
## Summary

Closes #179 

Exposes full-paper orchestration and manifest-based batch runs as MCP tools so IDE agents can drive the same flows as the CLI without shelling out. Extracts shared execution into paperbanana.core.workflow_runner and wires paperbanana batch, paperbanana plot-batch, and paperbanana orchestrate through it to avoid drift.

## Motivation
PaperBanana’s strongest workflows for publication work—orchestrating a whole figure package from a paper and running many diagrams or plots from a manifest—were only easy from the CLI (and Studio). The MCP surface was still centered on single diagram/plot calls, so agents in Cursor, Claude Code, and other MCP clients could not plan or run those paper-scale jobs in one tool invocation. That mismatch slowed down real “drive the repo from the IDE” workflows and duplicated mental overhead (leave the agent, run shell, paste paths back).


## Changes

- New: paperbanana/core/workflow_runner.py — run_methodology_batch, run_plot_batch, run_orchestration_package (optional after_plan_callback so the CLI can print the header before generation).
- MCP: orchestrate_figures, batch_diagrams, batch_plots in mcp_server/server.py — return pretty-printed JSON (paths, counts, strict_success, failures where relevant); validation failures return {"error": "...", "strict_success": false}. Long runs use asyncio.to_thread so nested asyncio.run() in orchestration/batch does not break the MCP event loop.
- CLI: batch, plot-batch, and orchestrate delegate to the workflow runner (behavior preserved; orchestration header still prints before work via callback).
- Docs: mcp_server/README.md — tool table + short notes on JSON return shape and threading.
- Tests: tests/test_workflow_runner.py — dry-run orchestration smoke + missing-manifest error.

## How to review

- Confirm MCP parameters match important CLI flags and defaults (e.g. plot-batch VLM default).
- Skim workflow_runner against prior CLI logic for parity (composite, checkpoints, PDF dependency for methodology batch).
