### PR TITLE
feat: add continue_run tool for resuming diagram/plot runs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ Key architectural layers:
 - **`paperbanana/providers/`** — Abstract `VLMProvider` and `ImageGenProvider` base classes in `base.py`. Concrete implementations in `vlm/` (OpenAI, Gemini, OpenRouter) and `image_gen/` (OpenAI, Google Imagen, OpenRouter). `ProviderRegistry` is the factory that creates providers from `Settings`.
 - **`prompts/`** — Text prompt templates organized by type (`diagram/`, `plot/`, `evaluation/`). Templates use `{placeholder}` formatting, loaded by `BaseAgent.load_prompt()`.
 - **`paperbanana/evaluation/`** — VLM-as-Judge system. Scores on 4 dimensions (Faithfulness, Readability, Conciseness, Aesthetics) with hierarchical aggregation.
-- **`mcp_server/`** — FastMCP server exposing four tools: `generate_diagram`, `generate_plot`, `evaluate_diagram`, `evaluate_plot`.
+- **`mcp_server/`** — FastMCP server exposing tools including `generate_diagram`, `continue_run`, `generate_plot`, `evaluate_diagram`, and `evaluate_plot`.
 - **`data/reference_sets/`** — 13 curated methodology diagram examples used for in-context learning by the Retriever agent.
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ PaperBanana includes an MCP server for use with Claude Code, Cursor, or any MCP-
 }
 ```
 
-Four MCP tools are exposed: `generate_diagram`, `generate_plot`, `evaluate_diagram`, and `evaluate_plot`.
+MCP tools include `generate_diagram`, `continue_run` (resume a prior `run_*` with optional feedback), `generate_plot`, `evaluate_diagram`, and `evaluate_plot`.
 
 The repo also ships with 3 Claude Code skills:
 - `/generate-diagram <file> [caption]` - generate a methodology diagram from a text file

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ PaperBanana includes an MCP server for use with Claude Code, Cursor, or any MCP-
 }
 ```
 
-Four MCP tools are exposed: `generate_diagram`, `generate_plot`, `evaluate_diagram`, and `evaluate_plot`.
+MCP tools include `generate_diagram`, `continue_run` (resume a prior `run_*` with optional feedback), `generate_plot`, `evaluate_diagram`, and `evaluate_plot`.
 
 The repo also ships with 3 Claude Code skills:
 - `/generate-diagram <file> [caption]` - generate a methodology diagram from a text file

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -7,6 +7,7 @@ MCP server that exposes PaperBanana's diagram and plot generation as tools for C
 | Tool | Description |
 |------|-------------|
 | `generate_diagram` | Generate a methodology diagram from text context + caption |
+| `continue_run` | Continue refinement for an existing `run_*` directory (optional critic feedback) |
 | `generate_plot` | Generate a statistical plot from JSON data + intent description |
 | `evaluate_diagram` | Compare a generated diagram against a human reference (4 dimensions) |
 | `evaluate_plot` | Compare a generated statistical plot against a human reference (4 dimensions) |
@@ -105,6 +106,14 @@ User: Generate a diagram for this methodology:
        an iterative refinement phase with Visualizer and Critic agents."
       Caption: "Overview of the PaperBanana multi-agent framework"
 ```
+
+### Continue a previous run
+
+```
+User: Continue run run_20260218_125448_e7b876 with feedback: "Use larger font for axis labels"
+```
+
+The tool resolves `outputs/<run_id>/` using the same output directory as other MCP tools (from `Settings`, typically `outputs`). The run must contain `run_input.json` from a prior `generate_diagram` or `generate_plot` call (or CLI).
 
 ### Generate a statistical plot
 

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -7,6 +7,7 @@ MCP server that exposes PaperBanana's diagram and plot generation as tools for C
 | Tool | Description |
 |------|-------------|
 | `generate_diagram` | Generate a methodology diagram from text context + caption |
+| `continue_run` | Continue refinement for an existing `run_*` directory (optional critic feedback) |
 | `generate_plot` | Generate a statistical plot from JSON data + intent description |
 | `continue_diagram` | Continue a prior methodology `run_*` (more refinement and/or critic feedback); returns JSON paths |
 | `continue_plot` | Continue a prior statistical-plot `run_*`; same JSON contract as `continue_diagram` |
@@ -111,6 +112,14 @@ User: Generate a diagram for this methodology:
        an iterative refinement phase with Visualizer and Critic agents."
       Caption: "Overview of the PaperBanana multi-agent framework"
 ```
