### PR TITLE
feat: add Orchestrate tab for figure-package workflow

### DIFF
--- a/paperbanana/studio/app.py
+++ b/paperbanana/studio/app.py
@@ -19,6 +19,7 @@ from paperbanana.studio.runner import (
     run_continue,
     run_evaluate,
     run_methodology,
+    run_orchestration,
     run_plot,
     run_plot_batch,
 )
@@ -687,6 +688,147 @@ def build_studio_app(
                         b_concurrency,
                     ],
                     outputs=[b_log, b_dir],
+                )
+
+            # ── Figure-package orchestration ───────────────────────────────
+            with gr.Tab("Orchestrate"):
+                gr.Markdown(
+                    "Plan and generate a **full-paper figure package** (same workflow as "
+                    "`paperbanana orchestrate`). Upload a paper **or** set resume — not both. "
+                    "`Dry run` writes `orchestration_plan.json` only (planning still uses the VLM)."
+                )
+                o_paper = gr.File(
+                    label="Paper source (.txt, .md, .pdf)",
+                    file_types=[".txt", ".md", ".pdf"],
+                )
+                o_data = gr.Textbox(
+                    label="Data directory (optional, new runs only)",
+                    lines=1,
+                    placeholder="Folder with CSV/JSON for auto-planned plots",
+                )
+                o_pdf_pages = gr.Textbox(
+                    label="PDF pages (optional, PDF papers only)",
+                    lines=1,
+                    placeholder="e.g. 1-5,8  (empty = all pages)",
+                )
+                with gr.Row():
+                    o_max_m = gr.Number(
+                        label="Max methodology figures",
+                        value=4,
+                        precision=0,
+                        minimum=1,
+                    )
+                    o_max_p = gr.Number(
+                        label="Max plot figures",
+                        value=4,
+                        precision=0,
+                        minimum=0,
+                    )
+                with gr.Row():
+                    o_dry = gr.Checkbox(
+                        label="Dry run (plan only, no image generation)",
+                        value=False,
+                    )
+                    o_venue = gr.Dropdown(
+                        label="Venue style",
+                        choices=["neurips", "icml", "acl", "ieee", "custom"],
+                        value="neurips",
+                    )
+                with gr.Row():
+                    o_resume = gr.Textbox(
+                        label="Resume orchestration (ID or directory path)",
+                        lines=1,
+                        placeholder="Optional: orchestrate_… under output dir, or full path",
+                    )
+                    o_retry = gr.Checkbox(label="Retry failed tasks", value=False)
+                with gr.Row():
+                    o_max_ret = gr.Number(label="Max retries per task", value=0, precision=0)
+                    o_conc = gr.Number(label="Concurrency", value=1, precision=0)
+                o_log = gr.Textbox(label="Orchestration log", lines=18)
+                o_dir = gr.Textbox(label="Orchestration directory", lines=1)
+                o_plan = gr.Textbox(label="orchestration_plan.json (preview)", lines=12)
+                o_pkg = gr.Textbox(label="figure_package.json (preview)", lines=12)
+                o_go = gr.Button("Run orchestration", variant="primary")
+
+                def _do_orch(
+                    od,
+                    c,
+                    vp,
+                    vm,
+                    ip,
+                    im,
+                    fo,
+                    it,
+                    au,
+                    mx,
+                    op,
+                    sp,
+                    sd,
+                    paper_f,
+                    data_dir_s,
+                    pdf_pgs,
+                    max_m,
+                    max_p,
+                    dry,
+                    venue_v,
+                    resume_s,
+                    retry_f,
+                    max_ret,
+                    conc,
+                ):
+                    _dotenv()
+                    try:
+                        st0 = _settings(od, c, vp, vm, ip, im, fo, it, au, mx, op, sp, sd)
+                        pp = _upload_path(paper_f)
+                        log, d, plan_pr, pkg_pr = run_orchestration(
+                            st0,
+                            paper_file_path=pp,
+                            resume_orchestrate=(resume_s or "").strip() or None,
+                            data_dir=(data_dir_s or "").strip() or None,
+                            max_method_figures=int(max_m or 4),
+                            max_plot_figures=int(max_p or 4),
+                            pdf_pages=(pdf_pgs or "").strip() or None,
+                            dry_run=bool(dry),
+                            venue=str(venue_v or "neurips"),
+                            retry_failed=bool(retry_f),
+                            max_retries=max(0, int(max_ret or 0)),
+                            concurrency=max(1, int(conc or 1)),
+                            config_path=(c or "").strip() or None,
+                            verbose_logging=False,
+                        )
+                        return log, d, plan_pr, pkg_pr
+                    except Exception as e:
+                        return f"{type(e).__name__}: {e}", "", "", ""
+
+                o_go.click(
+                    _do_orch,
+                    inputs=[
+                        out_dir,
+                        cfg,
+                        vlm_p,
+                        vlm_m,
+                        img_p,
+                        img_m,
+                        fmt,
+                        iters,
+                        auto_ref,
+                        max_it,
+                        opt_in,
+                        save_pr,
+                        seed_val,
+                        o_paper,
+                        o_data,
+                        o_pdf_pages,
+                        o_max_m,
+                        o_max_p,
+                        o_dry,
+                        o_venue,
+                        o_resume,
+                        o_retry,
+                        o_max_ret,
+                        o_conc,
+                    ],
+                    outputs=[o_log, o_dir, o_plan, o_pkg],
                 )
 
             # ── Composite multi-panel figure ──────────────────────────────

