### PR TITLE
fix: resolve bench image paths across Unicode normalization forms

### DIFF
--- a/paperbanana/data/manager.py
+++ b/paperbanana/data/manager.py
@@ -16,6 +16,7 @@ import json
 import os
 import shutil
 import tempfile
+import unicodedata
 import zipfile
 from pathlib import Path
 from typing import Callable, Optional
@@ -351,6 +352,29 @@ def _merge_index(index_path: Path, new_examples: list[dict]) -> int:
     return len(merged)
 
 
+def _resolve_image(source_images_dir: Path, gt_image_rel: str) -> Optional[Path]:
+    """Resolve a dataset image path tolerantly across Unicode normalization forms.
+
+    macOS extracts zip entries with NFD-normalized filenames, so a byte-exact
+    lookup misses names containing characters like U+2011 (non-breaking hyphen)
+    or U+200C (zero-width non-joiner). When the exact paths miss, fall back to
+    an NFC-normalized filename comparison within the candidate directories.
+    """
+    candidates = [source_images_dir / gt_image_rel, source_images_dir.parent / gt_image_rel]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    want = unicodedata.normalize("NFC", Path(gt_image_rel).name)
+    for candidate in candidates:
+        parent = candidate.parent
+        if not parent.is_dir():
+            continue
+        for f in parent.iterdir():
+            if unicodedata.normalize("NFC", f.name) == want:
+                return f
+    return None
+
+
 def _import_from_bench(
     bench_dir: Path,
     task: str,
@@ -412,11 +436,9 @@ def _import_from_bench(
             if not gt_image_rel:
                 continue
 
-            source_image = source_images_dir / gt_image_rel
-            if not source_image.exists():
-                source_image = source_images_dir.parent / gt_image_rel
-            if not source_image.exists():
-                logger.warning("Image not found, skipping", id=entry_id, path=str(source_image))
+            source_image = _resolve_image(source_images_dir, gt_image_rel)
+            if source_image is None:
+                logger.warning("Image not found, skipping", id=entry_id, path=gt_image_rel)
                 continue
 
             dest_filename = f"{entry_id}.jpg"

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -372,3 +372,40 @@ class TestClear:
 
     def test_clear_noop_when_empty(self, tmp_cache):
         tmp_cache.clear()  # should not raise
+
+
+class TestResolveImageUnicode:
+    """NFD-extracted filenames must still resolve (issue #234)."""
+
+    def test_nfd_filename_resolves_via_nfc_comparison(self, tmp_path):
+        import unicodedata
+
+        from paperbanana.data.manager import _resolve_image
+
+        images = tmp_path / "images"
+        images.mkdir()
+        # Name with U+2011 (non-breaking hyphen), written in NFD form as
+        # macOS zip extraction produces.
+        name_nfc = "VTON‑VLLM Aligning Modéls_diagram.jpg"
+        nfd_name = unicodedata.normalize("NFD", name_nfc)
+        (images / nfd_name).write_bytes(b"fake")
+
+        resolved = _resolve_image(images, name_nfc)
+        assert resolved is not None
+        assert resolved.read_bytes() == b"fake"
+
+    def test_exact_match_still_preferred(self, tmp_path):
+        from paperbanana.data.manager import _resolve_image
+
+        images = tmp_path / "images"
+        images.mkdir()
+        (images / "plain.jpg").write_bytes(b"x")
+        resolved = _resolve_image(images, "plain.jpg")
+        assert resolved == images / "plain.jpg"
+
+    def test_missing_image_returns_none(self, tmp_path):
+        from paperbanana.data.manager import _resolve_image
+
+        images = tmp_path / "images"
+        images.mkdir()
+        assert _resolve_image(images, "nope.jpg") is None


### PR DESCRIPTION
Fixes #234 — `ref_71`, `ref_284`, `ref_309` were skipped on macOS because zip extraction NFD-normalizes filenames while `path_to_gt_image` carries NFC forms (U+2011, en dash, U+200C). `_import_from_bench` now resolves via a new `_resolve_image` helper: exact path first, then NFC-normalized filename comparison within the candidate directories. 3 regression tests included; full import should now yield 298/298 diagram refs.