+
+### Continue a previous run
+
+```
+User: Continue run run_20260218_125448_e7b876 with feedback: "Use larger font for axis labels"
+```
+
+The tool resolves `outputs/<run_id>/` using the same output directory as other MCP tools (from `Settings`, typically `outputs`). The run must contain `run_input.json` from a prior `generate_diagram` or `generate_plot` call (or CLI).
 
 ### Generate a statistical plot
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -5,6 +5,7 @@ Claude Code, Cursor, or any MCP client.
 
 Tools:
     generate_diagram    — Generate a methodology diagram from text
+    continue_run        — Continue refinement for a prior diagram or plot run
     generate_plot       — Generate a statistical plot from JSON data
     evaluate_diagram    — Evaluate a generated diagram against a reference
     evaluate_plot       — Evaluate a generated plot against a reference
@@ -32,6 +33,7 @@ from PIL import Image as PILImage
 
 from paperbanana.core.config import Settings
 from paperbanana.core.pipeline import PaperBananaPipeline
+from paperbanana.core.resume import load_resume_state
 from paperbanana.core.types import DiagramType, GenerationInput
 from paperbanana.core.utils import detect_image_mime_type, find_prompt_dir
 from paperbanana.core.workflow_runner import (
@@ -204,6 +206,74 @@ async def generate_diagram(
         logger.info(
             "generated_caption",
             tool="generate_diagram",
+            caption=result.generated_caption,
+        )
+
+    return Image(path=effective_path, format=fmt)
+
+
+@mcp.tool
+async def continue_run(
+    run_id: str,
+    feedback: str | None = None,
+    iterations: int = 3,
+    optimize: bool = False,
+    auto_refine: bool = False,
+    generate_caption: bool = False,
+) -> Image:
+    """Continue refinement for a previous diagram or plot run (CLI: ``generate --continue-run``).
+
+    Loads state from ``<output_dir>/<run_id>/`` (default ``outputs/`` from settings), then runs
+    additional visualizer/critic iterations in the same run directory. Optional ``feedback`` is
+    passed to the critic, matching ``--feedback`` on the CLI.
+
+    Args:
+        run_id: Directory name of the run (e.g. ``run_20260218_125448_e7b876`` under ``outputs/``).
+        feedback: Optional user notes for the critic (layout, labels, style).
+        iterations: Extra refinement iterations when ``auto_refine`` is False (default 3).
+        optimize: Passed to settings for symmetry with ``generate_diagram``; continuation does not
+            re-run Phase 0 input optimization.
+        auto_refine: When True, loop until the critic is satisfied (capped by ``max_iterations``).
+        generate_caption: When True, generate a caption after continuation (same as
+            ``generate_diagram``).
+
+    Returns:
+        The latest image from the continued run (PNG or compressed JPEG for MCP size limits).
+
+    Raises:
+        FileNotFoundError: If the run directory or ``run_input.json`` is missing.
+        ValueError: If saved run state cannot be resumed.
+    """
+    settings = Settings(
+        refinement_iterations=iterations,
+        optimize_inputs=optimize,
+        auto_refine=auto_refine,
+        generate_caption=generate_caption,
+    )
+
+    def _on_progress(event: str, payload: dict) -> None:
+        logger.info(
+            "mcp_progress",
+            tool="continue_run",
+            progress_event=event,
+            **payload,
+        )
+
+    state = load_resume_state(settings.output_dir, run_id)
+    pipeline = PaperBananaPipeline(settings=settings, progress_callback=_on_progress)
+
+    result = await pipeline.continue_run(
+        resume_state=state,
+        additional_iterations=None,
+        user_feedback=feedback,
+    )
+    effective_path, fmt = _compress_for_api(result.image_path)
+
+    if result.generated_caption:
+        _embed_caption(effective_path, result.generated_caption)
+        logger.info(
+            "generated_caption",
+            tool="continue_run",
             caption=result.generated_caption,
         )
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -5,6 +5,7 @@ Claude Code, Cursor, or any MCP client.
 
 Tools:
     generate_diagram    — Generate a methodology diagram from text
+    continue_run        — Continue refinement for a prior diagram or plot run
     generate_plot       — Generate a statistical plot from JSON data
     continue_diagram    — Continue a prior methodology run (more refinement / feedback)
     continue_plot       — Continue a prior statistical-plot run
@@ -208,6 +209,74 @@ async def generate_diagram(
         logger.info(
             "generated_caption",
             tool="generate_diagram",
+            caption=result.generated_caption,
+        )
+
+    return Image(path=effective_path, format=fmt)
+
+
+@mcp.tool
+async def continue_run(
+    run_id: str,
+    feedback: str | None = None,
+    iterations: int = 3,
+    optimize: bool = False,
+    auto_refine: bool = False,
+    generate_caption: bool = False,
+) -> Image:
+    """Continue refinement for a previous diagram or plot run (CLI: ``generate --continue-run``).
+
+    Loads state from ``<output_dir>/<run_id>/`` (default ``outputs/`` from settings), then runs
+    additional visualizer/critic iterations in the same run directory. Optional ``feedback`` is
+    passed to the critic, matching ``--feedback`` on the CLI.
+
+    Args:
+        run_id: Directory name of the run (e.g. ``run_20260218_125448_e7b876`` under ``outputs/``).
+        feedback: Optional user notes for the critic (layout, labels, style).
+        iterations: Extra refinement iterations when ``auto_refine`` is False (default 3).
+        optimize: Passed to settings for symmetry with ``generate_diagram``; continuation does not
+            re-run Phase 0 input optimization.
+        auto_refine: When True, loop until the critic is satisfied (capped by ``max_iterations``).
+        generate_caption: When True, generate a caption after continuation (same as
+            ``generate_diagram``).
+
+    Returns:
+        The latest image from the continued run (PNG or compressed JPEG for MCP size limits).
+
+    Raises:
+        FileNotFoundError: If the run directory or ``run_input.json`` is missing.
+        ValueError: If saved run state cannot be resumed.
+    """
+    settings = Settings(
+        refinement_iterations=iterations,
+        optimize_inputs=optimize,
+        auto_refine=auto_refine,
+        generate_caption=generate_caption,
+    )
+
+    def _on_progress(event: str, payload: dict) -> None:
+        logger.info(
+            "mcp_progress",
+            tool="continue_run",
+            progress_event=event,
+            **payload,
+        )
+
+    state = load_resume_state(settings.output_dir, run_id)
+    pipeline = PaperBananaPipeline(settings=settings, progress_callback=_on_progress)
+
+    result = await pipeline.continue_run(
+        resume_state=state,
+        additional_iterations=None,
+        user_feedback=feedback,
+    )
+    effective_path, fmt = _compress_for_api(result.image_path)
+
+    if result.generated_caption:
+        _embed_caption(effective_path, result.generated_caption)
+        logger.info(
+            "generated_caption",
+            tool="continue_run",
             caption=result.generated_caption,
         )
 

--- a/server.json
+++ b/server.json
@@ -24,6 +24,10 @@
       "description": "Generate a methodology diagram from text context and caption"
     },
     {
+      "name": "continue_run",
+      "description": "Continue refinement for an existing run directory (optional critic feedback)"
+    },
+    {
       "name": "generate_plot",
       "description": "Generate a statistical plot from JSON data and intent description"
     },

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from io import BytesIO
 from pathlib import Path
 
@@ -256,3 +257,77 @@ class TestCompressForApi:
 
         with pytest.raises(ValueError, match="could not be compressed"):
             _compress_for_api(str(p))
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not _has_fastmcp, reason="fastmcp not installed")
+async def test_mcp_continue_run_loads_state_and_calls_pipeline(tmp_path: Path, monkeypatch):
+    """continue_run MCP tool wires load_resume_state + PaperBananaPipeline.continue_run."""
+    monkeypatch.chdir(tmp_path)
+    from mcp_server import server
+    from paperbanana.core.types import GenerationOutput
+
+    captured: dict = {}
+
+    class FakePipeline:
+        def __init__(self, settings=None, progress_callback=None):
+            captured["settings_auto"] = settings.auto_refine if settings else None
+            captured["settings_iters"] = settings.refinement_iterations if settings else None
+
+        async def continue_run(
+            self,
+            resume_state,
+            additional_iterations=None,
+            user_feedback=None,
+            progress_callback=None,
+        ):
+            captured["run_id"] = resume_state.run_id
+            captured["user_feedback"] = user_feedback
+            captured["additional_iterations"] = additional_iterations
+            img = tmp_path / "outputs" / "run_mcp_test" / "final.png"
+            img.parent.mkdir(parents=True, exist_ok=True)
+            Image.new("RGB", (8, 8), color=(0, 128, 255)).save(img, format="PNG")
+            return GenerationOutput(image_path=str(img), description="done", iterations=[])
+
+    monkeypatch.setattr(server, "PaperBananaPipeline", FakePipeline)
+
+    run_id = "run_mcp_test"
+    run_dir = tmp_path / "outputs" / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "run_input.json").write_text(
+        json.dumps(
+            {
+                "source_context": "ctx",
+                "communicative_intent": "cap",
+                "diagram_type": "methodology",
+            }
+        ),
+        encoding="utf-8",
+    )
+    iter1 = run_dir / "iter_1"
+    iter1.mkdir()
+    (iter1 / "details.json").write_text(
+        json.dumps(
+            {
+                "description": "d1",
+                "critique": {"critic_suggestions": [], "revised_description": "rev"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from mcp_server.server import continue_run as continue_run_mcp
+
+    img = await continue_run_mcp(
+        run_id=run_id,
+        feedback="bigger labels",
+        iterations=2,
+        auto_refine=True,
+    )
+    assert captured["run_id"] == run_id
+    assert captured["user_feedback"] == "bigger labels"
+    assert captured["additional_iterations"] is None
+    assert captured["settings_auto"] is True
+    assert captured["settings_iters"] == 2
+    assert img.path is not None
+    assert Path(img.path).exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -261,7 +261,7 @@ class TestCompressForApi:
 
 @pytest.mark.skipif(not _has_fastmcp, reason="fastmcp not installed")
 class TestMcpContinueRun:
-    """Tests for MCP continue_diagram / continue_plot helpers (no live API)."""
+    """Tests for MCP continue_run / continue_diagram / continue_plot (no live API)."""
 
     @staticmethod
     def _write_resumable_run(
@@ -383,3 +383,53 @@ class TestMcpContinueRun:
         assert data["run_id"] == "run_mcp_test"
         assert Path(data["final_image_path"]).name == "after_continue.png"
         assert data["new_iteration_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_continue_run_unified_tool_returns_image(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """continue_run accepts any resumable run and returns an Image (not JSON)."""
+        import mcp_server.server as mcp_server_mod
+        from mcp_server.server import continue_run as continue_run_mcp
+        from paperbanana.core.types import GenerationOutput
+
+        self._write_resumable_run(tmp_path, diagram_type="methodology")
+        monkeypatch.chdir(tmp_path)
+        captured: dict = {}
+
+        class _FakePipeline:
+            def __init__(self, settings=None, progress_callback=None):
+                captured["settings_auto"] = settings.auto_refine if settings else None
+                captured["settings_iters"] = settings.refinement_iterations if settings else None
+
+            async def continue_run(
+                self,
+                resume_state,
+                additional_iterations=None,
+                user_feedback=None,
+                progress_callback=None,
+            ):
+                captured["run_id"] = resume_state.run_id
+                captured["user_feedback"] = user_feedback
+                captured["additional_iterations"] = additional_iterations
+                final = tmp_path / "continue_run_out.png"
+                _write_png(final)
+                return GenerationOutput(
+                    image_path=str(final), description="done", iterations=[]
+                )
+
+        monkeypatch.setattr(mcp_server_mod, "PaperBananaPipeline", _FakePipeline)
+
+        img = await continue_run_mcp(
+            run_id="run_mcp_test",
+            feedback="bigger labels",
+            iterations=2,
+            auto_refine=True,
+        )
+        assert captured["run_id"] == "run_mcp_test"
+        assert captured["user_feedback"] == "bigger labels"
+        assert captured["additional_iterations"] is None
+        assert captured["settings_auto"] is True
+        assert captured["settings_iters"] == 2
+        assert img.path is not None
+        assert Path(img.path).exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -385,9 +385,7 @@ class TestMcpContinueRun:
         assert data["new_iteration_count"] == 0
 
     @pytest.mark.asyncio
-    async def test_continue_run_unified_tool_returns_image(
-        self, tmp_path: Path, monkeypatch
-    ):
+    async def test_continue_run_unified_tool_returns_image(self, tmp_path: Path, monkeypatch):
         """continue_run accepts any resumable run and returns an Image (not JSON)."""
         import mcp_server.server as mcp_server_mod
         from mcp_server.server import continue_run as continue_run_mcp
@@ -414,9 +412,7 @@ class TestMcpContinueRun:
                 captured["additional_iterations"] = additional_iterations
                 final = tmp_path / "continue_run_out.png"
                 _write_png(final)
-                return GenerationOutput(
-                    image_path=str(final), description="done", iterations=[]
-                )
+                return GenerationOutput(image_path=str(final), description="done", iterations=[])
 
         monkeypatch.setattr(mcp_server_mod, "PaperBananaPipeline", _FakePipeline)
 


### PR DESCRIPTION
## Summary
Adds a new MCP tool so clients (Cursor, Claude Code, etc.) can continue an existing outputs/run_* job the same way the CLI does with --continue-run and optional --feedback, without re-entering full methodology text or re-running from a blank run.

Closes #189 

## Motivation
generate_diagram / generate_plot always start a new pipeline. Run continuation was already supported in the core pipeline and CLI; MCP users had no supported path, while other MCP flows already expose resume-style parameters for batch/orchestration.

## Changes

- New @mcp.tool continue_run in mcp_server/server.py: load_resume_state(settings.output_dir, run_id) → continue_run(..., user_feedback=feedback).
- Docs: mcp_server/README.md, root README.md, copilot-instructions.md, server.json.
- Test: tests/test_utils.py::test_mcp_continue_run_loads_state_and_calls_pipeline with PaperBananaPipeline mocked (skipped when fastmcp is not installed).