### PR TITLE
fix: UTF-8 encoding for all text I/O; de-flake full-bench merge test

### DIFF
--- a/paperbanana/agents/visualizer.py
+++ b/paperbanana/agents/visualizer.py
@@ -216,7 +216,7 @@ class VisualizerAgent(BaseAgent):
         # Save generated code for inspection / manual editing
         code_path = Path(output_path).with_suffix(".py")
         code_path.parent.mkdir(parents=True, exist_ok=True)
-        code_path.write_text(code)
+        code_path.write_text(code, encoding="utf-8")
         logger.info("Plot code saved", path=str(code_path))
 
         # Execute the code
@@ -308,7 +308,9 @@ class VisualizerAgent(BaseAgent):
         # Ensure output directory exists
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False, encoding="utf-8"
+        ) as f:
             f.write(full_code)
             temp_path = f.name
 

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -283,7 +283,7 @@ class Settings(BaseSettings):
         """Load settings from a YAML config file with optional overrides."""
         config_path = Path(config_path)
         if config_path.exists():
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 yaml_config = yaml.safe_load(f) or {}
         else:
             yaml_config = {}

--- a/paperbanana/core/resume.py
+++ b/paperbanana/core/resume.py
@@ -80,7 +80,7 @@ def load_resume_state(output_dir: str, run_id: str) -> ResumeState:
             f"Only runs created with PaperBanana >= 0.2.0 can be continued."
         )
 
-    with open(input_path) as f:
+    with open(input_path, encoding="utf-8") as f:
         run_input = json.load(f)
 
     # Find the latest iteration
@@ -94,7 +94,7 @@ def load_resume_state(output_dir: str, run_id: str) -> ResumeState:
         planning_path = run_dir / "planning.json"
         if not planning_path.exists():
             raise ValueError(f"No iterations or planning.json found in {run_dir}")
-        with open(planning_path) as f:
+        with open(planning_path, encoding="utf-8") as f:
             planning = json.load(f)
         last_description = planning.get("optimized_description", "")
         last_iteration = 0
@@ -104,7 +104,7 @@ def load_resume_state(output_dir: str, run_id: str) -> ResumeState:
         last_iteration = int(last_iter_dir.name.split("_")[1])
         details_path = last_iter_dir / "details.json"
 
-        with open(details_path) as f:
+        with open(details_path, encoding="utf-8") as f:
             details = json.load(f)
 
         critique = details.get("critique", {})
@@ -132,7 +132,7 @@ def load_resume_state(output_dir: str, run_id: str) -> ResumeState:
     planner_ratio = None
     planning_path = run_dir / "planning.json"
     if planning_path.exists():
-        with open(planning_path) as f:
+        with open(planning_path, encoding="utf-8") as f:
             planning = json.load(f)
         planner_ratio = planning.get("planner_recommended_ratio")
     aspect_ratio = user_ratio or planner_ratio

--- a/paperbanana/data/manager.py
+++ b/paperbanana/data/manager.py
@@ -141,7 +141,7 @@ class DatasetManager:
         if not self.info_path.exists():
             return None
         try:
-            with open(self.info_path) as f:
+            with open(self.info_path, encoding="utf-8") as f:
                 return json.load(f)
         except (json.JSONDecodeError, OSError):
             return None
@@ -151,7 +151,7 @@ class DatasetManager:
         if not self.index_path.exists():
             return 0
         try:
-            with open(self.index_path) as f:
+            with open(self.index_path, encoding="utf-8") as f:
                 data = json.load(f)
             return len(data.get("examples", []))
         except (json.JSONDecodeError, OSError):
@@ -360,7 +360,7 @@ class DatasetManager:
         info.pop("source", None)
         info.pop("revision", None)
 
-        with open(self.info_path, "w") as f:
+        with open(self.info_path, "w", encoding="utf-8") as f:
             json.dump(info, f, indent=2)
 
     def clear(self) -> None:

--- a/paperbanana/reference/store.py
+++ b/paperbanana/reference/store.py
@@ -118,7 +118,7 @@ class ReferenceStore:
             "examples": [e.model_dump() for e in examples],
         }
 
-        with open(path / "index.json", "w") as f:
+        with open(path / "index.json", "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
 
         logger.info("Created reference store", path=str(path), count=len(examples))

--- a/tests/test_core/test_source_loader.py
+++ b/tests/test_core/test_source_loader.py
@@ -1,0 +1,21 @@
+"""Source loading tests that do not require PyMuPDF."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from paperbanana.core.source_loader import load_methodology_source
+
+
+def test_load_methodology_source_txt_utf8_non_ascii(tmp_path: Path) -> None:
+    """Regression test for #77: non-ASCII input must decode as UTF-8 regardless of locale.
+
+    On Windows with a CJK locale the default codec is GBK; reading UTF-8 files
+    without an explicit encoding raises UnicodeDecodeError. Write raw UTF-8
+    bytes (independent of any platform default) and round-trip them through
+    the methodology input loader used by `paperbanana generate --input`.
+    """
+    text = "稀疏路由的编码器-解码器架构概述 — naïve baseline 🍌"
+    p = tmp_path / "methodology.txt"
+    p.write_bytes(text.encode("utf-8"))
+    assert load_methodology_source(p) == text

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -317,6 +317,18 @@ class TestDownloadCurated:
 class TestFullBenchMerge:
     """Downloading full_bench after curated must preserve curated-only entries."""
 
+    @staticmethod
+    def _make_bench_zip(zip_dest: Path):
+        """Create a minimal fake PaperBananaBench.zip (no network).
+
+        Only the top-level ``PaperBananaBench/`` directory matters here —
+        the actual import is stubbed via ``_import_from_bench``.
+        """
+        import zipfile
+
+        with zipfile.ZipFile(zip_dest, "w") as zf:
+            zf.writestr("PaperBananaBench/.keep", "")
+
     def test_full_bench_preserves_curated_entries(self, tmp_cache):
         """Curated entries that are NOT in full_bench survive a full import."""
         # Seed cache with curated-only entries
@@ -348,9 +360,15 @@ class TestFullBenchMerge:
             {"id": "bench_new", "category": "bench_cat"},
         ]
 
-        with patch(
-            "paperbanana.data.manager._import_from_bench",
-            return_value=bench_examples,
+        def fake_download(url, dest):
+            self._make_bench_zip(dest)
+
+        with (
+            patch("paperbanana.data.manager._download_file", side_effect=fake_download),
+            patch(
+                "paperbanana.data.manager._import_from_bench",
+                return_value=bench_examples,
+            ),
         ):
             count = tmp_cache.download(dataset="full_bench", force=True)
 


### PR DESCRIPTION
Two fixes:

**Fixes #77** — on Windows with a CJK locale, text files opened without `encoding=` use the locale codec (gbk), crashing on UTF-8 content. Sweep adds explicit `encoding="utf-8"` to every text read/write in the package: YAML config load, resume-state JSON reads, dataset-manager JSON I/O, reference-store index write, and the visualizer's generated plot code (which the interpreter must re-read as UTF-8 source). Regression test round-trips Chinese + emoji through `load_methodology_source`.

**Fixes #227** — `test_full_bench_preserves_curated_entries` patched `_import_from_bench` but not `_download_file`, so it still live-downloaded the ~257 MB HuggingFace zip in CI and flaked with 429. Now mocked with the same pattern `TestDownloadCurated` uses; assertion intent unchanged; the test runs in ~0.2s offline. Audited the rest of the file — all other tests were already network-free.

Known remainder (out of scope, same bug class): `scripts/curate_reference_set.py` and `scripts/build_reference_set.py` also lack `encoding=` — they're dev scripts outside the installed package.