### PR TITLE
feat: Colab quickstart notebook + Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# VCS / CI
+.git
+.github
+.claude
+
+# Virtual environments
+.venv
+venv
+
+# Build artifacts and caches
+dist
+build
+*.egg-info
+__pycache__
+*.pyc
+.pytest_cache
+.ruff_cache
+.mypy_cache
+
+# Local state and secrets
+.env
+outputs
+wiki-temp
+
+# Not needed inside the image (Dockerfile copies explicit paths anyway;
+# these just keep the build context small)
+tests
+docs
+assets
+examples
+notebooks
+integrations
+scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# PaperBanana — publication-quality academic diagrams from text descriptions.
+#
+# Build:
+#   docker build -t paperbanana .
+#
+# Run (Gemini, free tier — get a key at https://aistudio.google.com/app/apikey):
+#   docker run --rm -e GOOGLE_API_KEY paperbanana generate --help
+#
+# Generate a diagram, persisting outputs to the host:
+#   docker run --rm -e GOOGLE_API_KEY \
+#     -v "$(pwd)/method.txt:/work/method.txt:ro" \
+#     -v "$(pwd)/outputs:/work/outputs" \
+#     paperbanana generate --input method.txt --caption "Overview of our framework"
+
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /build
+
+# Everything the hatchling wheel build needs:
+#  - pyproject.toml (build config), README.md (project.readme), LICENSE (SPDX license file)
+#  - paperbanana/ and mcp_server/ (wheel packages)
+#  - prompts/, data/, configs/ (force-included package data, resolved at runtime
+#    relative to the installed package)
+COPY pyproject.toml README.md LICENSE ./
+COPY paperbanana/ paperbanana/
+COPY mcp_server/ mcp_server/
+COPY prompts/ prompts/
+COPY data/ data/
+COPY configs/ configs/
+
+# Install the package (the wheel embeds prompts/, data/, configs/), then drop
+# the build context — it is fully duplicated inside site-packages.
+RUN pip install ".[google,openai,pdf]" && cd / && rm -rf /build
+
+# Non-root runtime user; /work is the writable working directory where the CLI
+# reads inputs and writes the outputs/ folder (mount volumes here).
+RUN useradd --create-home --uid 1000 paperbanana \
+    && mkdir /work \
+    && chown paperbanana:paperbanana /work
+
+USER paperbanana
+WORKDIR /work
+
+ENTRYPOINT ["paperbanana"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
         <a href="https://github.com/llmsresearch/paperbanana/actions/workflows/ci.yml"><img src="https://github.com/llmsresearch/paperbanana/actions/workflows/ci.yml/badge.svg" alt="CI"/></a>
         <a href="https://pypi.org/project/paperbanana/"><img src="https://img.shields.io/pypi/dm/paperbanana?label=PyPI%20downloads&logo=pypi&logoColor=white" alt="PyPI Downloads"/></a>
         <a href="https://huggingface.co/spaces/llmsresearch/paperbanana"><img src="https://img.shields.io/badge/Demo-HuggingFace-yellow?logo=huggingface&logoColor=white" alt="Demo"/></a>
+        <a href="https://colab.research.google.com/github/llmsresearch/paperbanana/blob/main/notebooks/PaperBanana_Colab_Quickstart.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open in Colab"/></a>
         <br/>
         <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white" alt="Python 3.10+"/></a>
         <a href="https://arxiv.org/abs/2601.23265"><img src="https://img.shields.io/badge/arXiv-2601.23265-b31b1b?logo=arxiv&logoColor=white" alt="arXiv"/></a>
@@ -64,6 +65,10 @@ Check out Atlas Cloud's new coding plan promotion for more budget-friendly API a
 
 ## Quick Start
 
+> **Try it in your browser:** the
+> [Colab quickstart notebook](https://colab.research.google.com/github/llmsresearch/paperbanana/blob/main/notebooks/PaperBanana_Colab_Quickstart.ipynb)
+> walks through install → API key → diagram generation end-to-end, no local setup required.
+
 ### Prerequisites
 
 - Python 3.10+
@@ -82,6 +87,24 @@ Or install from source for development:
 git clone https://github.com/llmsresearch/paperbanana.git
 cd paperbanana
 pip install -e ".[dev,openai,google]"
+```
+
+#### Docker
+
+Build the image from a clone of the repo and pass your API key at runtime:
+
+```bash
+docker build -t paperbanana .
+docker run --rm -e GOOGLE_API_KEY paperbanana generate --help
+```
+
+To generate a diagram, mount your input and an outputs folder into `/work`:
+
+```bash
+docker run --rm -e GOOGLE_API_KEY \
+  -v "$(pwd)/method.txt:/work/method.txt:ro" \
+  -v "$(pwd)/outputs:/work/outputs" \
+  paperbanana generate --input method.txt --caption "Overview of our framework"
 ```
 
 ### Step 2: Get Your API Key

--- a/notebooks/PaperBanana_Colab_Quickstart.ipynb
+++ b/notebooks/PaperBanana_Colab_Quickstart.ipynb
@@ -1,0 +1,320 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "colab": {
+   "name": "PaperBanana_Colab_Quickstart.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PaperBanana — Colab Quickstart\n",
+    "\n",
+    "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/llmsresearch/paperbanana/blob/main/notebooks/PaperBanana_Colab_Quickstart.ipynb)\n",
+    "\n",
+    "[PaperBanana](https://github.com/llmsresearch/paperbanana) generates publication-quality\n",
+    "methodology diagrams and statistical plots from plain-text descriptions, using a\n",
+    "multi-agent pipeline (Retriever → Planner → Stylist → Visualizer ⇄ Critic).\n",
+    "\n",
+    "This notebook runs end-to-end in about 5 minutes:\n",
+    "\n",
+    "1. Install PaperBanana from PyPI\n",
+    "2. Set a **Google Gemini API key** (free tier available)\n",
+    "3. Generate a methodology diagram from a tiny inline example\n",
+    "4. *(Optional)* Generate a statistical plot from inline CSV data\n",
+    "5. *(Optional)* Download the full reference set and run an evaluation\n",
+    "\n",
+    "**What you need:** a free Gemini API key from\n",
+    "[Google AI Studio](https://aistudio.google.com/app/apikey).\n",
+    "PaperBanana also supports OpenAI, Azure OpenAI, Atlas Cloud, and OpenRouter —\n",
+    "see the [README](https://github.com/llmsresearch/paperbanana#providers) — but Gemini\n",
+    "is the default and has a free tier, so that is what this notebook uses."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install\n",
+    "\n",
+    "Install PaperBanana from PyPI with the Google Gemini provider extra."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"paperbanana[google]\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Set your API key\n",
+    "\n",
+    "Get a free key from [Google AI Studio](https://aistudio.google.com/app/apikey) and paste it\n",
+    "below (the prompt hides your input; nothing is stored in the notebook).\n",
+    "\n",
+    "> **Using OpenAI instead?** Set `os.environ[\"OPENAI_API_KEY\"]` here and add\n",
+    "> `--vlm-provider openai --image-provider openai_imagen` to the commands below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "os.environ[\"GOOGLE_API_KEY\"] = getpass(\"Paste your Gemini API key: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Write a tiny methodology example\n",
+    "\n",
+    "PaperBanana takes a plain-text description of your method as input. We write a small\n",
+    "example inline so the notebook has no external dependencies — replace it with your\n",
+    "own methodology text later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "methodology = \"\"\"\\\n",
+    "Our model builds on the Transformer architecture with several key modifications.\n",
+    "\n",
+    "Input tokens are embedded through a learned embedding layer and combined with\n",
+    "sinusoidal positional encodings. The result passes through a stack of N=12 encoder\n",
+    "layers, each consisting of multi-head self-attention (8 heads) followed by a\n",
+    "position-wise feed-forward network with GELU activation. Layer normalization is\n",
+    "applied before each sub-layer (Pre-LN), with residual connections around each.\n",
+    "\n",
+    "The decoder mirrors this structure but adds a cross-attention layer between the\n",
+    "self-attention and feed-forward sub-layers, attending to the encoder output.\n",
+    "Causal masking prevents the decoder from attending to future positions.\n",
+    "\n",
+    "We introduce a sparse attention pattern in the encoder that reduces quadratic\n",
+    "complexity to O(n sqrt(n)): a learned router predicts attention scores for all\n",
+    "positions and selects the top-k positions for each query.\n",
+    "\n",
+    "The final decoder output is projected through a linear layer followed by softmax\n",
+    "to produce output token probabilities.\n",
+    "\"\"\"\n",
+    "\n",
+    "with open(\"method.txt\", \"w\") as f:\n",
+    "    f.write(methodology)\n",
+    "\n",
+    "print(f\"Wrote method.txt ({len(methodology)} chars)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Generate the diagram\n",
+    "\n",
+    "We run a single refinement iteration (`--iterations 1`) to keep this fast and cheap,\n",
+    "and cap spend with `--budget 0.50` (USD) — the pipeline aborts gracefully if the cap\n",
+    "would be exceeded. The default config already uses Gemini for both the VLM and image\n",
+    "generation.\n",
+    "\n",
+    "This typically takes 1–3 minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!paperbanana generate \\\n",
+    "  --input method.txt \\\n",
+    "  --caption \"Overview of our sparse-routing encoder-decoder architecture\" \\\n",
+    "  --iterations 1 \\\n",
+    "  --budget 0.50 \\\n",
+    "  --output diagram.png"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display the result inline:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image, display\n",
+    "\n",
+    "display(Image(\"diagram.png\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. (Optional) Statistical plot from CSV data\n",
+    "\n",
+    "`paperbanana plot` renders charts via VLM-generated matplotlib code — **no\n",
+    "image-generation model is involved**, so it is cheap and fast. We write a small\n",
+    "CSV inline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv_data = \"\"\"\\\n",
+    "model,MMLU,GSM8K,HumanEval\n",
+    "Baseline,62.1,48.3,35.4\n",
+    "Ours (dense),68.7,55.2,41.8\n",
+    "Ours (sparse),70.2,58.9,44.1\n",
+    "\"\"\"\n",
+    "\n",
+    "with open(\"results.csv\", \"w\") as f:\n",
+    "    f.write(csv_data)\n",
+    "\n",
+    "print(csv_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!paperbanana plot \\\n",
+    "  --data results.csv \\\n",
+    "  --intent \"Grouped bar chart comparing model accuracy across three benchmarks\" \\\n",
+    "  --iterations 1 \\\n",
+    "  --budget 0.25 \\\n",
+    "  --output plot.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image, display\n",
+    "\n",
+    "display(Image(\"plot.png\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. (Optional) Download the full reference set\n",
+    "\n",
+    "PaperBanana ships with a small curated set of reference diagrams, which the Retriever\n",
+    "agent uses for in-context planning. For best results you can download the full\n",
+    "**PaperBananaBench** reference set.\n",
+    "\n",
+    "> **Note:** this is a **~254 MB** download (cached under `~/.cache/paperbanana/`),\n",
+    "> so skip this cell if you are just exploring."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!paperbanana data download\n",
+    "!paperbanana data info"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. (Optional) Evaluate against a human reference\n",
+    "\n",
+    "`paperbanana evaluate` scores a generated diagram against a human-made reference using\n",
+    "a VLM-as-a-Judge on four dimensions: **Faithfulness**, **Readability**, **Conciseness**,\n",
+    "and **Aesthetics**.\n",
+    "\n",
+    "Normally you would pass your own paper's original figure as `--reference`. As a demo,\n",
+    "we borrow one image from the reference set downloaded in step 6 (so run that cell first)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "import os.path\n",
+    "\n",
+    "refs = sorted(glob.glob(os.path.expanduser(\"~/.cache/paperbanana/reference_sets/images/*\")))\n",
+    "assert refs, \"No reference images found - run the download cell in step 6 first.\"\n",
+    "reference_image = refs[0]\n",
+    "print(f\"Using demo reference: {reference_image}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!paperbanana evaluate \\\n",
+    "  --generated diagram.png \\\n",
+    "  --reference \"{reference_image}\" \\\n",
+    "  --context method.txt \\\n",
+    "  --caption \"Overview of our sparse-routing encoder-decoder architecture\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- **Better quality:** add `--optimize` (input enrichment) and `--auto` (refine until the\n",
+    "  critic is satisfied) to `paperbanana generate`.\n",
+    "- **Batch mode:** generate many figures from one YAML manifest with `paperbanana batch`.\n",
+    "- **Local web UI:** `pip install 'paperbanana[studio]'` then `paperbanana studio`.\n",
+    "- **MCP server:** use PaperBanana from Claude Code or Cursor via `paperbanana-mcp`.\n",
+    "- **Docker:** `docker build -t paperbanana . && docker run --rm -e GOOGLE_API_KEY paperbanana --help`\n",
+    "\n",
+    "Full documentation: [github.com/llmsresearch/paperbanana](https://github.com/llmsresearch/paperbanana)\n",
+    "\n",
+    "> PaperBanana is an unofficial, community-driven implementation of\n",
+    "> [\"PaperBanana: Automating Academic Illustration for AI Scientists\"](https://arxiv.org/abs/2601.23265)."
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
Fixes #239 — distribution parity for researchers who won't pip-install locally:

- `notebooks/PaperBanana_Colab_Quickstart.ipynb` — 21-cell end-to-end: install from PyPI with the `google` extra (free-tier Gemini path), inline demo input (no repo-file dependency), generate with `--iterations 1 --budget 0.50` and inline image display, optional plot/dataset/evaluate cells, next-steps pointers. All CLI flags verified against current `cli.py`.
- `Dockerfile` — python:3.11-slim, copies exactly what the hatchling build needs (verified against pyproject force-include), `[google,openai,pdf]` extras, non-root user, writable `/work` for volume-mounted outputs. `.dockerignore` keeps the context small and excludes `.env`.
- README: Colab badge in the header, Colab callout in Quick Start, Docker subsection with build/run/volume examples.