### PR TITLE
feat: add Tahoma font support with priority font loading and fonts pa…

### DIFF
--- a/paperbanana/config/__init__.py
+++ b/paperbanana/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration modules for PaperBanana."""

--- a/paperbanana/config/fonts.py
+++ b/paperbanana/config/fonts.py
@@ -1,0 +1,70 @@
+"""Font configuration and priority loading for diagram rendering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["FontConfig", "get_default_font_config"]
+
+
+@dataclass
+class FontConfig:
+    """Font configuration with priority-based font loading and fallbacks."""
+
+    primary_fonts: list[str]
+    fallback_fonts: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        """Validate and set defaults."""
+        if not self.primary_fonts:
+            raise ValueError("primary_fonts must not be empty")
+        if self.fallback_fonts is None:
+            self.fallback_fonts = ["Helvetica", "Arial", "sans-serif"]
+
+    def get_font_string(self, separator: str = ",") -> str:
+        """Get a font string suitable for Graphviz.
+
+        Combines primary and fallback fonts with the specified separator.
+
+        Args:
+            separator: Font separator for the output string (default: ",")
+
+        Returns:
+            A font string like "Tahoma,Helvetica,Arial"
+        """
+        all_fonts = self.primary_fonts + (self.fallback_fonts or [])
+        return separator.join(all_fonts)
+
+    def get_first_available_font(self) -> str:
+        """Get the first font from the priority list.
+
+        Returns:
+            The first font in the primary fonts list.
+        """
+        return self.primary_fonts[0]
+
+
+def get_default_font_config() -> FontConfig:
+    """Get the default font configuration.
+
+    Uses Tahoma as the primary font with fallbacks to Helvetica and Arial.
+
+    Returns:
+        FontConfig with Tahoma as primary font.
+    """
+    return FontConfig(
+        primary_fonts=["Tahoma"],
+        fallback_fonts=["Helvetica", "Arial", "sans-serif"],
+    )
+
+
+def get_legacy_font_config() -> FontConfig:
+    """Get the legacy font configuration (Helvetica-based).
+
+    Returns:
+        FontConfig with Helvetica as primary font.
+    """
+    return FontConfig(
+        primary_fonts=["Helvetica"],
+        fallback_fonts=["Arial", "sans-serif"],
+    )

--- a/paperbanana/vector/graphviz_render.py
+++ b/paperbanana/vector/graphviz_render.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import structlog
 
+from paperbanana.config.fonts import FontConfig, get_default_font_config
 from paperbanana.core.types import DiagramIR
 
 logger = structlog.get_logger()
@@ -56,16 +57,29 @@ def _escape_dot_label(text: str) -> str:
     return s
 
 
-def diagram_ir_to_dot(ir: DiagramIR) -> str:
-    """Convert Diagram IR to a Graphviz digraph (UTF-8)."""
+def diagram_ir_to_dot(ir: DiagramIR, font_config: FontConfig | None = None) -> str:
+    """Convert Diagram IR to a Graphviz digraph (UTF-8).
+
+    Args:
+        ir: The diagram intermediate representation.
+        font_config: Font configuration for text rendering. Uses default (Tahoma)
+                     if not provided.
+
+    Returns:
+        A Graphviz digraph string.
+    """
+    if font_config is None:
+        font_config = get_default_font_config()
+
     id_map = _build_dot_id_map(ir)
     rankdir = getattr(ir, "layout_direction", "LR")
+    font_string = font_config.get_font_string()
 
     lines: list[str] = [
         "digraph G {",
-        f'  graph [rankdir={rankdir}, bgcolor="white", fontname="Helvetica"];',
-        '  node [fontname="Helvetica", fontsize=10];',
-        '  edge [fontname="Helvetica", fontsize=9];',
+        f'  graph [rankdir={rankdir}, bgcolor="white", fontname="{font_string}"];',
+        f'  node [fontname="{font_string}", fontsize=10];',
+        f'  edge [fontname="{font_string}", fontsize=9];',
     ]
 
     # Nodes not assigned to any group

