### PR TITLE
Fix resume visualizer output directory

### DIFF
--- a/paperbanana/agents/visualizer.py
+++ b/paperbanana/agents/visualizer.py
@@ -40,6 +40,9 @@ class VisualizerAgent(BaseAgent):
         self.output_dir = Path(output_dir)
         self._last_vector_paths: dict[str, str] = {}
 
+    def set_output_dir(self, output_dir: str | Path) -> None:
+        self.output_dir = Path(output_dir)
+
     @property
     def agent_name(self) -> str:
         return "visualizer"

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -251,6 +251,7 @@ class PaperBananaPipeline:
         self.caption_agent = CaptionAgent(
             self._vlm, prompt_dir=prompt_dir, prompt_recorder=self._prompt_recorder
         )
+        self._sync_run_scoped_agents()
 
         logger.info(
             "Pipeline initialized",
@@ -297,6 +298,9 @@ class PaperBananaPipeline:
         if self.settings.prompt_dir:
             return self.settings.prompt_dir
         return find_prompt_dir()
+
+    def _sync_run_scoped_agents(self) -> None:
+        self.visualizer.set_output_dir(self._run_dir)
 
     async def _generate_caption(
         self,
@@ -1192,6 +1196,7 @@ class PaperBananaPipeline:
         # Override run dir to write into the existing run
         run_dir = Path(resume_state.run_dir)
         self.run_id = resume_state.run_id
+        self._sync_run_scoped_agents()
 
         if self.settings.auto_refine:
             total_iters = self.settings.max_iterations

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -385,6 +385,58 @@ async def test_continue_run_resumes_from_last_iteration(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_continue_run_rebinds_visualizer_output_dir_to_resumed_run(tmp_path):
+    """continue_run() must write new images into the resumed run directory."""
+    run_id = "run_resume_output_dir_test"
+    run_dir = tmp_path / "outputs" / run_id
+    run_dir.mkdir(parents=True)
+
+    (run_dir / "run_input.json").write_text(
+        json.dumps(
+            {
+                "source_context": "Encoder-decoder with attention",
+                "communicative_intent": "Architecture overview",
+                "diagram_type": "methodology",
+            }
+        )
+    )
+    iter1 = run_dir / "iter_1"
+    iter1.mkdir()
+    (iter1 / "details.json").write_text(
+        json.dumps(
+            {
+                "description": "Description from iter 1",
+                "critique": {
+                    "critic_suggestions": [],
+                    "revised_description": None,
+                },
+            }
+        )
+    )
+
+    state = load_resume_state(str(tmp_path / "outputs"), run_id)
+    vlm = _MockVLM([_critic_json([], None)])
+    image_gen = _MockImageGen()
+    settings = Settings(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "refs"),
+        refinement_iterations=1,
+        save_iterations=False,
+    )
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=image_gen)
+    stale_output_dir = pipeline.visualizer.output_dir
+
+    result = await pipeline.continue_run(resume_state=state, additional_iterations=1)
+
+    resumed_iter_path = run_dir / "diagram_iter_2.png"
+    assert stale_output_dir != run_dir
+    assert pipeline.visualizer.output_dir == run_dir
+    assert result.iterations[0].image_path == str(resumed_iter_path)
+    assert resumed_iter_path.exists()
+    assert not (stale_output_dir / "diagram_iter_2.png").exists()
+
+
+@pytest.mark.asyncio
 async def test_continue_run_passes_user_feedback_to_critic(tmp_path):
     """continue_run() forwards user_feedback into the critic's prompt."""
     run_id = "run_feedback_test"


### PR DESCRIPTION
## Summary

Fix resume-mode artifact routing so continued iterations write images into the resumed run directory instead of a stale directory captured when the pipeline was first initialized.

## What Changed

- Added a small `VisualizerAgent.set_output_dir()` method so the pipeline can refresh the agent’s default artifact directory.
- Added `PaperBananaPipeline._sync_run_scoped_agents()` to keep run-scoped agent state aligned with the active `run_id`.
- Called that sync helper during pipeline setup and again inside `continue_run()` right after switching to the resumed run.
- Added a regression test covering resumed iteration output paths.

## Why

Before this change, `continue_run()` updated `self.run_id`, but `VisualizerAgent` could still keep the old `output_dir`. If `output_path` was omitted, resumed iteration images could be written into the wrong run folder.

## Testing

```bash
uv run --with pytest --with pytest-asyncio python -m pytest tests/test_features.py -k "continue_run_resumes_from_last_iteration or continue_run_rebinds_visualizer_output_dir_to_resumed_run"
uv run --with pytest python -m pytest tests/test_agents/test_visualizer.py
```

Fixes #185