--- a/paperbanana/studio/runner.py
+++ b/paperbanana/studio/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 import traceback
 from pathlib import Path
@@ -683,6 +684,161 @@ def run_plot_batch(
     lines.append(f"Succeeded: {ok}/{len(items)}")
     lines.append(f"Total time: {report['total_seconds']}s")
     return "\n".join(lines), str(batch_dir.resolve())
+
+
+def _preview_json_file(path: Path, *, max_chars: int = 10_000) -> str:
+    """Load JSON (or raw text) from disk for Studio previews."""
+    if not path.is_file():
+        return ""
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        data = json.loads(raw)
+        text = json.dumps(data, indent=2, ensure_ascii=False)
+    except (OSError, json.JSONDecodeError):
+        text = path.read_text(encoding="utf-8", errors="replace")
+    if len(text) > max_chars:
+        return text[:max_chars] + "\n\n… [truncated]"
+    return text
+
+
+def run_orchestration(
+    settings: Settings,
+    paper_file_path: str | None,
+    resume_orchestrate: str | None,
+    data_dir: str | None,
+    max_method_figures: int,
+    max_plot_figures: int,
+    pdf_pages: str | None,
+    dry_run: bool,
+    venue: str,
+    retry_failed: bool,
+    max_retries: int,
+    concurrency: int,
+    config_path: str | None,
+    verbose_logging: bool = False,
+) -> tuple[str, str, str, str]:
+    """Run figure-package orchestration (CLI parity).
+
+    Returns (log, orch_dir, plan_preview, package_preview).
+    """
+    from paperbanana.core.workflow_runner import run_orchestration_package
+
+    configure_logging(verbose=verbose_logging)
+    lines: list[str] = ["Starting figure-package orchestration…", ""]
+
+    def emit(msg: str) -> None:
+        lines.append(msg)
+
+    resume = (resume_orchestrate or "").strip() or None
+    paper_upload = (paper_file_path or "").strip() or None
+    if paper_upload and not Path(paper_upload).is_file():
+        paper_upload = None
+
+    if resume and paper_upload:
+        msg = "Error: clear the paper upload when using resume (provide only resume ID or path)."
+        lines.append(msg)
+        return "\n".join(lines), "", "", ""
+
+    if not resume and (not paper_upload or not Path(paper_upload).is_file()):
+        msg = "Error: upload a paper file (.txt, .md, or .pdf), or enter a resume ID / path."
+        lines.append(msg)
+        return "\n".join(lines), "", "", ""
+
+    if not resume:
+        paper_arg: str | None = paper_upload
+    else:
+        paper_arg = None
+
+    data_arg = (data_dir or "").strip() or None
+    pages_arg = (pdf_pages or "").strip() or None
+    if resume:
+        data_arg = None
+        pages_arg = None
+
+    cfg = (config_path or "").strip() or None
+    venue_s = (venue or "neurips").strip().lower()
+    if venue_s not in ("neurips", "icml", "acl", "ieee", "custom"):
+        venue_s = "neurips"
+
+    max_m = max(1, int(max_method_figures or 1))
+    max_p = max(0, int(max_plot_figures or 0))
+    mret = max(0, int(max_retries or 0))
+    conc = max(1, int(concurrency or 1))
+
+    out_root = Path((settings.output_dir or "outputs").strip() or "outputs")
+
+    out_fmt = str(settings.output_format)
+    if out_fmt not in ("png", "jpeg", "webp"):
+        lines.append(
+            f"Note: orchestration supports png/jpeg/webp only; using png (format was {out_fmt!r})."
+        )
+        lines.append("")
+        out_fmt = "png"
+
+    try:
+        result = run_orchestration_package(
+            paper=paper_arg,
+            resume_orchestrate=resume,
+            output_dir=out_root,
+            data_dir=data_arg,
+            max_method_figures=max_m,
+            max_plot_figures=max_p,
+            pdf_pages=pages_arg,
+            dry_run=bool(dry_run),
+            config=cfg,
+            vlm_provider=settings.vlm_provider,
+            vlm_model=settings.vlm_model,
+            image_provider=settings.image_provider,
+            image_model=settings.image_model,
+            iterations=settings.refinement_iterations,
+            auto=settings.auto_refine,
+            max_iterations=settings.max_iterations,
+            optimize=settings.optimize_inputs,
+            format=out_fmt,
+            save_prompts=settings.save_prompts,
+            venue=venue_s,
+            retry_failed=bool(retry_failed),
+            max_retries=mret,
+            concurrency=conc,
+            progress_callback=emit,
+            after_plan_callback=None,
+        )
+    except (FileNotFoundError, ValueError, ImportError, RuntimeError) as e:
+        lines.append(f"FAILED: {type(e).__name__}: {e}")
+        return "\n".join(lines), "", "", ""
+    except Exception as e:
+        lines.append(f"FAILED: {type(e).__name__}: {e}")
+        lines.append(traceback.format_exc())
+        return "\n".join(lines), "", "", ""
+
+    orch_dir = str(result.get("orchestrate_dir") or "")
+    plan_path = Path(str(result.get("orchestration_plan_path") or ""))
+
+    lines.append("")
+    if result.get("dry_run"):
+        lines.append("Dry run complete (plan only).")
+        plan_preview = _preview_json_file(plan_path)
+        pkg_preview = "(dry run — no figure_package.json; use run without dry run to generate.)"
+        return "\n".join(lines), orch_dir, plan_preview, pkg_preview
+
+    gen_n = result.get("generated_count", 0)
+    fail_n = result.get("failed_count", 0)
+    ok = result.get("strict_success")
+    lines.append(f"Done. generated={gen_n} failed={fail_n} strict_success={ok}")
+    if result.get("figure_package_path"):
+        lines.append(f"Package: {result['figure_package_path']}")
+    if result.get("figures_tex_path"):
+        lines.append(f"LaTeX: {result['figures_tex_path']}")
+    if result.get("captions_md_path"):
+        lines.append(f"Captions: {result['captions_md_path']}")
+
+    plan_preview = _preview_json_file(plan_path)
+    pkg_path = Path(str(result.get("figure_package_path") or ""))
+    pkg_preview = _preview_json_file(pkg_path) if pkg_path.is_file() else ""
+    if not pkg_preview and result.get("figure_package_path"):
+        pkg_preview = f"(not readable yet: {pkg_path})"
+
+    return "\n".join(lines), orch_dir, plan_preview, pkg_preview
 
 
 def _sanitize_output_filename(name: str) -> str:

--- a/tests/test_studio.py
+++ b/tests/test_studio.py
@@ -235,6 +235,68 @@ def test_run_composite_dotdot_filename_falls_back(tmp_path):
     assert Path(output_path).name == "composite.png"
 
 
+def test_run_orchestration_requires_paper_or_resume(tmp_path):
+    from paperbanana.core.config import Settings
+    from paperbanana.studio.runner import run_orchestration
+
+    s = Settings().model_copy(update={"output_dir": str(tmp_path)})
+    log, orch, plan, pkg = run_orchestration(
+        s,
+        paper_file_path=None,
+        resume_orchestrate=None,
+        data_dir=None,
+        max_method_figures=2,
+        max_plot_figures=1,
+        pdf_pages=None,
+        dry_run=True,
+        venue="neurips",
+        retry_failed=False,
+        max_retries=0,
+        concurrency=1,
+        config_path=None,
+        verbose_logging=False,
+    )
+    assert "Error:" in log
+    assert orch == "" and plan == "" and pkg == ""
+
+
+def test_run_orchestration_rejects_paper_plus_resume(tmp_path):
+    from paperbanana.core.config import Settings
+    from paperbanana.studio.runner import run_orchestration
+
+    paper = tmp_path / "p.txt"
+    paper.write_text("hello", encoding="utf-8")
+    s = Settings().model_copy(update={"output_dir": str(tmp_path)})
+    log, orch, plan, pkg = run_orchestration(
+        s,
+        paper_file_path=str(paper),
+        resume_orchestrate="orchestrate_x",
+        data_dir=None,
+        max_method_figures=2,
+        max_plot_figures=0,
+        pdf_pages=None,
+        dry_run=True,
+        venue="neurips",
+        retry_failed=False,
+        max_retries=0,
+        concurrency=1,
+        config_path=None,
+        verbose_logging=False,
+    )
+    assert "clear the paper upload" in log.lower()
+    assert orch == ""
+
+
+def test_preview_json_file_truncates(tmp_path):
+    from paperbanana.studio import runner as runner_mod
+
+    p = tmp_path / "big.json"
+    p.write_text('{"x": "' + ("a" * 20_000) + '"}', encoding="utf-8")
+    prev = runner_mod._preview_json_file(p, max_chars=100)
+    assert "truncated" in prev
+    assert len(prev) <= 150
+
+
 def test_run_evaluate_plot_requires_data_file(tmp_path):
     """Plot evaluation mode validates data path before provider setup."""
     from paperbanana.core.config import Settings


### PR DESCRIPTION
## Summary
Adds an Orchestrate tab to PaperBanana Studio so users can run the full-paper figure-package workflow from the browser, aligned with paperbanana orchestrate and the MCP orchestrate_figures tool.
Closes #181 

## What changed

- paperbanana/studio/runner.py: New run_orchestration() wrapping run_orchestration_package, progress logging, JSON previews (orchestration_plan.json, figure_package.json), and format handling when the shared Studio format is svg (orchestration uses png/jpeg/webp only).
- paperbanana/studio/app.py: New Gradio tab with paper upload, optional data directory, PDF page spec, caps, dry run, venue, resume, retry/concurrency controls, and four outputs (log, directory, two previews).
- tests/test_studio.py: Tests for early validation (paper vs resume) and JSON preview truncation.

