### PR TITLE
fix: complete secrets exclusion (atlas/litellm) + effective-model display

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -714,8 +714,8 @@ def generate(
                 "[bold]PaperBanana[/bold] - Dry Run\n\n"
                 f"Input: {input_path}{pdf_note}\n"
                 f"Caption: {caption}\n"
-                f"VLM: {settings.vlm_provider} / {settings.vlm_model}\n"
-                f"Image: {settings.image_provider} / {settings.image_model}\n"
+                f"VLM: {settings.vlm_provider} / {settings.effective_vlm_model}\n"
+                f"Image: {settings.image_provider} / {settings.effective_image_model}\n"
                 f"Iterations: {settings.refinement_iterations}\n"
                 f"Output: {expected_output}",
                 border_style="yellow",

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -741,6 +741,8 @@ class PaperBananaPipeline:
                     "openai_api_key",
                     "openrouter_api_key",
                     "anthropic_api_key",
+                    "atlascloud_api_key",
+                    "litellm_api_key",
                 }
             ),
         )
@@ -1438,6 +1440,8 @@ class PaperBananaPipeline:
                     "openai_api_key",
                     "openrouter_api_key",
                     "anthropic_api_key",
+                    "atlascloud_api_key",
+                    "litellm_api_key",
                 }
             ),
         )
@@ -1826,6 +1830,8 @@ class PaperBananaPipeline:
                     "openai_api_key",
                     "openrouter_api_key",
                     "anthropic_api_key",
+                    "atlascloud_api_key",
+                    "litellm_api_key",
                 }
             ),
         )

--- a/paperbanana/providers/registry.py
+++ b/paperbanana/providers/registry.py
@@ -89,7 +89,7 @@ class ProviderRegistry:
     def create_vlm(settings: Settings) -> VLMProvider:
         """Create a VLM provider based on settings."""
         provider = settings.vlm_provider.lower()
-        logger.info("Creating VLM provider", provider=provider, model=settings.vlm_model)
+        logger.info("Creating VLM provider", provider=provider, model=settings.effective_vlm_model)
 
         if provider == "gemini":
             _validate_api_key(settings.google_api_key, "GOOGLE_API_KEY")
@@ -197,7 +197,11 @@ class ProviderRegistry:
     def create_image_gen(settings: Settings) -> ImageGenProvider:
         """Create an image generation provider based on settings."""
         provider = settings.image_provider.lower()
-        logger.info("Creating image gen provider", provider=provider, model=settings.image_model)
+        logger.info(
+            "Creating image gen provider",
+            provider=provider,
+            model=settings.effective_image_model,
+        )
 
         if provider == "none":
             from paperbanana.providers.image_gen.dummy import DummyImageGen

--- a/tests/test_metadata_secrets.py
+++ b/tests/test_metadata_secrets.py
@@ -50,6 +50,8 @@ async def test_api_keys_are_excluded_from_metadata_config_snapshot(tmp_path):
         openai_api_key="openai-secret",
         openrouter_api_key="openrouter-secret",
         anthropic_api_key="anthropic-secret",
+        atlascloud_api_key="atlas-secret",
+        litellm_api_key="litellm-secret",
     )
     vlm = _MockVLM(["Plan", "Style", _critic_satisfied()])
     pipeline = PaperBananaPipeline(
@@ -68,6 +70,8 @@ async def test_api_keys_are_excluded_from_metadata_config_snapshot(tmp_path):
         "openai_api_key",
         "openrouter_api_key",
         "anthropic_api_key",
+        "atlascloud_api_key",
+        "litellm_api_key",
     ):
         assert key not in config_snapshot
 
@@ -79,8 +83,11 @@ async def test_api_keys_are_excluded_from_metadata_config_snapshot(tmp_path):
         "openai_api_key",
         "openrouter_api_key",
         "anthropic_api_key",
+        "atlascloud_api_key",
+        "litellm_api_key",
     ):
         assert key not in saved_config_snapshot
 
     serialized_metadata = metadata_path.read_text(encoding="utf-8")
-    assert "anthropic-secret" not in serialized_metadata
+    for secret in ("anthropic-secret", "atlas-secret", "litellm-secret"):
+        assert secret not in serialized_metadata


### PR DESCRIPTION
Follow-up to #221: `atlascloud_api_key` and `litellm_api_key` had the same metadata exposure as the keys already excluded — both are real secrets routed through the provider registry. Added to all three `config_snapshot` exclude sets; the #221 regression test now covers them and asserts the secret strings never appear in serialized metadata.

Also fixes the misleading model display found while verifying #96: provider-creation logs and the dry-run banner printed the raw global `vlm_model`/`image_model` (e.g. `provider=openai model=gemini-2.5-flash`) instead of `effective_*`.