### PR TITLE
feat: add LiteLLM as VLM provider for 100+ LLM backends

### DIFF
--- a/configs/provider/vlm/litellm.yaml
+++ b/configs/provider/vlm/litellm.yaml
@@ -1,0 +1,14 @@
+# LiteLLM VLM Provider — 100+ LLM providers via unified interface
+# Docs: https://docs.litellm.ai/docs/providers
+# Model format: provider/model (e.g. openai/gpt-4o, anthropic/claude-sonnet-4-6)
+# API keys are read from environment variables automatically by LiteLLM.
+type: litellm
+priority: 1
+capabilities:
+  - text_generation
+  - vision_input
+  - json_mode
+config:
+  model: openai/gpt-4o-mini
+  temperature: 1.0
+  max_tokens: 4096

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -132,6 +132,11 @@ class Settings(BaseSettings):
     )
     openai_local_json_mode: bool = Field(default=False, alias="OPENAI_LOCAL_JSON_MODE")
 
+    # LiteLLM settings
+    litellm_model: Optional[str] = Field(default=None, alias="LITELLM_MODEL")
+    litellm_api_key: Optional[str] = Field(default=None, alias="LITELLM_API_KEY")
+    litellm_api_base: Optional[str] = Field(default=None, alias="LITELLM_API_BASE")
+
     # AWS Bedrock settings
     aws_region: str = Field(default="us-east-1", alias="AWS_REGION")
     aws_profile: Optional[str] = Field(default=None, alias="AWS_PROFILE")

--- a/paperbanana/providers/registry.py
+++ b/paperbanana/providers/registry.py
@@ -156,11 +156,25 @@ class ProviderRegistry:
                     " ensure `claude` is available on PATH."
                 )
             return vlm
+        elif provider == "litellm":
+            from paperbanana.providers.vlm.litellm import LiteLLMVLM
+
+            vlm = LiteLLMVLM(
+                model=settings.litellm_model or settings.vlm_model,
+                api_key=settings.litellm_api_key,
+                api_base=settings.litellm_api_base,
+            )
+            if not vlm.is_available():
+                raise ImportError(
+                    "litellm is required for the LiteLLM provider. "
+                    "Install with: pip install 'paperbanana[litellm]'"
+                )
+            return vlm
         else:
             raise ValueError(
                 "Unknown VLM provider: "
                 f"{provider}. Available: gemini, openrouter, openai, openai_local, "
-                f"bedrock, anthropic, ollama, claude_code"
+                f"bedrock, anthropic, ollama, claude_code, litellm"
             )
 
     @staticmethod