--- a/tests/test_font_config/__init__.py
+++ b/tests/test_font_config/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for configuration modules."""

--- a/tests/test_font_config/test_fonts.py
+++ b/tests/test_font_config/test_fonts.py
@@ -1,0 +1,56 @@
+"""Tests for font configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from paperbanana.config.fonts import (
+    FontConfig,
+    get_default_font_config,
+    get_legacy_font_config,
+)
+
+
+def test_font_config_get_font_string() -> None:
+    config = FontConfig(primary_fonts=["Tahoma"], fallback_fonts=["Helvetica", "Arial"])
+    assert config.get_font_string() == "Tahoma,Helvetica,Arial"
+
+
+def test_font_config_get_font_string_custom_separator() -> None:
+    config = FontConfig(primary_fonts=["Tahoma"], fallback_fonts=["Helvetica"])
+    assert config.get_font_string(separator=" ") == "Tahoma Helvetica"
+
+
+def test_font_config_get_first_available_font() -> None:
+    config = FontConfig(primary_fonts=["Tahoma"], fallback_fonts=["Helvetica"])
+    assert config.get_first_available_font() == "Tahoma"
+
+
+def test_font_config_default_fallbacks() -> None:
+    config = FontConfig(primary_fonts=["Tahoma"])
+    assert config.fallback_fonts == ["Helvetica", "Arial", "sans-serif"]
+
+
+def test_font_config_empty_primary_raises() -> None:
+    with pytest.raises(ValueError, match="primary_fonts must not be empty"):
+        FontConfig(primary_fonts=[])
+
+
+def test_get_default_font_config() -> None:
+    config = get_default_font_config()
+    assert config.primary_fonts == ["Tahoma"]
+    assert config.fallback_fonts == ["Helvetica", "Arial", "sans-serif"]
+    assert config.get_first_available_font() == "Tahoma"
+
+
+def test_get_legacy_font_config() -> None:
+    config = get_legacy_font_config()
+    assert config.primary_fonts == ["Helvetica"]
+    assert config.fallback_fonts == ["Arial", "sans-serif"]
+    assert config.get_first_available_font() == "Helvetica"
+
+
+def test_font_config_multiple_primary_fonts() -> None:
+    config = FontConfig(primary_fonts=["Tahoma", "Arial"], fallback_fonts=["Helvetica"])
+    assert config.get_font_string() == "Tahoma,Arial,Helvetica"
+    assert config.get_first_available_font() == "Tahoma"

--- a/tests/test_vector/test_vector_graphviz_ir.py
+++ b/tests/test_vector/test_vector_graphviz_ir.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from paperbanana.config.fonts import FontConfig, get_legacy_font_config
 from paperbanana.core.types import DiagramIR, DiagramIREdge, DiagramIRNode
 from paperbanana.vector.graphviz_render import (
     diagram_ir_to_dot,
@@ -72,3 +73,41 @@ def test_diagram_ir_json_roundtrip() -> None:
     data = json.loads(ir.model_dump_json())
     ir2 = DiagramIR.model_validate(data)
     assert ir2.nodes[0].id == "x"
+
+
+def test_diagram_ir_to_dot_uses_default_tahoma_font() -> None:
+    ir = DiagramIR(
+        title="Font Test",
+        nodes=[DiagramIRNode(id="n1", label="Node")],
+        edges=[],
+    )
+    dot = diagram_ir_to_dot(ir)
+    assert "Tahoma" in dot
+    assert "Helvetica" in dot
+    assert "Arial" in dot
+
+
+def test_diagram_ir_to_dot_with_custom_font_config() -> None:
+    ir = DiagramIR(
+        title="Font Test",
+        nodes=[DiagramIRNode(id="n1", label="Node")],
+        edges=[],
+    )
+    config = get_legacy_font_config()
+    dot = diagram_ir_to_dot(ir, font_config=config)
+    assert "Helvetica,Arial" in dot
+    assert "Tahoma" not in dot
+
+
+def test_diagram_ir_to_dot_font_config_in_graph_node_and_edge() -> None:
+    ir = DiagramIR(
+        title="Font Test",
+        nodes=[DiagramIRNode(id="n1", label="Node")],
+        edges=[],
+    )
+    config = FontConfig(primary_fonts=["CustomFont"])
+    dot = diagram_ir_to_dot(ir, font_config=config)
+    assert 'fontname="CustomFont,Helvetica,Arial,sans-serif"' in dot
+    lines = dot.split("\n")
+    fontname_lines = [line for line in lines if "fontname=" in line]
+    assert len(fontname_lines) >= 3


### PR DESCRIPTION
…ckage

Implement a comprehensive font configuration system with priority-based font loading and fallback support. The system now defaults to Tahoma with fallbacks to Helvetica, Arial, and sans-serif for maximum compatibility.

Key changes:
- Created new paperbanana/config/fonts.py module with FontConfig class
- FontConfig supports priority fonts with automatic fallback chain
- Updated graphviz_render.py to use FontConfig for all text rendering
- Added get_default_font_config() that uses Tahoma as primary font
- Added get_legacy_font_config() for backward compatibility with Helvetica
- Comprehensive test coverage for font configuration and diagram rendering

The implementation is fully backward compatible - existing code continues to work with default Tahoma font configuration.

https://claude.ai/code/session_01DTPPy2FUBtSS3GbSiexu9b