### PR TITLE
fix: continue-run honours custom output dirs; robust critic JSON parsing

### DIFF
--- a/paperbanana/agents/critic.py
+++ b/paperbanana/agents/critic.py
@@ -9,7 +9,7 @@ import structlog
 
 from paperbanana.agents.base import BaseAgent
 from paperbanana.core.types import CritiqueResult, DiagramType
-from paperbanana.core.utils import extract_json, load_image
+from paperbanana.core.utils import extract_json, load_image, truncate_text
 from paperbanana.providers.base import VLMProvider
 
 logger = structlog.get_logger()
@@ -118,5 +118,8 @@ class CriticAgent(BaseAgent):
                 )
             except (KeyError, TypeError) as e:
                 logger.warning("Failed to build CritiqueResult", error=str(e))
-        logger.warning("Failed to parse critic response as JSON")
+        logger.warning(
+            "Failed to parse critic response as JSON",
+            raw_response=truncate_text(response, 500),
+        )
         return CritiqueResult(critic_suggestions=[], revised_description=None)

--- a/paperbanana/agents/retriever.py
+++ b/paperbanana/agents/retriever.py
@@ -6,7 +6,7 @@ import structlog
 
 from paperbanana.agents.base import BaseAgent
 from paperbanana.core.types import DiagramType, ReferenceExample
-from paperbanana.core.utils import extract_json
+from paperbanana.core.utils import extract_json, truncate_text
 from paperbanana.providers.base import VLMProvider
 
 logger = structlog.get_logger()
@@ -112,7 +112,10 @@ class RetrieverAgent(BaseAgent):
         """Parse VLM response to extract selected example IDs."""
         data = extract_json(response)
         if not isinstance(data, dict):
