### PR TITLE
chore: v0.2.0 release prep — first-run defaults, budget pricing, version sync, --version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ ATLASCLOUD_IMAGE_MODEL=openai/gpt-image-2/text-to-image
 # Google Gemini (free, no credit card): https://makersuite.google.com/app/apikey
 GOOGLE_API_KEY=
 GOOGLE_BASE_URL=
-GOOGLE_VLM_MODEL=gemini-2.0-flash
+GOOGLE_VLM_MODEL=gemini-2.5-flash
 GOOGLE_IMAGE_MODEL=gemini-3-pro-image-preview
 
 # ── Local open-weight models ──────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,35 @@ jobs:
           cache: "pip"
       - name: Install build dependencies
         run: pip install build
+      - name: Verify versions match the tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          python - "$TAG" <<'PY'
+          import json, sys, tomllib
+
+          tag = sys.argv[1]
+          pkg = tomllib.load(open("pyproject.toml", "rb"))["project"]["version"]
+          init = next(
+              line.split('"')[1]
+              for line in open("paperbanana/__init__.py")
+              if line.startswith("__version__")
+          )
+          server = json.load(open("server.json"))["version"]
+          versions = {"tag": tag, "pyproject": pkg, "__init__": init, "server.json": server}
+          print(versions)
+          if len(set(versions.values())) != 1:
+              raise SystemExit(f"version mismatch: {versions}")
+          PY
       - name: Build package
         run: python -m build
