### PR TITLE
feat: serve PaperBananaBench from project-controlled mirror with checksum verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Rendered sweep reports include a summary, a top-5 ranked table, the full variant
 | `--optimize` | | Preprocess inputs for each item |
 | `--auto` | | Loop until critic satisfied per item |
 | `--format` | `-f` | Output image format (png, jpeg, webp) |
-| `--auto-download-data` | | Download expanded reference set if needed |
+| `--auto-download-data` | | Auto-download the PaperBananaBench reference set (~254 MB) if not cached |
 
 ### `paperbanana plot-batch` -- Batch Statistical Plots
 
@@ -510,6 +510,29 @@ paperbanana setup
 
 Interactive wizard that first asks whether to use the official Gemini API.
 If you choose official API, it follows the default AI Studio key flow; if not, it asks for a custom Gemini-compatible URL and API key.
+
+### `paperbanana data` -- Reference Dataset
+
+```bash
+# Download the PaperBananaBench reference set (~254 MB, one command)
+paperbanana data download
+
+# Import plot references too (or both)
+paperbanana data download --task plot
+paperbanana data download --task both
+
+# Inspect / clear the cache
+paperbanana data info
+paperbanana data clear
+```
+
+The dataset is served from a project-hosted GitHub release mirror
+([`bench-data-v1`](https://github.com/llmsresearch/paperbanana/releases/tag/bench-data-v1))
+and its SHA256 checksum is verified before extraction. Credit to the
+[PaperBananaBench](https://huggingface.co/datasets/dwzhu/PaperBananaBench) authors —
+the mirror tracks their 2026-03-22 revision. The set is cached under
+`~/.cache/paperbanana/` (override with `PAPERBANANA_CACHE_DIR`); generation
+commands can also fetch it on first use via `--auto-download-data`.
 
 ---
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -11,7 +11,7 @@ Tools:
     continue_plot       — Continue a prior statistical-plot run
     evaluate_diagram    — Evaluate a generated diagram against a reference
     evaluate_plot       — Evaluate a generated plot against a reference
-    download_references — Download expanded reference set (~294 examples)
+    download_references — Download the PaperBananaBench reference set (~298 examples)
     orchestrate_figures — Full-paper figure package (plan + optional generation)
     batch_diagrams      — Batch methodology diagrams from a YAML/JSON manifest
     batch_plots         — Batch statistical plots from a YAML/JSON manifest
@@ -583,11 +583,12 @@ async def evaluate_plot(
 async def download_references(
     force: bool = False,
 ) -> str:
-    """Download the expanded reference set from official PaperBananaBench.
+    """Download the PaperBananaBench reference set.
 
-    Downloads ~257MB of reference diagrams (294 examples) from HuggingFace
-    and caches them locally. The Retriever agent uses these for better
-    in-context learning during diagram generation.
+    Downloads ~254 MB of reference diagrams (~298 examples) from the
+    project-hosted GitHub release mirror (SHA256-verified) and caches them
+    locally. The Retriever agent uses these for better in-context learning
+    during diagram generation.
 
     Only needs to be run once — subsequent calls detect the cached data
     and return immediately. Use force=True to re-download.
@@ -604,11 +605,14 @@ async def download_references(
 
     if dm.is_downloaded() and not force:
         info = dm.get_info() or {}
+        version = info.get("dataset_meta", {}).get("full_bench", {}).get("version") or info.get(
+            "version", "unknown"
+        )
         return (
             f"Expanded reference set already cached.\n"
             f"Location: {dm.reference_dir}\n"
             f"Examples: {dm.get_example_count()}\n"
-            f"Version: {info.get('version', 'unknown')}\n"
+            f"Version: {version}\n"
             f"Use force=True to re-download."
         )
 

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -314,7 +314,9 @@ def generate(
     auto_download_data: bool = typer.Option(
         False,
         "--auto-download-data",
-        help="Auto-download curated expansion reference set on first run if not cached",
+        help=(
+            "Auto-download the PaperBananaBench reference set (~254 MB) on first run if not cached"
+        ),
     ),
     reference_ids: Optional[str] = typer.Option(
         None,
@@ -527,16 +529,16 @@ def generate(
 
     from paperbanana.core.pipeline import PaperBananaPipeline
 
-    # ── Auto-download curated expansion if requested ────────────────────
+    # ── Auto-download reference set if requested ────────────────────────
     if auto_download_data:
         from paperbanana.data.manager import DatasetManager
 
         dm = DatasetManager(cache_dir=settings.cache_dir)
         if not dm.is_downloaded():
             console.print()
-            console.print("  [dim]●[/dim] Downloading curated expansion set...", end="")
+            console.print("  [dim]●[/dim] Downloading PaperBananaBench reference set...", end="")
             try:
-                count = dm.download(dataset="curated")
+                count = dm.download()
                 console.print(f" [green]✓[/green] [dim]{count} examples cached[/dim]")
             except Exception as e:
                 console.print(f" [red]✗[/red] Download failed: {e}")
@@ -791,9 +793,7 @@ def generate(
                 "  [dim]Using built-in reference set"
                 f" ({ref_count} examples). For better results:[/dim]"
             )
-            console.print(
-                "  [dim]  paperbanana data download --curated   # or --auto-download-data[/dim]"
-            )
+            console.print("  [dim]  paperbanana data download   # or --auto-download-data[/dim]")
 
         def on_progress(event: PipelineProgressEvent) -> None:
             if event.stage == PipelineProgressStage.OPTIMIZER_START:
@@ -1243,7 +1243,9 @@ def sweep(
     auto_download_data: bool = typer.Option(
         False,
         "--auto-download-data",
-        help="Auto-download expanded reference set (~257MB) on first run if not cached",
+        help=(
+            "Auto-download the PaperBananaBench reference set (~254 MB) on first run if not cached"
+        ),
     ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed progress"),
 ):
@@ -1542,7 +1544,11 @@ def batch(
         help="Target venue style (neurips, icml, acl, ieee, custom)",
     ),
     auto_download_data: bool = typer.Option(
-        False, "--auto-download-data", help="Auto-download curated expansion if needed"
+        False,
+        "--auto-download-data",
+        help=(
+            "Auto-download the PaperBananaBench reference set (~254 MB) on first run if not cached"
+        ),
     ),
     resume_batch: Optional[str] = typer.Option(
         None, "--resume-batch", help="Batch ID or batch directory to resume"
@@ -3604,48 +3610,37 @@ def download(
     task: str = typer.Option(
         "diagram",
         "--task",
-        help="Which references to import: diagram, plot, or both (full_bench only)",
-    ),
-    curated: bool = typer.Option(
-        False,
-        "--curated",
-        help="Download the lightweight curated expansion instead of the full benchmark",
+        help="Which references to import: diagram, plot, or both",
     ),
     force: bool = typer.Option(False, "--force", help="Re-download even if already cached"),
 ):
-    """Download an expanded reference set.
+    """Download the PaperBananaBench reference set (~254 MB).
 
-    By default downloads the full PaperBananaBench (~257MB).
-    Use --curated for the lightweight curated expansion (~20-35 images).
+    Fetches the project-hosted GitHub release mirror and verifies its
+    SHA256 checksum before caching.
     """
     from paperbanana.data.manager import DatasetManager
 
-    dataset = "curated" if curated else "full_bench"
-    if curated and task != "diagram":
-        console.print("[yellow]Warning:[/yellow] --task is ignored when --curated is set.")
     dm = DatasetManager()
-    if dm.is_downloaded(dataset=dataset) and not force:
+    if dm.is_downloaded() and not force:
         info = dm.get_info() or {}
         meta = info.get("dataset_meta", {})
-        ds_version = meta.get(dataset, {}).get("version", info.get("version", "unknown"))
+        ds_version = meta.get("full_bench", {}).get("version", info.get("version", "unknown"))
         console.print(
             Panel.fit(
                 f"[bold]Reference Set — Already Cached[/bold]\n\n"
                 f"Location: {dm.reference_dir}\n"
                 f"Examples: {dm.get_example_count()}\n"
-                f"Version: {ds_version}\n"
-                f"Datasets: {', '.join(info.get('datasets', ['unknown']))}",
+                f"Version: {ds_version}",
                 border_style="green",
             )
         )
         console.print("\nUse [bold]--force[/bold] to re-download.")
         return
 
-    label = "Curated Expansion" if curated else "Full PaperBananaBench"
-    console.print(f"[bold]PaperBanana[/bold] — Downloading {label}\n")
+    console.print("[bold]PaperBanana[/bold] — Downloading PaperBananaBench\n")
     try:
         count = dm.download(
-            dataset=dataset,
             task=task,
             force=force,
             progress_callback=lambda msg: console.print(f"  [dim]●[/dim] {msg}"),

--- a/paperbanana/core/workflow_runner.py
+++ b/paperbanana/core/workflow_runner.py
@@ -146,9 +146,9 @@ def run_methodology_batch(
         dm = DatasetManager(cache_dir=settings.cache_dir)
         if not dm.is_downloaded():
             try:
-                dm.download(dataset="curated")
+                dm.download()
             except Exception as e:
-                logger.warning("curated_download_failed", error=str(e))
+                logger.warning("reference_download_failed", error=str(e))
 
     state = init_or_load_checkpoint(
         batch_dir=batch_dir,

--- a/paperbanana/data/manager.py
+++ b/paperbanana/data/manager.py
@@ -18,26 +18,24 @@ import shutil
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Callable, Literal, Optional
+from typing import Callable, Optional
 
 import structlog
 
 logger = structlog.get_logger()
 
-# Pin dataset revision for reproducibility
-DATASET_REVISION = "main"
+# Project-controlled mirror of the upstream dataset
+# (https://huggingface.co/datasets/dwzhu/PaperBananaBench).
+# The bench-data-v1 release tag mirrors its 2026-03-22 revision; serving the
+# archive from a GitHub release we control gives stable URLs and lets us pin
+# the exact bytes via checksum.
+DATASET_RELEASE_TAG = "bench-data-v1"
 DATASET_URL = (
-    "https://huggingface.co/datasets/dwzhu/PaperBananaBench"
-    f"/resolve/{DATASET_REVISION}/PaperBananaBench.zip"
+    "https://github.com/llmsresearch/paperbanana/releases/download/"
+    f"{DATASET_RELEASE_TAG}/PaperBananaBench.zip"
 )
+DATASET_SHA256 = "a980d23954c0cb47017cdaa8a9029dbea3598791fd269a457482033821927e37"
 DATASET_VERSION = "1.0.0"
-
-# Curated expansion — lightweight set of 20–35 reference images
-CURATED_EXPANSION_URL = (
-    "https://huggingface.co/datasets/dwzhu/PaperBananaBench"
-    f"/resolve/{DATASET_REVISION}/CuratedExpansion.zip"
-)
-CURATED_EXPANSION_VERSION = "1.0.0"
 
 
 def default_cache_dir() -> Path:
@@ -103,34 +101,24 @@ class DatasetManager:
         """Path to dataset version info."""
         return self.reference_dir / "dataset_info.json"
 
-    def is_downloaded(self, dataset: str | None = None) -> bool:
+    def is_downloaded(self) -> bool:
         """Check if an expanded reference set is available in cache.
-
-        Args:
-            dataset: Check for a specific dataset ('curated' or 'full_bench').
-                     If None, returns True if *any* expansion is cached.
 
         Note:
             Caches that pre-date ``dataset_info.json`` (only ``index.json``
-            present) are treated as an untracked expansion when *dataset* is
-            None, but will not match a specific dataset name.
+            present) are treated as a downloaded expansion. Old-format
+            ``dataset_info.json`` files (top-level ``source`` instead of a
+            ``datasets`` list) are also honoured.
         """
         info = self.get_info()
         if info is None:
-            # Fallback: legacy caches may only have index.json with no
-            # dataset_info.json.  Treat them as "something is downloaded"
-            # when no specific dataset is requested.
-            if dataset is None and self.index_path.exists():
-                return True
-            return False
-        downloaded = info.get("datasets", [])
-        # Back-compat: old dataset_info.json without "datasets" key
-        # was written by the full_bench downloader
-        if not downloaded and info.get("source") == DATASET_URL:
-            downloaded = ["full_bench"]
-        if dataset is not None:
-            return dataset in downloaded
-        return len(downloaded) > 0
+            # Legacy caches may only have index.json with no dataset_info.json.
+            return self.index_path.exists()
+        if info.get("datasets"):
+            return True
+        # Back-compat: old dataset_info.json without "datasets" key recorded a
+        # top-level "source" instead.
+        return bool(info.get("source"))
 
     def get_info(self) -> Optional[dict]:
         """Get cached dataset info (version, revision, count).
@@ -160,19 +148,17 @@ class DatasetManager:
     def download(
         self,
         *,
-        dataset: Literal["full_bench", "curated"] = "full_bench",
         task: str = "diagram",
         force: bool = False,
         progress_callback: Optional[Callable[[str], None]] = None,
     ) -> int:
-        """Download and cache a reference dataset.
+        """Download and cache the PaperBananaBench reference dataset.
+
+        Fetches the project-controlled GitHub release mirror (~254 MB) and
+        verifies its SHA256 checksum before extraction.
 
         Args:
-            dataset: Which dataset to fetch — 'full_bench' for the full
-                     PaperBananaBench (~257MB) or 'curated' for the lightweight
-                     curated expansion (~20–35 images).
             task: Which references to import ('diagram', 'plot', or 'both').
-                  Only used for 'full_bench'.
             force: Re-download even if already cached.
             progress_callback: Optional callback(message) for progress updates.
 
@@ -180,104 +166,13 @@ class DatasetManager:
             Number of examples in the cache after import.
 
         Raises:
-            RuntimeError: If download or extraction fails.
+            RuntimeError: If download, checksum verification, or extraction
+                fails.
         """
-        if self.is_downloaded(dataset=dataset) and not force:
+        if self.is_downloaded() and not force:
             count = self.get_example_count()
-            logger.info(
-                "Dataset already cached", dataset=dataset, count=count, path=str(self.reference_dir)
-            )
+            logger.info("Dataset already cached", count=count, path=str(self.reference_dir))
             return count
-
-        if dataset == "curated":
-            return self._download_curated(force=force, progress_callback=progress_callback)
-        return self._download_full_bench(
-            task=task, force=force, progress_callback=progress_callback
-        )
-
-    def _download_curated(
-        self,
-        *,
-        force: bool = False,
-        progress_callback: Optional[Callable[[str], None]] = None,
-    ) -> int:
-        """Download the curated expansion and merge into cache."""
-
-        def _log(msg: str):
-            logger.info(msg)
-            if progress_callback:
-                progress_callback(msg)
-
-        with tempfile.TemporaryDirectory(prefix="paperbanana_curated_") as tmp:
-            tmp_dir = Path(tmp)
-            zip_path = tmp_dir / "CuratedExpansion.zip"
-
-            _log("Downloading curated expansion set...")
-            try:
-                _download_file(CURATED_EXPANSION_URL, zip_path)
-            except Exception as exc:
-                raise RuntimeError(
-                    f"Failed to download curated expansion from {CURATED_EXPANSION_URL} "
-                    f"— the artifact may not be published yet. Original error: {exc}"
-                ) from exc
-
-            _log("Extracting curated expansion...")
-            with zipfile.ZipFile(zip_path) as zf:
-                zf.extractall(tmp_dir)
-
-            # Expect the zip to contain index.json + images/
-            expansion_dir = tmp_dir / "CuratedExpansion"
-            if not expansion_dir.exists():
-                candidates = list(tmp_dir.glob("*/index.json"))
-                if candidates:
-                    expansion_dir = candidates[0].parent
-                else:
-                    raise RuntimeError("Could not find index.json in curated expansion archive.")
-
-            expansion_index = expansion_dir / "index.json"
-            if not expansion_index.exists():
-                raise RuntimeError("Curated expansion archive missing index.json.")
-
-            with open(expansion_index, encoding="utf-8") as f:
-                expansion_data = json.load(f)
-
-            new_examples = expansion_data.get("examples", [])
-            if not new_examples:
-                raise RuntimeError("Curated expansion contains no examples.")
-
-            # Copy images into cache
-            self.reference_dir.mkdir(parents=True, exist_ok=True)
-            images_dir = self.reference_dir / "images"
-            images_dir.mkdir(exist_ok=True)
-
-            src_images = expansion_dir / "images"
-            for ex in new_examples:
-                img_rel = ex.get("image_path", "")
-                if img_rel and src_images.exists():
-                    src = expansion_dir / img_rel
-                    if src.exists():
-                        dest = self.reference_dir / img_rel
-                        dest.parent.mkdir(parents=True, exist_ok=True)
-                        if not dest.exists() or force:
-                            shutil.copy2(src, dest)
-
-            # Merge into existing cache index
-            count = _merge_index(self.index_path, new_examples)
-
-            # Update dataset_info.json
-            self._record_dataset("curated", CURATED_EXPANSION_VERSION, CURATED_EXPANSION_URL, count)
-
-            _log(f"Merged {len(new_examples)} curated examples → {count} total in cache")
-            return count
-
-    def _download_full_bench(
-        self,
-        *,
-        task: str = "diagram",
-        force: bool = False,
-        progress_callback: Optional[Callable[[str], None]] = None,
-    ) -> int:
-        """Download the full PaperBananaBench dataset."""
 
         def _log(msg: str):
             logger.info(msg)
@@ -289,8 +184,12 @@ class DatasetManager:
             zip_path = tmp_dir / "PaperBananaBench.zip"
 
             # Download
-            _log(f"Downloading PaperBananaBench ({DATASET_REVISION})...")
+            _log(f"Downloading PaperBananaBench ({DATASET_RELEASE_TAG})...")
             _download_file(DATASET_URL, zip_path)
+
+            # Verify integrity before touching the archive
+            _log("Verifying checksum...")
+            _verify_sha256(zip_path, DATASET_SHA256)
 
             # Extract
             _log("Extracting dataset...")
@@ -322,7 +221,7 @@ class DatasetManager:
                 DATASET_VERSION,
                 DATASET_URL,
                 count,
-                extra={"revision": DATASET_REVISION, "task": task},
+                extra={"revision": DATASET_RELEASE_TAG, "task": task},
             )
 
             _log(f"Cached {count} reference examples to {self.reference_dir}")
@@ -339,7 +238,9 @@ class DatasetManager:
         """Update dataset_info.json, preserving the list of downloaded datasets."""
         info = self.get_info() or {}
         downloaded = set(info.get("datasets", []))
-        if not downloaded and info.get("source") == DATASET_URL:
+        # Back-compat: old dataset_info.json without "datasets" key recorded a
+        # top-level "source" — written by the full_bench downloader.
+        if not downloaded and info.get("source"):
             downloaded.add("full_bench")
         downloaded.add(dataset)
 
@@ -379,6 +280,22 @@ def _download_file(url: str, dest: Path) -> None:
         with open(dest, "wb") as f:
             for chunk in response.iter_bytes(chunk_size=8192):
                 f.write(chunk)
+
+
+def _verify_sha256(path: Path, expected: str) -> None:
+    """Verify a file's SHA256 checksum, raising RuntimeError on mismatch."""
+    import hashlib
+
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    actual = digest.hexdigest()
+    if actual != expected:
+        raise RuntimeError(
+            f"SHA256 mismatch for {path.name}: expected {expected}, got {actual}. "
+            "The downloaded archive is corrupted or has been tampered with — aborting."
+        )
 
 
 def _merge_index(index_path: Path, new_examples: list[dict]) -> int:
@@ -443,8 +360,7 @@ def _import_from_bench(
 
     Images are copied into *images_dir*; the caller is responsible for
     merging the returned examples into the cached ``index.json`` (via
-    ``_merge_index``) so that previously-downloaded datasets (e.g. the
-    curated expansion) are preserved.
+    ``_merge_index``) so that previously-cached entries are preserved.
 
     Args:
         bench_dir: Extracted PaperBananaBench directory.

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -1,17 +1,20 @@
-"""Tests for DatasetManager lazy-download and curated expansion support."""
+"""Tests for DatasetManager lazy-download, checksum verification, and caching."""
 
 from __future__ import annotations
 
+import hashlib
+import inspect
 import json
-import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+import paperbanana.data.manager as manager_mod
 from paperbanana.data.manager import (
     DatasetManager,
     _merge_index,
+    _verify_sha256,
     resolve_reference_path,
 )
 
@@ -72,6 +75,22 @@ class TestMergeIndex:
         assert count == 1
 
 
+# ── _verify_sha256 ────────────────────────────────────────────────────
+
+
+class TestVerifySha256:
+    def test_matching_checksum_passes(self, tmp_path):
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"hello world")
+        _verify_sha256(f, hashlib.sha256(b"hello world").hexdigest())
+
+    def test_mismatch_raises_runtime_error(self, tmp_path):
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"hello world")
+        with pytest.raises(RuntimeError, match="SHA256 mismatch"):
+            _verify_sha256(f, "0" * 64)
+
+
 # ── DatasetManager.is_downloaded ──────────────────────────────────────
 
 
@@ -84,45 +103,28 @@ class TestIsDownloaded:
         tmp_cache.info_path.write_text(
             json.dumps(
                 {
-                    "datasets": ["curated"],
+                    "datasets": ["full_bench"],
                     "version": "1.0.0",
                 }
             )
         )
         assert tmp_cache.is_downloaded()
-        assert tmp_cache.is_downloaded(dataset="curated")
-        assert not tmp_cache.is_downloaded(dataset="full_bench")
-
-    def test_true_with_both_datasets(self, tmp_cache):
-        tmp_cache.reference_dir.mkdir(parents=True)
-        tmp_cache.info_path.write_text(
-            json.dumps(
-                {
-                    "datasets": ["curated", "full_bench"],
-                    "version": "1.0.0",
-                }
-            )
-        )
-        assert tmp_cache.is_downloaded()
-        assert tmp_cache.is_downloaded(dataset="curated")
-        assert tmp_cache.is_downloaded(dataset="full_bench")
 
     def test_back_compat_old_format(self, tmp_cache):
-        """Old dataset_info.json without 'datasets' key but with DATASET_URL source."""
-        from paperbanana.data.manager import DATASET_URL
-
+        """Old dataset_info.json without 'datasets' key but with a top-level source."""
         tmp_cache.reference_dir.mkdir(parents=True)
         tmp_cache.info_path.write_text(
             json.dumps(
                 {
                     "version": "1.0.0",
-                    "source": DATASET_URL,
+                    "source": (
+                        "https://huggingface.co/datasets/dwzhu/PaperBananaBench"
+                        "/resolve/main/PaperBananaBench.zip"
+                    ),
                 }
             )
         )
         assert tmp_cache.is_downloaded()
-        assert tmp_cache.is_downloaded(dataset="full_bench")
-        assert not tmp_cache.is_downloaded(dataset="curated")
 
     def test_legacy_cache_index_only(self, tmp_cache):
         """Caches with index.json but no dataset_info.json count as downloaded."""
@@ -136,9 +138,6 @@ class TestIsDownloaded:
             )
         )
         assert tmp_cache.is_downloaded()
-        # But a specific dataset query still returns False
-        assert not tmp_cache.is_downloaded(dataset="full_bench")
-        assert not tmp_cache.is_downloaded(dataset="curated")
 
     def test_false_with_corrupt_info(self, tmp_cache):
         tmp_cache.reference_dir.mkdir(parents=True)
@@ -150,59 +149,68 @@ class TestIsDownloaded:
 
 
 class TestRecordDataset:
-    def test_records_new_dataset(self, tmp_cache):
+    def test_records_dataset(self, tmp_cache):
         tmp_cache.reference_dir.mkdir(parents=True)
-        tmp_cache._record_dataset("curated", "1.0.0", "https://example.com", 25)
+        tmp_cache._record_dataset("full_bench", "1.0.0", "https://example.com", 298)
         info = json.loads(tmp_cache.info_path.read_text())
-        assert "curated" in info["datasets"]
-        assert info["example_count"] == 25
-        assert info["dataset_meta"]["curated"]["version"] == "1.0.0"
-        assert info["dataset_meta"]["curated"]["source"] == "https://example.com"
+        assert "full_bench" in info["datasets"]
+        assert info["example_count"] == 298
+        assert info["dataset_meta"]["full_bench"]["version"] == "1.0.0"
+        assert info["dataset_meta"]["full_bench"]["source"] == "https://example.com"
 
-    def test_preserves_existing_datasets(self, tmp_cache):
+    def test_no_top_level_version_or_source(self, tmp_cache):
         tmp_cache.reference_dir.mkdir(parents=True)
-        tmp_cache._record_dataset("curated", "1.0.0", "https://curated.example.com", 25)
         tmp_cache._record_dataset("full_bench", "2.0.0", "https://bench.example.com", 294)
         info = json.loads(tmp_cache.info_path.read_text())
-        assert sorted(info["datasets"]) == ["curated", "full_bench"]
-        assert info["dataset_meta"]["curated"]["version"] == "1.0.0"
-        assert info["dataset_meta"]["curated"]["source"] == "https://curated.example.com"
-        assert info["dataset_meta"]["full_bench"]["version"] == "2.0.0"
-
-    def test_per_dataset_meta_not_overwritten(self, tmp_cache):
-        tmp_cache.reference_dir.mkdir(parents=True)
-        tmp_cache._record_dataset("curated", "1.0.0", "https://curated.example.com", 25)
-        tmp_cache._record_dataset("full_bench", "2.0.0", "https://bench.example.com", 294)
-        info = json.loads(tmp_cache.info_path.read_text())
-        # top-level version/source should not exist
         assert "version" not in info
         assert "source" not in info
-        # per-dataset metadata preserved
-        assert info["dataset_meta"]["curated"]["source"] == "https://curated.example.com"
         assert info["dataset_meta"]["full_bench"]["source"] == "https://bench.example.com"
 
     def test_back_compat_upgrade(self, tmp_cache):
-        """Recording a new dataset upgrades old-format info to include datasets list."""
-        from paperbanana.data.manager import DATASET_URL
-
+        """Recording over an old-format info upgrades it to include the datasets list."""
         tmp_cache.reference_dir.mkdir(parents=True)
         tmp_cache.info_path.write_text(
             json.dumps(
                 {
                     "version": "1.0.0",
-                    "source": DATASET_URL,
+                    "source": "https://old.example.com/PaperBananaBench.zip",
                 }
             )
         )
-        tmp_cache._record_dataset("curated", "1.0.0", "https://example.com", 38)
+        tmp_cache._record_dataset("full_bench", "1.0.0", "https://example.com", 298)
         info = json.loads(tmp_cache.info_path.read_text())
-        assert sorted(info["datasets"]) == ["curated", "full_bench"]
+        assert info["datasets"] == ["full_bench"]
 
 
-# ── DatasetManager.download (skip check) ─────────────────────────────
+# ── DatasetManager.download ──────────────────────────────────────────
 
 
-class TestDownloadSkip:
+class TestDownload:
+    @staticmethod
+    def _make_bench_zip(zip_dest: Path):
+        """Create a minimal fake PaperBananaBench.zip (no network).
+
+        Only the top-level ``PaperBananaBench/`` directory matters here —
+        the actual import is stubbed via ``_import_from_bench``.
+        """
+        import zipfile
+
+        with zipfile.ZipFile(zip_dest, "w") as zf:
+            zf.writestr("PaperBananaBench/.keep", "")
+
+    def test_download_has_no_dataset_param(self):
+        """The curated/full_bench split is gone — download() takes no dataset arg."""
+        sig = inspect.signature(DatasetManager.download)
+        assert "dataset" not in sig.parameters
+
+    def test_url_points_at_github_mirror(self):
+        assert manager_mod.DATASET_URL == (
+            "https://github.com/llmsresearch/paperbanana/releases/download/"
+            "bench-data-v1/PaperBananaBench.zip"
+        )
+        assert manager_mod.DATASET_RELEASE_TAG == "bench-data-v1"
+        assert len(manager_mod.DATASET_SHA256) == 64
+
     def test_skip_when_already_cached(self, tmp_cache):
         tmp_cache.reference_dir.mkdir(parents=True)
         # Write a cached index with 2 examples
@@ -217,121 +225,28 @@ class TestDownloadSkip:
         tmp_cache.info_path.write_text(
             json.dumps(
                 {
-                    "datasets": ["curated"],
+                    "datasets": ["full_bench"],
                     "version": "1.0.0",
                 }
             )
         )
-        count = tmp_cache.download(dataset="curated")
+        count = tmp_cache.download()
         assert count == 2  # returns cached count, no download
 
-
-# ── DatasetManager._download_curated ─────────────────────────────────
-
-
-class TestDownloadCurated:
-    def _make_curated_zip(self, zip_dest: Path, examples: list[dict], images: dict[str, bytes]):
-        """Helper to create a fake CuratedExpansion.zip."""
-        import zipfile
-
-        with tempfile.TemporaryDirectory() as staging:
-            staging_path = Path(staging)
-            expansion = staging_path / "CuratedExpansion"
-            expansion.mkdir()
-            images_dir = expansion / "images"
-            images_dir.mkdir()
-            expansion_index = {
-                "metadata": {"name": "curated_expansion"},
-                "examples": examples,
-            }
-            (expansion / "index.json").write_text(json.dumps(expansion_index))
-            for name, data in images.items():
-                (images_dir / name).write_bytes(data)
-
-            with zipfile.ZipFile(zip_dest, "w") as zf:
-                for f in expansion.rglob("*"):
-                    zf.write(f, f.relative_to(staging_path))
-
-    def test_download_curated_merges(self, tmp_cache):
-        examples = [
-            {"id": "new1", "category": "cat1", "image_path": "images/new1.jpg"},
-            {"id": "new2", "category": "cat2", "image_path": "images/new2.jpg"},
-        ]
-        images = {"new1.jpg": b"\xff\xd8fake", "new2.jpg": b"\xff\xd8fake"}
-
-        # Seed cache with one existing example
-        tmp_cache.reference_dir.mkdir(parents=True)
-        (tmp_cache.reference_dir / "images").mkdir()
-        tmp_cache.index_path.write_text(
-            json.dumps(
-                {
-                    "metadata": {},
-                    "examples": [{"id": "existing", "category": "cat0"}],
-                }
-            )
-        )
+    def test_sha256_mismatch_raises(self, tmp_cache, monkeypatch):
+        """A corrupted/tampered archive must hard-fail before extraction."""
+        monkeypatch.setattr(manager_mod, "DATASET_SHA256", "0" * 64)
 
         def fake_download(url, dest):
-            self._make_curated_zip(dest, examples, images)
+            dest.write_bytes(b"definitely not the real dataset")
 
         with patch("paperbanana.data.manager._download_file", side_effect=fake_download):
-            count = tmp_cache.download(dataset="curated", force=True)
+            with pytest.raises(RuntimeError, match="SHA256 mismatch"):
+                tmp_cache.download(force=True)
 
-        assert count == 3  # 1 existing + 2 new
-        data = json.loads(tmp_cache.index_path.read_text())
-        ids = {e["id"] for e in data["examples"]}
-        assert ids == {"existing", "new1", "new2"}
-
-        info = json.loads(tmp_cache.info_path.read_text())
-        assert "curated" in info["datasets"]
-
-    def test_download_curated_with_progress(self, tmp_cache):
-        examples = [{"id": "p1", "category": "c", "image_path": "images/p1.jpg"}]
-        images = {"p1.jpg": b"\xff\xd8fake"}
-        messages = []
-
-        def fake_download(url, dest):
-            self._make_curated_zip(dest, examples, images)
-
-        with patch("paperbanana.data.manager._download_file", side_effect=fake_download):
-            tmp_cache.download(
-                dataset="curated",
-                force=True,
-                progress_callback=lambda msg: messages.append(msg),
-            )
-
-        assert any("curated" in m.lower() for m in messages)
-
-    def test_download_curated_404_gives_clear_error(self, tmp_cache):
-        def fake_download(url, dest):
-            raise Exception("404 Not Found")
-
-        with patch("paperbanana.data.manager._download_file", side_effect=fake_download):
-            with pytest.raises(RuntimeError, match="artifact may not be published yet"):
-                tmp_cache.download(dataset="curated", force=True)
-
-
-# ── full_bench merges with existing curated ───────────────────────────
-
-
-class TestFullBenchMerge:
-    """Downloading full_bench after curated must preserve curated-only entries."""
-
-    @staticmethod
-    def _make_bench_zip(zip_dest: Path):
-        """Create a minimal fake PaperBananaBench.zip (no network).
-
-        Only the top-level ``PaperBananaBench/`` directory matters here —
-        the actual import is stubbed via ``_import_from_bench``.
-        """
-        import zipfile
-
-        with zipfile.ZipFile(zip_dest, "w") as zf:
-            zf.writestr("PaperBananaBench/.keep", "")
-
-    def test_full_bench_preserves_curated_entries(self, tmp_cache):
-        """Curated entries that are NOT in full_bench survive a full import."""
-        # Seed cache with curated-only entries
+    def test_download_merges_and_records(self, tmp_cache, monkeypatch):
+        """Entries already in the cache survive a fresh full-bench import."""
+        # Seed cache with pre-existing entries
         tmp_cache.reference_dir.mkdir(parents=True)
         (tmp_cache.reference_dir / "images").mkdir()
         tmp_cache.index_path.write_text(
@@ -339,17 +254,9 @@ class TestFullBenchMerge:
                 {
                     "metadata": {},
                     "examples": [
-                        {"id": "curated_only", "category": "extra"},
+                        {"id": "preexisting", "category": "extra"},
                         {"id": "overlap", "category": "old_cat"},
                     ],
-                }
-            )
-        )
-        tmp_cache.info_path.write_text(
-            json.dumps(
-                {
-                    "datasets": ["curated"],
-                    "version": "1.0.0",
                 }
             )
         )
@@ -362,6 +269,10 @@ class TestFullBenchMerge:
 
         def fake_download(url, dest):
             self._make_bench_zip(dest)
+            # Make the checksum match the fake archive we just wrote
+            monkeypatch.setattr(
+                manager_mod, "DATASET_SHA256", hashlib.sha256(dest.read_bytes()).hexdigest()
+            )
 
         with (
             patch("paperbanana.data.manager._download_file", side_effect=fake_download),
@@ -370,20 +281,48 @@ class TestFullBenchMerge:
                 return_value=bench_examples,
             ),
         ):
-            count = tmp_cache.download(dataset="full_bench", force=True)
+            count = tmp_cache.download(force=True)
 
-        assert count == 3  # curated_only + overlap (updated) + bench_new
+        assert count == 3  # preexisting + overlap (updated) + bench_new
         data = json.loads(tmp_cache.index_path.read_text())
         ids = {e["id"] for e in data["examples"]}
-        assert ids == {"curated_only", "overlap", "bench_new"}
+        assert ids == {"preexisting", "overlap", "bench_new"}
 
-        # overlap entry should be updated by full_bench (new wins)
+        # overlap entry should be updated by the bench import (new wins)
         overlap = next(e for e in data["examples"] if e["id"] == "overlap")
         assert overlap["category"] == "bench_cat"
 
-        # dataset_info should list both
+        # dataset_info should record the mirror + release tag
         info = json.loads(tmp_cache.info_path.read_text())
-        assert sorted(info["datasets"]) == ["curated", "full_bench"]
+        assert info["datasets"] == ["full_bench"]
+        meta = info["dataset_meta"]["full_bench"]
+        assert meta["source"] == manager_mod.DATASET_URL
+        assert meta["revision"] == manager_mod.DATASET_RELEASE_TAG
+
+    def test_download_with_progress(self, tmp_cache, monkeypatch):
+        bench_examples = [{"id": "p1", "category": "c"}]
+        messages = []
+
+        def fake_download(url, dest):
+            self._make_bench_zip(dest)
+            monkeypatch.setattr(
+                manager_mod, "DATASET_SHA256", hashlib.sha256(dest.read_bytes()).hexdigest()
+            )
+
+        with (
+            patch("paperbanana.data.manager._download_file", side_effect=fake_download),
+            patch(
+                "paperbanana.data.manager._import_from_bench",
+                return_value=bench_examples,
+            ),
+        ):
+            tmp_cache.download(
+                force=True,
+                progress_callback=lambda msg: messages.append(msg),
+            )
+
+        assert any("checksum" in m.lower() for m in messages)
+        assert any("paperbananabench" in m.lower() for m in messages)
 
 
 # ── resolve_reference_path ────────────────────────────────────────────
@@ -408,7 +347,7 @@ class TestResolveReferencePath:
         (ref_dir / "dataset_info.json").write_text(
             json.dumps(
                 {
-                    "datasets": ["curated"],
+                    "datasets": ["full_bench"],
                     "version": "1.0.0",
                 }
             )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -120,9 +120,9 @@ def test_check_expanded_refs_downloaded(tmp_path, monkeypatch):
     (ref_dir / "dataset_info.json").write_text(
         json.dumps(
             {
-                "datasets": ["curated"],
+                "datasets": ["full_bench"],
                 "example_count": 2,
-                "dataset_meta": {"curated": {"version": "1.0.0", "source": "test"}},
+                "dataset_meta": {"full_bench": {"version": "1.0.0", "source": "test"}},
             }
         ),
         encoding="utf-8",


### PR DESCRIPTION
Rewires dataset distribution to the mirror we now host as a [bench-data-v1 release asset](https://github.com/llmsresearch/paperbanana/releases/tag/bench-data-v1) (credit: upstream [dwzhu/PaperBananaBench](https://huggingface.co/datasets/dwzhu/PaperBananaBench), 2026-03-22 revision, mirrored unmodified).

- `DATASET_URL` → GitHub release asset; SHA256 pinned and verified before extraction (RuntimeError on mismatch, no fallbacks)
- **Removes the `curated` dataset option — Fixes #200.** `CuratedExpansion.zip` never existed at any revision upstream; the option could never succeed.
- UX: `paperbanana data download` with zero flags now fetches everything; `--auto-download-data` help standardized; low-reference hint points at the one command
- MCP `download_references` + batch runner updated to match
- Tests: curated tests removed, mirror constants + checksum-mismatch coverage added; all download tests network-free

Verified with a real download from the release asset: checksum pass, 295 examples imported in 58s.

Found during verification (separate issue, pre-existing): 3 diagram entries skip import due to Unicode filename normalization (NFD) on macOS.