### PR TITLE
fix: raise non-retryable error on empty Gemini response

### DIFF
--- a/paperbanana/providers/vlm/gemini.py
+++ b/paperbanana/providers/vlm/gemini.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import structlog
 from PIL import Image
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_exponential
 
 from paperbanana.core.utils import image_to_base64
 from paperbanana.providers.base import VLMProvider
@@ -17,6 +17,15 @@ logger = structlog.get_logger()
 # Gemini 2.5+ models use "thinking" tokens counted within max_output_tokens.
 _THINKING_MODEL_RE = re.compile(r"gemini-(?:[3-9]|[1-9]\d|2\.[5-9]|2\.\d{2,})")
 _DEFAULT_THINKING_BUDGET = 8192
+
+
+class GeminiEmptyResponseError(RuntimeError):
+    """Gemini returned a valid API response but with no text content.
+
+    This typically indicates a deterministic refusal (safety filter, content
+    policy) rather than a transient failure, so retrying the same input is
+    unlikely to produce a different result.
+    """
 
 
 class GeminiVLM(VLMProvider):
@@ -67,7 +76,11 @@ class GeminiVLM(VLMProvider):
     def is_available(self) -> bool:
         return self._api_key is not None
 
-    @retry(stop=stop_after_attempt(8), wait=wait_exponential(min=2, max=120))
+    @retry(
+        stop=stop_after_attempt(8),
+        wait=wait_exponential(min=2, max=120),
+        retry=retry_if_not_exception_type(GeminiEmptyResponseError),
+    )
     async def generate(
         self,
         prompt: str,
@@ -133,4 +146,14 @@ class GeminiVLM(VLMProvider):
                 input_tokens=getattr(usage, "prompt_token_count", 0),
                 output_tokens=getattr(usage, "candidates_token_count", 0),
             )
-        return response.text
+        text = response.text
+        if text is None:
+            logger.warning(
+                "Gemini returned empty response (no candidates)",
+                model=self._model,
+                usage=usage,
+            )
+            raise GeminiEmptyResponseError(
+                f"Gemini model {self._model} returned no text content. Usage metadata: {usage}"
+            )
+        return text

--- a/tests/test_providers/test_gemini_thinking.py
+++ b/tests/test_providers/test_gemini_thinking.py
@@ -6,6 +6,7 @@ import pytest
 
 from paperbanana.providers.vlm.gemini import (
     _DEFAULT_THINKING_BUDGET,
+    GeminiEmptyResponseError,
     GeminiVLM,
 )
 
@@ -136,3 +137,84 @@ class TestThinkingBudgetAdjustment:
         config = captured["config"]
         assert config.max_output_tokens == 4096
         assert not hasattr(config, "thinking_config")
+
+
+# ---------------------------------------------------------------------------
+# None response handling
+# ---------------------------------------------------------------------------
+
+
+class TestNoneResponseHandling:
+    """Verify that None response.text raises GeminiEmptyResponseError (no retry)."""
+
+    @pytest.fixture()
+    def _mock_genai_none_response(self, monkeypatch):
+        """Mock Gemini to return None text."""
+        import types as builtin_types
+        from unittest.mock import MagicMock
+
+        mock_types = builtin_types.ModuleType("types")
+
+        class _FakeConfig:
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        class _FakeThinkingConfig:
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        mock_types.GenerateContentConfig = _FakeConfig
+        mock_types.ThinkingConfig = _FakeThinkingConfig
+        mock_types.Part = MagicMock()
+
+        class _FakeClient:
+            class Models:
+                @staticmethod
+                def generate_content(model, contents, config):
+                    resp = MagicMock()
+                    resp.text = None  # Simulate empty response
+                    resp.usage_metadata = MagicMock()
+                    resp.usage_metadata.prompt_token_count = 3000
+                    resp.usage_metadata.candidates_token_count = 0
+                    return resp
+
+            models = Models()
+
+        import sys
+
+        mock_google = builtin_types.ModuleType("google")
+        mock_genai = builtin_types.ModuleType("google.genai")
+        mock_genai.types = mock_types
+        mock_google.genai = mock_genai
+
+        monkeypatch.setitem(sys.modules, "google", mock_google)
+        monkeypatch.setitem(sys.modules, "google.genai", mock_genai)
+        monkeypatch.setitem(sys.modules, "google.genai.types", mock_types)
+
+        return _FakeClient
+
+    @pytest.mark.asyncio
+    async def test_none_response_raises_without_retry(self, _mock_genai_none_response):
+        """When response.text is None, generate() raises GeminiEmptyResponseError immediately."""
+        import paperbanana.providers.vlm.gemini as gemini_mod
+
+        # Access the unwrapped function to bypass tenacity for unit testing
+        original_generate = gemini_mod.GeminiVLM.generate.__wrapped__
+        vlm = GeminiVLM(api_key="fake", model="gemini-2.5-pro")
+        vlm._client = _mock_genai_none_response()
+
+        with pytest.raises(GeminiEmptyResponseError, match="returned no text content"):
+            await original_generate(vlm, "test prompt", max_tokens=4096)
+
+    @pytest.mark.asyncio
+    async def test_empty_response_error_is_not_retried(self, _mock_genai_none_response):
+        """GeminiEmptyResponseError should NOT trigger tenacity retry."""
+        vlm = GeminiVLM(api_key="fake", model="gemini-2.5-pro")
+        vlm._client = _mock_genai_none_response()
+
+        # Call the retry-wrapped generate() directly — it should raise immediately
+        # without retrying (if it retried 8 times, the test would be very slow).
+        with pytest.raises(GeminiEmptyResponseError):
+            await vlm.generate("test prompt", max_tokens=4096)


### PR DESCRIPTION
## What does this PR do?

When Gemini 2.5+ thinking models produce only thought tokens with zero candidates (e.g. due to safety filters or content policy), `response.text` returns `None`. Previously this `None` propagated silently to callers, causing `AttributeError` in downstream JSON parsing. This PR adds an explicit check and raises a dedicated `GeminiEmptyResponseError` that is excluded from tenacity retry.

Related: #40 (this addresses the extreme variant where `ThinkingConfig` from #55 doesn't prevent an empty response)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Reference dataset addition
- [ ] Documentation update
- [ ] Refactor (no functional change)
- [ ] New provider support

## Changes made

- `paperbanana/providers/vlm/gemini.py`:
  - Added `GeminiEmptyResponseError(RuntimeError)` exception class
  - Added `retry_if_not_exception_type(GeminiEmptyResponseError)` to the `@retry` decorator so deterministic empty responses are not retried (saves ~6 min of wasted API calls)
  - Replaced `return response.text` with a None check that logs a warning and raises the new exception
- `tests/test_providers/test_gemini_thinking.py`:
  - Added `TestNoneResponseHandling` with two tests: one verifying the exception type, one verifying tenacity does not retry it

## How to test

1. `pytest tests/test_providers/test_gemini_thinking.py -v` — all tests pass
2. The `test_empty_response_error_is_not_retried` test calls the retry-wrapped `generate()` directly; if retry were triggered, the test would hang (8 attempts × exponential backoff) rather than completing instantly

## Checklist

- [x] `pytest tests/ -v` passes
- [x] `ruff check paperbanana/ mcp_server/ tests/ scripts/` passes
- [x] I've added/updated tests for new functionality (if applicable)
- [ ] I've updated documentation (if applicable)
- [ ] For reference dataset additions: verified methodology text matches diagram, aspect ratio is within [1.5, 2.5], metadata.json is complete