-            logger.warning("Failed to parse retriever response as JSON, using fallback")
+            logger.warning(
+                "Failed to parse retriever response as JSON, using fallback",
+                raw_response=truncate_text(response, 500),
+            )
             return candidates
         selected_ids = (
             data.get("selected_ids") or data.get("top_10_papers") or data.get("top_10_plots") or []

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json as json_mod
+import os
 import time
 from pathlib import Path
 from typing import Optional
@@ -237,6 +238,14 @@ def generate(
         None, "--caption", "-c", help="Figure caption / communicative intent"
     ),
     output: Optional[str] = typer.Option(None, "--output", "-o", help="Output image path"),
+    output_dir: Optional[str] = typer.Option(
+        None,
+        "--output-dir",
+        help=(
+            "Directory for run outputs; also where --continue/--continue-run "
+            "look up the existing run"
+        ),
+    ),
     vlm_provider: Optional[str] = typer.Option(
         None, "--vlm-provider", help="VLM provider (gemini)"
     ),
@@ -473,6 +482,9 @@ def generate(
         overrides["save_prompts"] = save_prompts
     if output:
         overrides["output_dir"] = str(Path(output).parent)
+    if output_dir:
+        # Explicit --output-dir wins over the directory inferred from --output.
+        overrides["output_dir"] = output_dir
     overrides["output_format"] = format
     if vector:
         overrides["vector_export"] = True
@@ -534,20 +546,36 @@ def generate(
     if continue_run is not None or continue_last:
         from paperbanana.core.resume import find_latest_run, load_resume_state
 
+        resume_output_dir = settings.output_dir
         if continue_run:
-            run_id = continue_run
+            if "/" in continue_run or os.sep in continue_run:
+                # --continue-run was given as a path to the run directory itself.
+                run_path = Path(continue_run).expanduser()
+                if not run_path.is_dir():
+                    console.print(
+                        f"[red]Error: Run directory not found: {run_path.resolve()}[/red]"
+                    )
+                    raise typer.Exit(1)
+                resume_output_dir = str(run_path.parent)
+                run_id = run_path.name
+            else:
+                run_id = continue_run
         else:
             try:
-                run_id = find_latest_run(settings.output_dir)
+                run_id = find_latest_run(resume_output_dir)
                 console.print(f"  [dim]Using latest run:[/dim] [bold]{run_id}[/bold]")
             except FileNotFoundError as e:
                 console.print(f"[red]Error: {e}[/red]")
                 raise typer.Exit(1)
 
         try:
-            resume_state = load_resume_state(settings.output_dir, run_id)
+            resume_state = load_resume_state(resume_output_dir, run_id)
         except (FileNotFoundError, ValueError) as e:
             console.print(f"[red]Error: {e}[/red]")
+            console.print(
+                "[dim]Hint: if the run lives outside the default output directory, "
+                "pass --output-dir <dir> or --continue-run <path/to/run_dir>.[/dim]"
+            )
             raise typer.Exit(1)
 
         iter_label = "auto" if auto else str(iterations or settings.refinement_iterations)

--- a/paperbanana/core/resume.py
+++ b/paperbanana/core/resume.py
@@ -28,13 +28,13 @@ def find_latest_run(output_dir: str) -> str:
     """
     out = Path(output_dir)
     if not out.exists():
-        raise FileNotFoundError(f"Output directory not found: {output_dir}")
+        raise FileNotFoundError(f"Output directory not found: {out.resolve()}")
 
     runs = sorted(
         [d.name for d in out.iterdir() if d.is_dir() and d.name.startswith("run_")],
     )
     if not runs:
-        raise FileNotFoundError(f"No runs found in {output_dir}")
+        raise FileNotFoundError(f"No runs found in {out.resolve()}")
 
     return runs[-1]
 
@@ -70,7 +70,10 @@ def load_resume_state(output_dir: str, run_id: str) -> ResumeState:
     """
     run_dir = Path(output_dir) / run_id
     if not run_dir.exists():
-        raise FileNotFoundError(f"Run directory not found: {run_dir}")
+        raise FileNotFoundError(
+            f"Run directory not found: {run_dir.resolve()} "
+            f"(looked for run '{run_id}' under output dir '{Path(output_dir).resolve()}')"
+        )
 
     # Load original input
     input_path = run_dir / "run_input.json"

--- a/paperbanana/core/utils.py
+++ b/paperbanana/core/utils.py
@@ -218,7 +218,9 @@ def extract_json(text: str | None) -> dict | list | None:
     result = _try_parse_json(text)
     if result is not None:
         return result
-    for pattern in [r"```json\s*\n(.*?)```", r"```\s*\n(.*?)```"]:
+    # Code fences with or without a language tag; newline after the opening
+    # fence is optional (some models emit ```json{...}``` on one line).
+    for pattern in [r"```json\s*(.*?)\s*```", r"```\s*(.*?)\s*```"]:
         m = re.search(pattern, text, re.DOTALL)
         if m:
             result = _try_parse_json(m.group(1).strip())

--- a/paperbanana/evaluation/judge.py
+++ b/paperbanana/evaluation/judge.py
@@ -14,7 +14,7 @@ from paperbanana.core.types import (
     DimensionResult,
     EvaluationScore,
 )
-from paperbanana.core.utils import extract_json, load_image
+from paperbanana.core.utils import extract_json, load_image, truncate_text
 from paperbanana.providers.base import VLMProvider
 
 logger = structlog.get_logger()
@@ -164,7 +164,11 @@ class VLMJudge:
                 score=score,
                 reasoning=reasoning,
             )
-        logger.warning("Failed to parse evaluation response", dimension=dimension)
+        logger.warning(
+            "Failed to parse evaluation response",
+            dimension=dimension,
+            raw_response=truncate_text(response, 500),
+        )
         return DimensionResult(
             winner="Both are good",
             score=50.0,

--- a/tests/test_agents/test_critic_parse.py
+++ b/tests/test_agents/test_critic_parse.py
@@ -32,6 +32,41 @@ class TestExtractJsonNoneSafe:
         assert extract_json('{"key": "val') is None
 
 
+class TestExtractJsonRobustness:
+    """extract_json should recover JSON wrapped in fences or prose."""
+
+    def test_json_fence(self):
+        text = '```json\n{"key": "value"}\n```'
+        assert extract_json(text) == {"key": "value"}
+
+    def test_plain_fence(self):
+        text = '```\n{"key": "value"}\n```'
+        assert extract_json(text) == {"key": "value"}
+
+    def test_inline_fence_without_newline(self):
+        text = '```json{"key": "value"}```'
+        assert extract_json(text) == {"key": "value"}
+
+    def test_leading_prose(self):
+        text = 'Here is my evaluation of the image:\n{"key": "value"}'
+        assert extract_json(text) == {"key": "value"}
+
+    def test_trailing_commentary(self):
+        text = '{"key": "value"}\nLet me know if you need anything else.'
+        assert extract_json(text) == {"key": "value"}
+
+    def test_prose_around_fenced_json(self):
+        text = 'Sure! Here it is:\n```json\n{"key": "value"}\n```\nHope that helps.'
+        assert extract_json(text) == {"key": "value"}
+
+    def test_nested_braces_in_strings(self):
+        text = 'Result: {"summary": "use {curly} braces", "n": 1} done'
+        assert extract_json(text) == {"summary": "use {curly} braces", "n": 1}
+
+    def test_genuinely_invalid_returns_none(self):
+        assert extract_json("I could not evaluate the image, sorry.") is None
+
+
 class TestCriticParseResponse:
     """CriticAgent._parse_response should not crash on malformed input."""
 
@@ -66,3 +101,26 @@ class TestCriticParseResponse:
     def test_truncated_json_returns_empty_critique(self, critic):
         result = critic._parse_response('{"critic_suggestions": ["fix')
         assert result.needs_revision is False
+
+    def test_fenced_json_parsed(self, critic):
+        data = {"critic_suggestions": ["fix arrow"], "revised_description": "v2"}
+        result = critic._parse_response(f"```json\n{json.dumps(data)}\n```")
+        assert result.needs_revision is True
+        assert result.critic_suggestions == ["fix arrow"]
+        assert result.revised_description == "v2"
+
+    def test_json_with_leading_prose_parsed(self, critic):
+        data = {"critic_suggestions": ["align labels"], "revised_description": None}
+        result = critic._parse_response(f"Here is the critique:\n{json.dumps(data)}")
+        assert result.critic_suggestions == ["align labels"]
+
+    def test_json_with_trailing_commentary_parsed(self, critic):
+        data = {"critic_suggestions": [], "revised_description": None}
+        result = critic._parse_response(f"{json.dumps(data)}\nOverall the figure looks good.")
+        assert result.needs_revision is False
+
+    def test_invalid_response_returns_empty_critique_without_raising(self, critic):
+        result = critic._parse_response("The model refused to answer in JSON format.")
+        assert result.needs_revision is False
+        assert result.critic_suggestions == []
+        assert result.revised_description is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1242,3 +1242,166 @@ def test_references_categories_json(tmp_path, monkeypatch):
     data = json.loads(result.output)
     assert data["nlp_language"] == 2
     assert data["vision_perception"] == 1
+
+
+# ── generate --continue-run output dir resolution (issue #217) ──────
+
+
+def _make_run_dir(base: Path, run_id: str = "run_20260518_190654_814b57") -> Path:
+    """Create a minimal resumable run directory under *base*."""
+    run_dir = base / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "run_input.json").write_text(
+        json.dumps(
+            {
+                "source_context": "Method text",
+                "communicative_intent": "Overview figure",
+                "diagram_type": "methodology",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "planning.json").write_text(
+        json.dumps({"optimized_description": "A described diagram"}),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def _fake_continue_pipeline(tmp_path: Path, captured: dict):
+    from paperbanana.core.types import GenerationOutput
+
+    class _FakePipeline:
+        def __init__(self, settings=None, **kwargs):
+            captured["settings"] = settings
+
+        async def continue_run(
+            self,
+            resume_state,
+            additional_iterations=None,
+            user_feedback=None,
+            progress_callback=None,
+        ):
+            captured["resume_state"] = resume_state
+            captured["user_feedback"] = user_feedback
+            out_path = tmp_path / "continued.png"
+            out_path.write_bytes(b"fake")
+            return GenerationOutput(
+                image_path=str(out_path),
+                description="continued",
+                iterations=[],
+                metadata={"run_id": resume_state.run_id},
+            )
+
+    return _FakePipeline
+
+
+def test_continue_run_with_custom_output_dir(tmp_path, monkeypatch):
+    """--continue-run finds the run under --output-dir, not just settings.output_dir."""
+    custom_out = tmp_path / "custom_out"
+    run_dir = _make_run_dir(custom_out)
+    captured: dict = {}
+    monkeypatch.setattr(
+        "paperbanana.core.pipeline.PaperBananaPipeline",
+        _fake_continue_pipeline(tmp_path, captured),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            "--continue-run",
+            run_dir.name,
+            "--output-dir",
+            str(custom_out),
+            "--feedback",
+            "tweak the colours",
+        ],
+        terminal_width=HELP_TERMINAL_WIDTH,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Done!" in result.output
+    assert captured["resume_state"].run_id == run_dir.name
+    assert Path(captured["resume_state"].run_dir) == run_dir
+    assert captured["user_feedback"] == "tweak the colours"
+
+
+def test_continue_run_accepts_run_dir_path(tmp_path, monkeypatch):
+    """--continue-run accepts an absolute path to the run directory itself."""
+    run_dir = _make_run_dir(tmp_path / "elsewhere")
+    captured: dict = {}
+    monkeypatch.setattr(
+        "paperbanana.core.pipeline.PaperBananaPipeline",
+        _fake_continue_pipeline(tmp_path, captured),
+    )
+
+    result = runner.invoke(
+        app,
+        ["generate", "--continue-run", str(run_dir)],
+        terminal_width=HELP_TERMINAL_WIDTH,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["resume_state"].run_id == run_dir.name
+    assert Path(captured["resume_state"].run_dir) == run_dir
+
+
+def test_continue_latest_uses_custom_output_dir(tmp_path, monkeypatch):
+    """--continue (latest) resolves the run under --output-dir."""
+    custom_out = tmp_path / "custom_out"
+    run_dir = _make_run_dir(custom_out)
+    captured: dict = {}
+    monkeypatch.setattr(
+        "paperbanana.core.pipeline.PaperBananaPipeline",
+        _fake_continue_pipeline(tmp_path, captured),
+    )
+
+    result = runner.invoke(
+        app,
+        ["generate", "--continue", "--output-dir", str(custom_out)],
+        terminal_width=HELP_TERMINAL_WIDTH,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["resume_state"].run_id == run_dir.name
+
+
+def test_continue_run_missing_reports_searched_path(tmp_path):
+    """Missing run errors clearly with the directory that was searched."""
+    empty_out = tmp_path / "empty_out"
+    empty_out.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            "--continue-run",
+            "run_missing",
+            "--output-dir",
+            str(empty_out),
+        ],
+        terminal_width=HELP_TERMINAL_WIDTH,
+    )
+
+    flat = result.output.replace("\n", "")
+    assert result.exit_code == 1
+    assert "Run directory not found" in flat
+    assert "run_missing" in flat
+    assert str(empty_out.resolve()) in flat
+
+
+def test_continue_run_missing_path_reports_resolved_path(tmp_path):
+    """A path-form --continue-run that doesn't exist errors with the resolved path."""
+    missing = tmp_path / "nowhere" / "run_x"
+
+    result = runner.invoke(
+        app,
+        ["generate", "--continue-run", str(missing)],
+        terminal_width=HELP_TERMINAL_WIDTH,
+    )
+
+    flat = result.output.replace("\n", "")
+    assert result.exit_code == 1
+    assert "Run directory not found" in flat
+    assert "run_x" in flat


### PR DESCRIPTION
Two fixes:

**Fixes #217** — continue runs resolved only via `settings.output_dir`, so a run generated with a custom output location couldn't be continued. `generate` now takes `--output-dir` (used by `--continue`/`--continue-run` lookup), `--continue-run` also accepts a direct path to the run directory, and lookup failures report the absolute searched path instead of failing opaquely. No silent fallbacks — missing runs error with where we looked.

**Fixes #40** — hardens the parse side of critic failures: `extract_json` fence patterns no longer require a newline after the opening fence (one-line fenced output parsed as failure before), and parse failures in critic/retriever/judge now log the raw response (truncated to 500 chars) so future reports are diagnosable. The upstream cause for truncated responses (thinking-token budget) was addressed separately in #47; this keeps the clean-failure semantics with proper observability. 18 new tests across both fixes.

Full suite: 779 passed; the two failures in the shared dev venv (`test_studio`, `test_compress`) reproduce identically on clean main — environment pinning issues, tracked separately.