--- a/paperbanana/providers/vlm/litellm.py
+++ b/paperbanana/providers/vlm/litellm.py
@@ -1,0 +1,109 @@
+"""LiteLLM VLM provider — unified access to 100+ LLM providers."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import structlog
+from PIL import Image
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from paperbanana.core.utils import image_to_base64
+from paperbanana.providers.base import VLMProvider
+
+logger = structlog.get_logger()
+
+
+class LiteLLMVLM(VLMProvider):
+    """VLM provider using the LiteLLM SDK (async).
+
+    Supports any LiteLLM model string, e.g. ``openai/gpt-4o``,
+    ``anthropic/claude-sonnet-4-6``, ``groq/llama-3.3-70b-versatile``.
+    Provider API keys are read from environment variables automatically.
+    """
+
+    def __init__(
+        self,
+        model: str = "openai/gpt-4o-mini",
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ):
+        self._model = model
+        self._api_key = api_key
+        self._api_base = api_base
+
+    @property
+    def name(self) -> str:
+        return "litellm"
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    def is_available(self) -> bool:
+        try:
+            import litellm  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(min=2, max=30))
+    async def generate(
+        self,
+        prompt: str,
+        images: Optional[list[Image.Image]] = None,
+        system_prompt: Optional[str] = None,
+        temperature: float = 1.0,
+        max_tokens: int = 4096,
+        response_format: Optional[str] = None,
+    ) -> str:
+        import litellm
+
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+
+        content = []
+        if images:
+            for img in images:
+                b64 = image_to_base64(img)
+                content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{b64}"},
+                    }
+                )
+        content.append({"type": "text", "text": prompt})
+        messages.append({"role": "user", "content": content})
+
+        kwargs = {
+            "model": self._model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "drop_params": True,
+        }
+
+        if self._api_key:
+            kwargs["api_key"] = self._api_key
+        if self._api_base:
+            kwargs["api_base"] = self._api_base
+
+        if response_format == "json":
+            kwargs["response_format"] = {"type": "json_object"}
+
+        response = await litellm.acompletion(**kwargs)
+        text = response.choices[0].message.content
+
+        usage = getattr(response, "usage", None)
+        logger.debug("LiteLLM response", model=self._model, usage=usage)
+
+        if self.cost_tracker is not None and usage is not None:
+            self.cost_tracker.record_vlm_call(
+                provider=self.name,
+                model=self._model,
+                input_tokens=getattr(usage, "prompt_tokens", 0),
+                output_tokens=getattr(usage, "completion_tokens", 0),
+            )
+        return text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,13 @@ google = ["google-genai>=1.65"]
 openai = ["openai>=1.0"]
 bedrock = ["boto3>=1.34"]
 anthropic = ["anthropic>=0.83"]
+litellm = ["litellm>=1.67.0,<2.0"]
 all-providers = [
     "google-genai>=1.65",
     "openai>=1.0",
     "boto3>=1.34",
     "anthropic>=0.83",
+    "litellm>=1.67.0,<2.0",
 ]
 mcp = ["fastmcp>=2.0"]
 dev = [

--- a/tests/test_providers/test_litellm_vlm.py
+++ b/tests/test_providers/test_litellm_vlm.py
@@ -1,0 +1,278 @@
+"""Tests for the LiteLLM VLM provider."""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image
+
+from paperbanana.providers.vlm.litellm import LiteLLMVLM
+
+
+def _install_litellm_stub(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Install a fake litellm module and return the mock acompletion."""
+    fake = types.ModuleType("litellm")
+    fake.acompletion = AsyncMock(name="litellm.acompletion")
+
+    fake.RateLimitError = type("RateLimitError", (Exception,), {})
+    fake.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    fake.NotFoundError = type("NotFoundError", (Exception,), {})
+    fake.APIConnectionError = type("APIConnectionError", (Exception,), {})
+    fake.Timeout = type("Timeout", (Exception,), {})
+    fake.APIError = type("APIError", (Exception,), {})
+
+    monkeypatch.setitem(sys.modules, "litellm", fake)
+    return fake.acompletion
+
+
+def _mock_response(content: str = "Hello", prompt_tokens: int = 10, completion_tokens: int = 5):
+    usage = types.SimpleNamespace(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens)
+    message = types.SimpleNamespace(content=content)
+    choice = types.SimpleNamespace(message=message)
+    return types.SimpleNamespace(choices=[choice], usage=usage)
+
+
+# ── Init + config ──────────────────────────────────────────────
+
+
+class TestLiteLLMVLMInit:
+    def test_default_model(self) -> None:
+        vlm = LiteLLMVLM()
+        assert vlm.model_name == "openai/gpt-4o-mini"
+        assert vlm.name == "litellm"
+
+    def test_custom_model(self) -> None:
+        vlm = LiteLLMVLM(model="anthropic/claude-sonnet-4-6")
+        assert vlm.model_name == "anthropic/claude-sonnet-4-6"
+
+    def test_is_available_with_litellm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install_litellm_stub(monkeypatch)
+        vlm = LiteLLMVLM()
+        assert vlm.is_available() is True
+
+    def test_is_available_without_litellm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delitem(sys.modules, "litellm", raising=False)
+        monkeypatch.setattr(
+            "builtins.__import__",
+            _make_import_raiser("litellm", monkeypatch),
+        )
+        vlm = LiteLLMVLM()
+        assert vlm.is_available() is False
+
+
+def _make_import_raiser(blocked_name: str, monkeypatch: pytest.MonkeyPatch):
+    """Return an __import__ replacement that raises ImportError for a specific module."""
+    real_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+    def _raiser(name, *args, **kwargs):
+        if name == blocked_name:
+            raise ImportError(f"No module named '{blocked_name}'")
+        return real_import(name, *args, **kwargs)
+
+    return _raiser
+
+
+# ── Generate (text-only) ──────────────────────────────────────
+
+
+class TestLiteLLMVLMGenerate:
+    @pytest.mark.asyncio
+    async def test_generate_text_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response("The answer is 4.")
+
+        vlm = LiteLLMVLM(model="openai/gpt-4o")
+        text = await vlm.generate("What is 2+2?")
+
+        assert text == "The answer is 4."
+        call_kwargs = mock_acompletion.call_args.kwargs
+        assert call_kwargs["model"] == "openai/gpt-4o"
+        assert call_kwargs["drop_params"] is True
+        assert call_kwargs["temperature"] == 1.0
+        assert call_kwargs["max_tokens"] == 4096
+
+    @pytest.mark.asyncio
+    async def test_generate_with_system_prompt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response("Done")
+
+        vlm = LiteLLMVLM()
+        await vlm.generate("test", system_prompt="You are a helpful assistant")
+
+        messages = mock_acompletion.call_args.kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "You are a helpful assistant"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_json_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response('{"key": "value"}')
+
+        vlm = LiteLLMVLM()
+        await vlm.generate("test", response_format="json")
+
+        call_kwargs = mock_acompletion.call_args.kwargs
+        assert call_kwargs["response_format"] == {"type": "json_object"}
+
+    @pytest.mark.asyncio
+    async def test_generate_passes_temperature_and_max_tokens(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response("ok")
+
+        vlm = LiteLLMVLM()
+        await vlm.generate("test", temperature=0.5, max_tokens=1024)
+
+        call_kwargs = mock_acompletion.call_args.kwargs
+        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["max_tokens"] == 1024
+
+    @pytest.mark.asyncio
+    async def test_api_key_forwarded_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response("ok")
+
+        vlm = LiteLLMVLM(api_key="sk-test-123")
+        await vlm.generate("test")
+
+        assert mock_acompletion.call_args.kwargs["api_key"] == "sk-test-123"
+
+    @pytest.mark.asyncio
+    async def test_api_key_omitted_when_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response("ok")
+
+        vlm = LiteLLMVLM()
+        await vlm.generate("test")
+
+        assert "api_key" not in mock_acompletion.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_api_base_forwarded_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response("ok")
+
+        vlm = LiteLLMVLM(api_base="http://localhost:4000")
+        await vlm.generate("test")
+
+        assert mock_acompletion.call_args.kwargs["api_base"] == "http://localhost:4000"
+
+
+# ── Generate (with images / vision) ───────────────────────────
+
+
+class TestLiteLLMVLMVision:
+    @pytest.mark.asyncio
+    async def test_generate_with_images(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response("I see a red square")
+
+        monkeypatch.setattr(
+            "paperbanana.providers.vlm.litellm.image_to_base64",
+            lambda _: "fake-b64-data",
+        )
+
+        vlm = LiteLLMVLM()
+        img = Image.new("RGB", (4, 4), color="red")
+        text = await vlm.generate("What do you see?", images=[img])
+
+        assert text == "I see a red square"
+        messages = mock_acompletion.call_args.kwargs["messages"]
+        user_content = messages[-1]["content"]
+        assert user_content[0]["type"] == "image_url"
+        assert "fake-b64-data" in user_content[0]["image_url"]["url"]
+        assert user_content[-1]["type"] == "text"
+
+
+# ── Error handling ────────────────────────────────────────────
+
+
+class TestLiteLLMVLMErrors:
+    @pytest.mark.asyncio
+    async def test_auth_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        litellm_mod = sys.modules["litellm"]
+        mock_acompletion.side_effect = litellm_mod.AuthenticationError("Invalid API key")
+
+        vlm = LiteLLMVLM()
+        with pytest.raises(Exception, match="Invalid API key"):
+            await vlm.generate.__wrapped__(vlm, "test")
+
+    @pytest.mark.asyncio
+    async def test_not_found_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        litellm_mod = sys.modules["litellm"]
+        mock_acompletion.side_effect = litellm_mod.NotFoundError("Model not found: bad/model")
+
+        vlm = LiteLLMVLM(model="bad/model")
+        with pytest.raises(Exception, match="not found"):
+            await vlm.generate.__wrapped__(vlm, "test")
+
+    @pytest.mark.asyncio
+    async def test_timeout_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        litellm_mod = sys.modules["litellm"]
+        mock_acompletion.side_effect = litellm_mod.Timeout("Request timed out")
+
+        vlm = LiteLLMVLM()
+        with pytest.raises(Exception, match="timed out"):
+            await vlm.generate.__wrapped__(vlm, "test")
+
+    @pytest.mark.asyncio
+    async def test_null_content_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response(content=None)
+
+        vlm = LiteLLMVLM()
+        result = await vlm.generate("test")
+        assert result is None
+
+
+# ── Cost tracking ─────────────────────────────────────────────
+
+
+class TestLiteLLMVLMCostTracking:
+    @pytest.mark.asyncio
+    async def test_cost_tracker_called_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response("ok", prompt_tokens=100, completion_tokens=50)
+
+        tracker = MagicMock()
+        vlm = LiteLLMVLM(model="anthropic/claude-sonnet-4-6")
+        vlm.cost_tracker = tracker
+
+        await vlm.generate("test")
+
+        tracker.record_vlm_call.assert_called_once_with(
+            provider="litellm",
+            model="anthropic/claude-sonnet-4-6",
+            input_tokens=100,
+            output_tokens=50,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_cost_tracker_no_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        mock_acompletion.return_value = _mock_response("ok")
+
+        vlm = LiteLLMVLM()
+        vlm.cost_tracker = None
+        text = await vlm.generate("test")
+        assert text == "ok"
+
+    @pytest.mark.asyncio
+    async def test_no_usage_in_response_skips_tracking(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_acompletion = _install_litellm_stub(monkeypatch)
+        message = types.SimpleNamespace(content="ok")
+        choice = types.SimpleNamespace(message=message)
+        mock_acompletion.return_value = types.SimpleNamespace(choices=[choice], usage=None)
+
+        tracker = MagicMock()
+        vlm = LiteLLMVLM()
+        vlm.cost_tracker = tracker
+
+        await vlm.generate("test")
+        tracker.record_vlm_call.assert_not_called()

--- a/tests/test_providers/test_litellm_vlm.py
+++ b/tests/test_providers/test_litellm_vlm.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 import types
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -119,7 +118,9 @@ class TestLiteLLMVLMGenerate:
         assert call_kwargs["response_format"] == {"type": "json_object"}
 
     @pytest.mark.asyncio
-    async def test_generate_passes_temperature_and_max_tokens(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_generate_passes_temp_and_max_tokens(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         mock_acompletion = _install_litellm_stub(monkeypatch)
         mock_acompletion.return_value = _mock_response("ok")
 
@@ -238,7 +239,9 @@ class TestLiteLLMVLMCostTracking:
     @pytest.mark.asyncio
     async def test_cost_tracker_called_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_acompletion = _install_litellm_stub(monkeypatch)
-        mock_acompletion.return_value = _mock_response("ok", prompt_tokens=100, completion_tokens=50)
+        mock_acompletion.return_value = _mock_response(
+            "ok", prompt_tokens=100, completion_tokens=50
+        )
 
         tracker = MagicMock()
         vlm = LiteLLMVLM(model="anthropic/claude-sonnet-4-6")
@@ -264,7 +267,9 @@ class TestLiteLLMVLMCostTracking:
         assert text == "ok"
 
     @pytest.mark.asyncio
-    async def test_no_usage_in_response_skips_tracking(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_no_usage_in_response_skips_tracking(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         mock_acompletion = _install_litellm_stub(monkeypatch)
         message = types.SimpleNamespace(content="ok")
         choice = types.SimpleNamespace(message=message)


### PR DESCRIPTION


## Summary

Adds [LiteLLM](https://github.com/BerriAI/litellm) as a VLM provider, enabling access to 100+ LLM backends (OpenAI, Anthropic, Google, Groq, Together AI, AWS Bedrock, Azure, Mistral, etc.) through a single unified interface.

## Changes

| File | What |
|------|------|
| `paperbanana/providers/vlm/litellm.py` | New `LiteLLMVLM(VLMProvider)` using `litellm.acompletion()`. Supports vision, JSON mode, cost tracking, retry with backoff. Uses `drop_params=True` for cross-provider compatibility. |
| `paperbanana/providers/registry.py` | Register `"litellm"` provider in `create_vlm()` with availability check. |
| `paperbanana/core/config.py` | Added `LITELLM_MODEL`, `LITELLM_API_KEY`, `LITELLM_API_BASE` settings. |
| `pyproject.toml` | Added `litellm>=1.67.0,<2.0` optional extra + included in `all-providers`. |
| `configs/provider/vlm/litellm.yaml` | YAML config following existing provider pattern. |
| `tests/test_providers/test_litellm_vlm.py` | 19 unit tests covering generate, vision, errors, cost tracking. |

## Tests

**Unit tests -- 19 new, all passing:**
```
tests/test_providers/test_litellm_vlm.py::TestLiteLLMVLMInit           4 passed
tests/test_providers/test_litellm_vlm.py::TestLiteLLMVLMGenerate       7 passed
tests/test_providers/test_litellm_vlm.py::TestLiteLLMVLMVision         1 passed
tests/test_providers/test_litellm_vlm.py::TestLiteLLMVLMErrors         4 passed
tests/test_providers/test_litellm_vlm.py::TestLiteLLMVLMCostTracking   3 passed
19 passed in 0.09s
```

Edge cases covered:
- `drop_params=True` always set
- API key/base forwarded when set, omitted when None (env var fallback)
- System prompt, temperature, max_tokens forwarded correctly
- JSON mode (`response_format`) applied
- Vision: images encoded as base64 content parts
- Auth error, model-not-found, timeout propagation
- Null content handling
- Cost tracker called with correct tokens when set
- Cost tracker skipped when None or usage absent
- `is_available()` returns False when litellm not installed

**Regression -- 685 passed, 0 failures:**
```
$ python -m pytest tests/ --ignore=tests/test_utils.py -q
685 passed, 1 skipped in 41.19s
```

**Lint:**
```
$ ruff check paperbanana/providers/vlm/litellm.py
All checks passed!
```

## Example usage

```bash
pip install 'paperbanana[litellm]'
export ANTHROPIC_API_KEY=sk-...

paperbanana run \
  --vlm-provider litellm \
  --vlm-model anthropic/claude-sonnet-4-6 \
  --paper my_paper.pdf
```

Or via env vars:
```bash
export VLM_PROVIDER=litellm
export LITELLM_MODEL=openai/gpt-4o
export OPENAI_API_KEY=sk-...
paperbanana run --paper my_paper.pdf
```

See [LiteLLM provider docs](https://docs.litellm.ai/docs/providers) for the full list of supported providers and model strings.