+      - name: Verify the built wheel installs and exposes the current CLI
+        run: |
+          python -m venv /tmp/verify-venv
+          /tmp/verify-venv/bin/pip install --quiet dist/*.whl
+          OUT=$(/tmp/verify-venv/bin/paperbanana --version)
+          echo "$OUT"
+          echo "$OUT" | grep -q "paperbanana ${GITHUB_REF_NAME#v}"
+          /tmp/verify-venv/bin/paperbanana generate --help | grep -q -- "--budget"
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cp .env.example .env
 #
 # Optional Gemini overrides:
 #   GOOGLE_BASE_URL=https://your-gemini-proxy.example.com
-#   GOOGLE_VLM_MODEL=gemini-2.0-flash
+#   GOOGLE_VLM_MODEL=gemini-2.5-flash
 #   GOOGLE_IMAGE_MODEL=gemini-3-pro-image-preview
 ```
 
@@ -171,8 +171,8 @@ PaperBanana supports multiple VLM and image generation providers:
 | Image Generation | OpenAI | `gpt-image-1.5` | Default |
 | VLM | Atlas Cloud | `deepseek-ai/DeepSeek-V3-0324` | OpenAI-compatible chat endpoint |
 | Image Generation | Atlas Cloud | `openai/gpt-image-2/text-to-image` | Async prediction API |
-| VLM | Google Gemini | `gemini-2.0-flash` | Free tier |
-| Image Generation | Google Gemini | `gemini-3-pro-image-preview` | Free tier |
+| VLM | Google Gemini | `gemini-2.5-flash` | Low cost |
+| Image Generation | Google Gemini | `gemini-3-pro-image-preview` | $0.134/image (1K) |
 | VLM / Image | OpenRouter | Any supported model | Flexible routing |
 
 Azure OpenAI / Foundry endpoints are auto-detected — set `OPENAI_BASE_URL` to your endpoint.
@@ -642,7 +642,7 @@ ATLASCLOUD_IMAGE_MODEL=openai/gpt-image-2/text-to-image
 # Google Gemini (alternative, free)
 GOOGLE_API_KEY=your-key
 GOOGLE_BASE_URL=                            # optional custom Gemini-compatible endpoint
-GOOGLE_VLM_MODEL=gemini-2.0-flash          # override Gemini VLM model
+GOOGLE_VLM_MODEL=gemini-2.5-flash          # override Gemini VLM model
 GOOGLE_IMAGE_MODEL=gemini-3-pro-image-preview  # override Gemini image model
 ```
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -4,7 +4,7 @@
 # Provider settings
 vlm:
   provider: gemini
-  model: gemini-2.0-flash
+  model: gemini-2.5-flash
 
 image:
   provider: google_imagen

--- a/configs/eval/benchmark.yaml
+++ b/configs/eval/benchmark.yaml
@@ -3,7 +3,7 @@
 
 vlm:
   provider: gemini
-  model: gemini-2.0-flash
+  model: gemini-2.5-flash
 
 image:
   provider: google_imagen

--- a/configs/provider/vlm/gemini.yaml
+++ b/configs/provider/vlm/gemini.yaml
@@ -7,7 +7,7 @@ capabilities:
   - vision_input
   - json_mode
 config:
-  model: gemini-2.0-flash
+  model: gemini-2.5-flash
   api_key: ${GOOGLE_API_KEY}
   temperature: 1.0
   max_tokens: 4096

--- a/paperbanana/__init__.py
+++ b/paperbanana/__init__.py
@@ -7,7 +7,7 @@ if sys.platform == "win32":
         if hasattr(_stream, "reconfigure"):
             _stream.reconfigure(encoding="utf-8", errors="replace")
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from paperbanana.core.pipeline import PaperBananaPipeline
 from paperbanana.core.types import DiagramType, GenerationInput, GenerationOutput

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -38,6 +38,31 @@ app = typer.Typer(
 )
 console = Console()
 
+
+def _version_callback(value: bool) -> None:
+    if value:
+        import platform
+
+        from paperbanana import __version__
+
+        console.print(f"paperbanana {__version__} (Python {platform.python_version()})")
+        raise typer.Exit()
+
+
+@app.callback()
+def _main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        help="Show paperbanana and Python versions, then exit.",
+        callback=_version_callback,
+        is_eager=True,
+    ),
+) -> None:
+    """Generate publication-quality academic illustrations from text."""
+
+
 # ── Data subcommand group ─────────────────────────────────────────
 data_app = typer.Typer(
     name="data",

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -20,7 +20,7 @@ class VLMConfig(BaseSettings):
     """VLM provider configuration."""
 
     provider: str = "gemini"
-    model: str = "gemini-2.0-flash"
+    model: str = "gemini-2.5-flash"
 
 
 class ImageConfig(BaseSettings):
@@ -61,7 +61,7 @@ class Settings(BaseSettings):
 
     # Provider settings
     vlm_provider: str = Field(default="gemini", alias="VLM_PROVIDER")
-    vlm_model: str = Field(default="gemini-2.0-flash", alias="VLM_MODEL")
+    vlm_model: str = Field(default="gemini-2.5-flash", alias="VLM_MODEL")
     image_provider: str = Field(default="google_imagen", alias="IMAGE_PROVIDER")
     image_model: str = Field(default="gemini-3-pro-image-preview", alias="IMAGE_MODEL")
 

--- a/paperbanana/core/pricing.py
+++ b/paperbanana/core/pricing.py
@@ -1,7 +1,7 @@
 """Pricing tables for VLM and image generation providers.
 
 Prices are in USD. VLM prices are per 1K tokens. Image prices are per image.
-Last updated: 2026-05-01.
+Last updated: 2026-06-10.
 """
 
 from __future__ import annotations
@@ -48,8 +48,9 @@ VLM_PRICING: dict[tuple[str, str], dict[str, float]] = {
 
 # (provider, model_prefix) -> USD per image
 IMAGE_GEN_PRICING: dict[tuple[str, str], float] = {
-    # Google Imagen — free tier
-    ("google_imagen", "gemini-3-pro-image-preview"): 0.0,
+    # Google Imagen — paid; 1K-resolution per-image prices (4K is higher)
+    ("google_imagen", "gemini-3-pro-image-preview"): 0.134,
+    ("google_imagen", "gemini-3.1-flash-image-preview"): 0.067,
     # OpenAI
     # gpt-image-2 is token-priced; this is a high-quality square-image estimate.
     ("openai_imagen", "gpt-image-1.5"): 0.02,

--- a/paperbanana/providers/vlm/gemini.py
+++ b/paperbanana/providers/vlm/gemini.py
@@ -37,7 +37,7 @@ class GeminiVLM(VLMProvider):
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model: str = "gemini-2.0-flash",
+        model: str = "gemini-2.5-flash",
         base_url: Optional[str] = None,
     ):
         self._api_key = api_key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paperbanana"
-version = "0.1.2"
+version = "0.2.0"
 description = "Agentic framework for automated academic illustration generation"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.llmsresearch/paperbanana",
   "title": "PaperBanana",
   "description": "Generate academic diagrams and statistical plots from text using multi-agent AI.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "paperbanana",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "transport": {
         "type": "stdio"
       }

--- a/tests/test_cost_tracking.py
+++ b/tests/test_cost_tracking.py
@@ -36,8 +36,11 @@ class TestPricingLookup:
 
     def test_exact_match_image(self):
         result = lookup_image_price("google_imagen", "gemini-3-pro-image-preview")
-        assert result is not None
-        assert result == 0.0
+        assert result == pytest.approx(0.134)
+
+    def test_gemini_flash_image_pricing(self):
+        result = lookup_image_price("google_imagen", "gemini-3.1-flash-image-preview")
+        assert result == pytest.approx(0.067)
 
     def test_openai_image_pricing(self):
         result = lookup_image_price("openai_imagen", "gpt-image-1.5")
@@ -91,7 +94,7 @@ class TestCostTracker:
         assert tracker.entries[0].call_type == "image_gen"
         assert tracker.total_cost > 0
 
-    def test_free_tier_cost_is_zero(self):
+    def test_free_tier_vlm_paid_image_cost(self):
         tracker = CostTracker()
         tracker.record_vlm_call(
             provider="gemini",
@@ -105,7 +108,8 @@ class TestCostTracker:
             model="gemini-3-pro-image-preview",
             agent="visualizer",
         )
-        assert tracker.total_cost == 0.0
+        # VLM side is free tier; the image model is paid (issue #213).
+        assert tracker.total_cost == pytest.approx(0.134)
         assert tracker.pricing_complete is True
 
     def test_set_agent_fallback(self):
@@ -255,8 +259,8 @@ class TestCostEstimator:
         assert "image_calls" in result
         assert result["vlm_calls"] >= 6  # retriever + planner + stylist + 3x critic
         assert result["image_calls"] == 3
-        # Free tier — cost should be 0
-        assert result["estimated_total_usd"] == 0.0
+        # 3 paid images at $0.134 (issue #213); VLM side is free tier.
+        assert result["estimated_total_usd"] == pytest.approx(3 * 0.134)
 
     def test_paid_provider_estimation(self):
         from paperbanana.core.config import Settings


### PR DESCRIPTION
Bundles the release-blocking fixes for v0.2.0:

- **Fixes #214** — default VLM bumped to `gemini-2.5-flash`; the deprecated `gemini-2.0-flash` default made every fresh `pip install 'paperbanana[google]'` fail on first generate. (Kept `gemini-3-pro-image-preview` as the image default — quality-first — but its pricing is now tracked, see below. Happy to switch the default to 3.1-flash if we'd rather optimize first-run cost.)
- **Fixes #213** — image pricing corrected: `gemini-3-pro-image-preview` $0.134/image (1K) instead of $0.0, `gemini-3.1-flash-image-preview` added at $0.067. `--budget` now actually protects Gemini image spend.
- **Fixes #215** — versions synced to 0.2.0 across `pyproject.toml`, `paperbanana.__version__` (was still 0.1.0), and `server.json` (was 0.1.1).
- **Fixes #25** — `paperbanana --version` / `-V` prints package + Python version (supersedes #29/#69; thanks @AthanasEdigerMartin and @haosenwang1018 for the groundwork).
- **Hardens against #216** — release workflow now (a) refuses to publish if the tag, pyproject, `__init__`, and server.json versions disagree, and (b) installs the built wheel into a clean venv and verifies `--version` and a modern flag before upload. Investigation note: the 0.1.2 wheel was never actually mis-built — it matches its tag exactly; the tag was just 4 months stale. The real fix for #216 is cutting v0.2.0, which this PR prepares.

Full suite green locally: 723 passed, 9 skipped. Cost tests that asserted the free-tier assumption were updated to the corrected prices.