### PR TITLE
test: MCP tool-surface smoke tests + README tool list sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ PaperBanana includes an MCP server for use with Claude Code, Cursor, or any MCP-
 }
 ```
 
-MCP tools include `generate_diagram`, `continue_run` (resume a prior `run_*` with optional feedback), `generate_plot`, `evaluate_diagram`, and `evaluate_plot`.
+Eleven MCP tools are exposed: `generate_diagram`, `generate_plot`, `continue_run` (resume a prior `run_*` with optional feedback), `continue_diagram`, `continue_plot`, `evaluate_diagram`, `evaluate_plot`, `orchestrate_figures` (full-paper figure packages), `batch_diagrams`, `batch_plots`, and `download_references`.
 
 The repo also ships with 3 Claude Code skills:
 - `/generate-diagram <file> [caption]` - generate a methodology diagram from a text file

--- a/tests/test_mcp/test_server_tools.py
+++ b/tests/test_mcp/test_server_tools.py
@@ -1,0 +1,55 @@
+"""Smoke tests for the MCP server tool surface.
+
+These guard against tools silently dropping out of registration (e.g. a
+decorator typo or an import error in a tool module) and keep the public
+tool list in sync with the docs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastmcp", reason="mcp extra not installed")
+
+from mcp_server.server import mcp  # noqa: E402
+
+EXPECTED_TOOLS = {
+    "batch_diagrams",
+    "batch_plots",
+    "continue_diagram",
+    "continue_plot",
+    "continue_run",
+    "download_references",
+    "evaluate_diagram",
+    "evaluate_plot",
+    "generate_diagram",
+    "generate_plot",
+    "orchestrate_figures",
+}
+
+
+def _list_tools():
+    return asyncio.run(mcp.list_tools())
+
+
+def test_all_expected_tools_registered():
+    names = {t.name for t in _list_tools()}
+    missing = EXPECTED_TOOLS - names
+    assert not missing, f"MCP tools missing from registration: {missing}"
+
+
+def test_no_unexpected_tools():
+    """New tools are welcome — add them to EXPECTED_TOOLS and the README."""
+    names = {t.name for t in _list_tools()}
+    unexpected = names - EXPECTED_TOOLS
+    assert not unexpected, (
+        f"New MCP tools {unexpected} — update EXPECTED_TOOLS, the server "
+        "docstring, and the README MCP section together."
+    )
+
+
+def test_every_tool_has_description():
+    undocumented = [t.name for t in _list_tools() if not (t.description or "").strip()]
+    assert not undocumented, f"MCP tools without descriptions: {undocumented}"


### PR DESCRIPTION
The MCP server now exposes **11 tools** (verified by live `list_tools()`), but the README advertised five and there was no MCP test coverage at all (`tests/test_mcp/` contained only a stale `__pycache__`).

- Smoke tests pin the expected tool set: missing tools fail (registration breakage), unexpected tools fail with instructions to update docs + test together, and undescribed tools fail. Skips cleanly when the `mcp` extra isn't installed.
- README MCP section now lists all 11 tools.
- Server docstring was already accurate — no change needed.