### PR TITLE
Add Tahoma font support with priority font loading and fonts package …

### DIFF
--- a/paperbanana/core/composite.py
+++ b/paperbanana/core/composite.py
@@ -60,12 +60,15 @@ def _parse_layout(layout: str, image_count: int) -> tuple[int, int]:
 def _get_font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
     """Try to load a TrueType font, fall back to default."""
     try:
-        return ImageFont.truetype("DejaVuSans-Bold.ttf", size)
+        return ImageFont.truetype("Tahoma.ttf", size)
     except (OSError, IOError):
         try:
-            return ImageFont.truetype("Arial Bold.ttf", size)
+            return ImageFont.truetype("DejaVuSans-Bold.ttf", size)
         except (OSError, IOError):
-            return ImageFont.load_default()
+            try:
+                return ImageFont.truetype("Arial Bold.ttf", size)
+            except (OSError, IOError):
+                return ImageFont.load_default()
 
 
 def compose_images(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "structlog>=24.0",
     "python-dotenv>=1.0",
     "platformdirs>=4.0",
+    "fonts>=1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
…dependency

- Update _get_font() to try Tahoma.ttf first before falling back to DejaVuSans-Bold and Arial Bold
- Add 'fonts>=1.0' dependency to provide Tahoma and other common TrueType fonts
- Maintains backwards compatibility with existing font fallback chain