### PR TITLE
feat: benchmark on the official PaperBananaBench test split + vanilla baseline

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -3170,6 +3170,27 @@ def benchmark(
     ),
     auto: bool = typer.Option(False, "--auto", help="Loop until critic satisfied per entry"),
     optimize: bool = typer.Option(False, "--optimize", help="Preprocess inputs per entry"),
+    split: str = typer.Option(
+        "reference",
+        "--split",
+        help=(
+            "Entry source: 'reference' (curated pool) or 'test' "
+            "(official PaperBananaBench test split — comparable to the paper)"
+        ),
+    ),
+    task: str = typer.Option(
+        "diagram",
+        "--task",
+        help="Task for --split test: 'diagram' (292 entries) or 'plot' (240 entries)",
+    ),
+    mode: str = typer.Option(
+        "full",
+        "--mode",
+        help=(
+            "'full' runs the complete agentic pipeline; 'vanilla' is the no-pipeline "
+            "baseline (single direct visualizer call, no planning/critique)"
+        ),
+    ),
     category: Optional[str] = typer.Option(
         None, "--category", help="Only run entries in this category"
     ),
@@ -3205,6 +3226,15 @@ def benchmark(
         raise typer.Exit(1)
     if concurrency < 1:
         console.print("[red]Error: --concurrency must be at least 1[/red]")
+        raise typer.Exit(1)
+    if split not in ("reference", "test"):
+        console.print(f"[red]Error: --split must be 'reference' or 'test'. Got: {split}[/red]")
+        raise typer.Exit(1)
+    if task not in ("diagram", "plot"):
+        console.print(f"[red]Error: --task must be 'diagram' or 'plot'. Got: {task}[/red]")
+        raise typer.Exit(1)
+    if mode not in ("full", "vanilla"):
+        console.print(f"[red]Error: --mode must be 'full' or 'vanilla'. Got: {mode}[/red]")
         raise typer.Exit(1)
 
     configure_logging(verbose=verbose)
@@ -3247,8 +3277,11 @@ def benchmark(
     # Load and filter entries
     id_list = [s.strip() for s in ids.split(",") if s.strip()] if ids else None
     try:
-        entries = runner.load_entries(category=category, ids=id_list, limit=limit)
-    except ValueError as e:
+        if split == "test":
+            entries = runner.load_test_entries(task, category=category, ids=id_list, limit=limit)
+        else:
+            entries = runner.load_entries(category=category, ids=id_list, limit=limit)
+    except (ValueError, RuntimeError) as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)
 
@@ -3256,12 +3289,14 @@ def benchmark(
         console.print("[red]Error: No entries match the given filters.[/red]")
         raise typer.Exit(1)
 
-    mode = "eval-only" if eval_only else "generate + evaluate"
+    run_mode = "eval-only" if eval_only else f"{mode} (generate + evaluate)"
+    split_label = f"test ({task})" if split == "test" else "reference"
     console.print(
         Panel.fit(
             f"[bold]PaperBanana[/bold] — Benchmark\n\n"
             f"Entries: {len(entries)}\n"
-            f"Mode: {mode}\n"
+            f"Split: {split_label}\n"
+            f"Mode: {run_mode}\n"
             f"VLM: {settings.vlm_provider} / {settings.effective_vlm_model}\n"
             f"Image: {settings.image_provider} / {settings.effective_image_model}",
             border_style="magenta",
@@ -3272,7 +3307,14 @@ def benchmark(
     bench_output_dir = Path(output_dir) if output_dir else None
 
     async def _run():
-        return await runner.run(entries, output_dir=bench_output_dir, eval_only_dir=eval_only)
+        return await runner.run(
+            entries,
+            output_dir=bench_output_dir,
+            eval_only_dir=eval_only,
+            mode=mode,
+            split=split,
+            task=task if split == "test" else None,
+        )
 
     report = asyncio.run(_run())
     summary = report.summary
@@ -3313,6 +3355,17 @@ def benchmark(
         for cat, stats in cat_breakdown.items():
             console.print(
                 f"  {cat:30s} n={stats['count']:3d}  "
+                f"win_rate={stats['model_win_rate']:5.1f}%  "
+                f"mean={stats['mean_score']:.1f}"
+            )
+
+    # Per-difficulty breakdown (official plot test split)
+    diff_breakdown = summary.get("difficulty_breakdown", {})
+    if diff_breakdown:
+        console.print("\n[bold]Per-difficulty breakdown:[/bold]")
+        for diff, stats in diff_breakdown.items():
+            console.print(
+                f"  {diff:30s} n={stats['count']:3d}  "
                 f"win_rate={stats['model_win_rate']:5.1f}%  "
                 f"mean={stats['mean_score']:.1f}"
             )

--- a/paperbanana/core/types.py
+++ b/paperbanana/core/types.py
@@ -116,6 +116,38 @@ class ReferenceExample(BaseModel):
     structure_hints: Optional[dict[str, Any] | list[Any] | str] = None
 
 
+class TestCase(BaseModel):
+    """A single entry from the official PaperBananaBench test split.
+
+    Mirrors the upstream ``test.json`` schema (292 diagram / 240 plot entries)
+    so benchmark runs are comparable to the paper (arXiv:2601.23265).
+    """
+
+    id: str
+    task: Literal["diagram", "plot"] = Field(
+        default="diagram", description="Benchmark task this case belongs to"
+    )
+    category: str = ""
+    source_context: str = Field(
+        description="Methodology text (diagram) or JSON-encoded data table (plot)"
+    )
+    caption: str = Field(default="", description="Official visual_intent for the entry")
+    gt_image_path: str = Field(description="Path to the ground-truth (human-drawn) image")
+    aspect_ratio: Optional[str] = Field(
+        default=None,
+        description="Official rounded_ratio from additional_info (e.g. '16:9')",
+    )
+    raw_data: Optional[dict[str, Any]] = Field(
+        default=None, description="Raw data table for plot entries"
+    )
+    gt_code: Optional[str] = Field(
+        default=None, description="Ground-truth matplotlib code (plot entries only)"
+    )
+    difficulty: Optional[str] = Field(
+        default=None, description="Official difficulty label (plot entries only)"
+    )
+
+
 class CritiqueResult(BaseModel):
     """Output from the Critic agent."""
 

--- a/paperbanana/data/manager.py
+++ b/paperbanana/data/manager.py
@@ -2,12 +2,19 @@
 
 Cache layout:
     ~/.cache/paperbanana/              (or PAPERBANANA_CACHE_DIR)
-    └── reference_sets/
-        ├── index.json
-        ├── dataset_info.json          (version + revision tracking)
-        └── images/
-            ├── ref_001.jpg
-            └── ...
+    ├── reference_sets/
+    │   ├── index.json
+    │   ├── dataset_info.json          (version + revision tracking)
+    │   └── images/
+    │       ├── ref_001.jpg
+    │       └── ...
+    └── test_split/                    (official PaperBananaBench test split)
+        ├── diagram/
+        │   ├── test.json
+        │   └── images/
+        └── plot/
+            ├── test.json
+            └── images/
 """
 
 from __future__ import annotations
@@ -19,9 +26,12 @@ import tempfile
 import unicodedata
 import zipfile
 from pathlib import Path
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 import structlog
+
+if TYPE_CHECKING:
+    from paperbanana.core.types import TestCase
 
 logger = structlog.get_logger()
 
@@ -101,6 +111,19 @@ class DatasetManager:
     def info_path(self) -> Path:
         """Path to dataset version info."""
         return self.reference_dir / "dataset_info.json"
+
+    @property
+    def test_split_dir(self) -> Path:
+        """Directory containing the cached official test split."""
+        return self._cache_dir / "test_split"
+
+    def test_split_index_path(self, task: str) -> Path:
+        """Path to the cached, normalized test.json for a task."""
+        return self.test_split_dir / task / "test.json"
+
+    def is_test_split_downloaded(self, task: str) -> bool:
+        """Check if the official test split for *task* is cached."""
+        return self.test_split_index_path(task).exists()
 
     def is_downloaded(self) -> bool:
         """Check if an expanded reference set is available in cache.
@@ -216,17 +239,63 @@ class DatasetManager:
             bench_examples = _import_from_bench(bench_dir, task, images_dir)
             count = _merge_index(self.index_path, bench_examples)
 
+            # Cache the official test split alongside the reference import
+            _log("Caching official test split...")
+            test_count = _import_test_split(bench_dir, task, self.test_split_dir)
+
             # Update dataset_info.json
             self._record_dataset(
                 "full_bench",
                 DATASET_VERSION,
                 DATASET_URL,
                 count,
-                extra={"revision": DATASET_RELEASE_TAG, "task": task},
+                extra={
+                    "revision": DATASET_RELEASE_TAG,
+                    "task": task,
+                    "test_cases": test_count,
+                },
             )
 
             _log(f"Cached {count} reference examples to {self.reference_dir}")
+            if test_count:
+                _log(f"Cached {test_count} official test cases to {self.test_split_dir}")
             return count
+
+    def load_test_split(self, task: str = "diagram") -> list[TestCase]:
+        """Load the official PaperBananaBench test split for a task.
+
+        Args:
+            task: Which split to load ('diagram' or 'plot').
+
+        Returns:
+            List of typed TestCase entries with absolute ground-truth image paths.
+
+        Raises:
+            ValueError: If *task* is not 'diagram' or 'plot'.
+            RuntimeError: If the test split has not been downloaded yet.
+        """
+        from paperbanana.core.types import TestCase
+
+        if task not in ("diagram", "plot"):
+            raise ValueError(f"task must be 'diagram' or 'plot', got: {task}")
+
+        index_path = self.test_split_index_path(task)
+        if not index_path.exists():
+            raise RuntimeError(
+                f"Official test split for task '{task}' not found at {index_path}. "
+                "Run 'paperbanana data download --force' to fetch and cache it."
+            )
+
+        with open(index_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        task_dir = index_path.parent
+        cases: list[TestCase] = []
+        for raw in data.get("cases", []):
+            raw = dict(raw)
+            raw["gt_image_path"] = str(task_dir / raw.get("gt_image_path", ""))
+            cases.append(TestCase(**raw))
+        return cases
 
     def _record_dataset(
         self,
@@ -270,6 +339,9 @@ class DatasetManager:
         if self.reference_dir.exists():
             shutil.rmtree(self.reference_dir)
             logger.info("Cleared cached dataset", path=str(self.reference_dir))
+        if self.test_split_dir.exists():
+            shutil.rmtree(self.test_split_dir)
+            logger.info("Cleared cached test split", path=str(self.test_split_dir))
 
 
 def _download_file(url: str, dest: Path) -> None:
@@ -465,6 +537,103 @@ def _import_from_bench(
         raise RuntimeError("No examples could be imported from the dataset.")
 
     return all_examples
+
+
+def _import_test_split(
+    bench_dir: Path,
+    task: str,
+    dest_root: Path,
+) -> int:
+    """Cache the official test split (test.json + images) in normalized form.
+
+    Converts each upstream test entry to the TestCase schema and copies its
+    ground-truth image into ``dest_root/<task>/images/<id><ext>`` (ID-based
+    names sidestep Unicode-normalization issues in cached filenames). Writes
+    ``dest_root/<task>/test.json`` per task.
+
+    Args:
+        bench_dir: Extracted PaperBananaBench directory.
+        task: 'diagram', 'plot', or 'both'.
+        dest_root: Destination root for the cached test split.
+
+    Returns:
+        Total number of imported test cases across tasks.
+    """
+    tasks = ["diagram", "plot"] if task == "both" else [task]
+    total = 0
+
+    for t in tasks:
+        task_dir = bench_dir / t
+        test_file = task_dir / "test.json"
+
+        if not test_file.exists():
+            logger.warning("Task test.json not found, skipping", task=t, path=str(test_file))
+            continue
+
+        with open(test_file, encoding="utf-8") as f:
+            entries = json.load(f)
+
+        source_images_dir = task_dir / "images"
+        dest_dir = dest_root / t
+        images_dir = dest_dir / "images"
+        images_dir.mkdir(parents=True, exist_ok=True)
+
+        cases: list[dict] = []
+        for entry in entries:
+            entry_id = str(entry.get("id", ""))
+            gt_image_rel = entry.get("path_to_gt_image", "")
+            if not entry_id or not gt_image_rel:
+                continue
+
+            source_image = _resolve_image(source_images_dir, gt_image_rel)
+            if source_image is None:
+                logger.warning("Test image not found, skipping", id=entry_id, path=gt_image_rel)
+                continue
+
+            dest_filename = f"{entry_id}{source_image.suffix or '.jpg'}"
+            dest_image = images_dir / dest_filename
+            if not dest_image.exists():
+                shutil.copy2(source_image, dest_image)
+
+            content = entry.get("content", "")
+            raw_data = content if isinstance(content, dict) else None
+            if isinstance(content, (dict, list)):
+                source_context = json.dumps(content, indent=2)
+            else:
+                source_context = content
+
+            additional = entry.get("additional_info") or {}
+            cases.append(
+                {
+                    "id": entry_id,
+                    "task": t,
+                    "category": entry.get("category", "") or "",
+                    "source_context": source_context,
+                    "caption": entry.get("visual_intent", ""),
+                    "gt_image_path": f"images/{dest_filename}",
+                    "aspect_ratio": additional.get("rounded_ratio"),
+                    "raw_data": raw_data,
+                    "gt_code": additional.get("gt_code"),
+                    "difficulty": entry.get("difficulty"),
+                }
+            )
+
+        index_data = {
+            "metadata": {
+                "name": f"paperbananabench_test_{t}",
+                "description": f"Official PaperBananaBench {t} test split ({len(cases)} cases).",
+                "task": t,
+                "total_cases": len(cases),
+            },
+            "cases": cases,
+        }
+        with open(dest_dir / "test.json", "w", encoding="utf-8") as f:
+            json.dump(index_data, f, indent=2, ensure_ascii=False)
+
+        total += len(cases)
+        logger.info("Imported test split", task=t, count=len(cases), total=len(entries))
+
+    return total
 
 
 def resolve_reference_path(

--- a/paperbanana/evaluation/benchmark.py
+++ b/paperbanana/evaluation/benchmark.py
@@ -11,17 +11,19 @@ import datetime
 import os
 import time
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Optional, TypeVar, Union
 
 import structlog
 from pydantic import BaseModel, Field
 
+from paperbanana.agents.visualizer import VisualizerAgent
 from paperbanana.core.config import Settings
 from paperbanana.core.pipeline import PaperBananaPipeline
 from paperbanana.core.types import (
     DiagramType,
     GenerationInput,
     ReferenceExample,
+    TestCase,
 )
 from paperbanana.core.utils import ensure_dir, save_json
 from paperbanana.evaluation.judge import DIMENSIONS, VLMJudge
@@ -40,6 +42,8 @@ class BenchmarkEntryResult(BaseModel):
 
     id: str
     category: str = ""
+    task: str = "diagram"
+    difficulty: Optional[str] = None
     run_id: Optional[str] = None
     image_path: Optional[str] = None
     iteration_count: int = 0
@@ -53,6 +57,9 @@ class BenchmarkReport(BaseModel):
 
     created_at: str
     run_dir: Optional[str] = None  # Directory where report and partial results were written
+    split: str = "reference"  # Entry source: curated 'reference' pool or official 'test' split
+    task: Optional[str] = None  # 'diagram' or 'plot' for official test-split runs
+    mode: str = "full"  # 'full' pipeline or 'vanilla' (single direct visualizer call)
     settings_snapshot: dict = Field(default_factory=dict)
     total_entries: int = 0
     completed: int = 0
@@ -65,15 +72,18 @@ class BenchmarkReport(BaseModel):
 
 # ── Filtering ────────────────────────────────────────────────────
 
+BenchmarkEntry = Union[ReferenceExample, TestCase]
+EntryT = TypeVar("EntryT", ReferenceExample, TestCase)
+
 
 def filter_examples(
-    examples: list[ReferenceExample],
+    examples: list[EntryT],
     *,
     category: Optional[str] = None,
     ids: Optional[list[str]] = None,
     limit: Optional[int] = None,
-) -> list[ReferenceExample]:
-    """Filter benchmark examples by category, IDs, or subset size."""
+) -> list[EntryT]:
+    """Filter benchmark entries (reference or test split) by category, IDs, or subset size."""
     result = examples
 
     if ids:
@@ -137,10 +147,26 @@ def aggregate_results(entries: list[BenchmarkEntryResult]) -> dict:
             "mean_score": round(sum(cat_scores) / n, 1) if n else 0.0,
         }
 
+    # Per-difficulty breakdown (official plot test split carries difficulty labels)
+    difficulty_breakdown: dict[str, dict] = {}
+    by_difficulty: dict[str, list[BenchmarkEntryResult]] = {}
+    for e in scored:
+        if e.difficulty:
+            by_difficulty.setdefault(e.difficulty, []).append(e)
+    for diff, diff_entries in sorted(by_difficulty.items()):
+        diff_scores = [_score(e) for e in diff_entries]
+        diff_model = sum(1 for e in diff_entries if _winner(e) == "Model")
+        n = len(diff_entries)
+        difficulty_breakdown[diff] = {
+            "count": n,
+            "model_win_rate": round(diff_model / n * 100, 1) if n else 0.0,
+            "mean_score": round(sum(diff_scores) / n, 1) if n else 0.0,
+        }
+
     gen_times = [e.generation_seconds for e in scored if e.generation_seconds > 0]
     mean_gen_time = round(sum(gen_times) / len(gen_times), 1) if gen_times else 0.0
 
-    return {
+    summary = {
         "evaluated": len(scored),
         "model_wins": model_wins,
         "human_wins": human_wins,
@@ -151,6 +177,9 @@ def aggregate_results(entries: list[BenchmarkEntryResult]) -> dict:
         "category_breakdown": category_breakdown,
         "mean_generation_seconds": mean_gen_time,
     }
+    if difficulty_breakdown:
+        summary["difficulty_breakdown"] = difficulty_breakdown
+    return summary
 
 
 # ── Runner ───────────────────────────────────────────────────────
@@ -165,10 +194,13 @@ class BenchmarkRunner:
         *,
         pipeline_factory: Callable[[Settings], PaperBananaPipeline] = PaperBananaPipeline,
         judge_factory: Optional[Callable[[Settings], VLMJudge]] = None,
+        visualizer_factory: Optional[Callable[[Settings], VisualizerAgent]] = None,
     ):
         self.settings = settings
         self.pipeline_factory = pipeline_factory
         self.judge_factory = judge_factory or self._default_judge_factory
+        # Used only in vanilla mode: a single direct Visualizer call per entry.
+        self.visualizer_factory = visualizer_factory or self._default_visualizer_factory
         # Concurrency for processing benchmark entries (generation + evaluation).
         # Defaults to 1 to preserve existing sequential behaviour unless
         # explicitly overridden by the caller.
@@ -179,6 +211,42 @@ class BenchmarkRunner:
 
         vlm = ProviderRegistry.create_vlm(settings)
         return VLMJudge(vlm, prompt_dir=find_prompt_dir())
+
+    def _default_visualizer_factory(self, settings: Settings) -> VisualizerAgent:
+        from paperbanana.core.utils import find_prompt_dir
+
+        vlm = ProviderRegistry.create_vlm(settings)
+        image_gen = ProviderRegistry.create_image_gen(settings)
+        prompt_dir = settings.prompt_dir or find_prompt_dir()
+        return VisualizerAgent(
+            image_gen,
+            vlm,
+            prompt_dir=prompt_dir,
+            output_resolution=settings.output_resolution,
+            image_quality=settings.image_quality,
+        )
+
+    def load_test_entries(
+        self,
+        task: str = "diagram",
+        *,
+        category: Optional[str] = None,
+        ids: Optional[list[str]] = None,
+        limit: Optional[int] = None,
+    ) -> list[TestCase]:
+        """Load the official PaperBananaBench test split with optional filtering."""
+        from paperbanana.data.manager import DatasetManager
+
+        manager = DatasetManager()
+        cases = manager.load_test_split(task)
+        filtered = filter_examples(cases, category=category, ids=ids, limit=limit)
+        logger.info(
+            "Loaded official test split",
+            task=task,
+            total=len(cases),
+            filtered=len(filtered),
+        )
+        return filtered
 
     def load_entries(
         self,
@@ -204,19 +272,30 @@ class BenchmarkRunner:
 
     async def run(
         self,
-        entries: list[ReferenceExample],
+        entries: list[BenchmarkEntry],
         *,
         output_dir: Optional[Path] = None,
         eval_only_dir: Optional[str] = None,
+        mode: str = "full",
+        split: str = "reference",
+        task: Optional[str] = None,
     ) -> BenchmarkReport:
         """Run the benchmark across all entries.
 
         Args:
-            entries: Benchmark entries to process.
+            entries: Benchmark entries to process (curated ReferenceExample pool
+                or official-test-split TestCase entries).
             output_dir: Directory for outputs. Auto-generated if None.
             eval_only_dir: If set, skip generation and evaluate existing images
                 from this directory. Expects <entry_id>/final_output.png layout.
+            mode: 'full' runs the complete agentic pipeline; 'vanilla' makes a
+                single direct Visualizer call (no retrieval/planning/styling/critique)
+                for ablation parity with the upstream baseline.
+            split: Label recorded in the report ('reference' or 'test').
+            task: Label recorded in the report ('diagram' or 'plot') for test-split runs.
         """
+        if mode not in ("full", "vanilla"):
+            raise ValueError(f"mode must be 'full' or 'vanilla', got: {mode}")
         run_dir = (
             Path(output_dir)
             if output_dir is not None
@@ -236,7 +315,7 @@ class BenchmarkRunner:
         semaphore = asyncio.Semaphore(self.concurrency)
         results_lock = asyncio.Lock()
 
-        async def _run_single(idx: int, entry: ReferenceExample) -> None:
+        async def _run_single(idx: int, entry: BenchmarkEntry) -> None:
             async with semaphore:
                 logger.info(
                     f"Benchmark entry {idx + 1}/{len(entries)}",
@@ -244,7 +323,7 @@ class BenchmarkRunner:
                     category=entry.category,
                 )
                 result = await self._process_entry(
-                    entry, judge=judge, run_dir=run_dir, eval_only_dir=eval_only_dir
+                    entry, judge=judge, run_dir=run_dir, eval_only_dir=eval_only_dir, mode=mode
                 )
             # Append and save partials under a lock so that writes remain
             # consistent even when many tasks complete at once.
@@ -265,6 +344,9 @@ class BenchmarkRunner:
         report = BenchmarkReport(
             created_at=datetime.datetime.now().isoformat(),
             run_dir=str(run_dir),
+            split=split,
+            task=task,
+            mode=mode,
             settings_snapshot=self.settings.model_dump(
                 exclude={
                     "google_api_key",
@@ -293,30 +375,48 @@ class BenchmarkRunner:
 
     async def _process_entry(
         self,
-        entry: ReferenceExample,
+        entry: BenchmarkEntry,
         *,
         judge: VLMJudge,
         run_dir: Path,
         eval_only_dir: Optional[str] = None,
+        mode: str = "full",
     ) -> BenchmarkEntryResult:
         """Generate and evaluate a single benchmark entry."""
-        result = BenchmarkEntryResult(id=entry.id, category=entry.category or "")
+        is_test_case = isinstance(entry, TestCase)
+        reference_path = entry.gt_image_path if is_test_case else entry.image_path
+        diagram_type = (
+            DiagramType.STATISTICAL_PLOT
+            if is_test_case and entry.task == "plot"
+            else DiagramType.METHODOLOGY
+        )
+        aspect_ratio = entry.aspect_ratio if is_test_case else None
+        raw_data = entry.raw_data if is_test_case else None
+
+        result = BenchmarkEntryResult(
+            id=entry.id,
+            category=entry.category or "",
+            task=entry.task if is_test_case else "diagram",
+            difficulty=entry.difficulty if is_test_case else None,
+        )
 
         # Skip entries without reference images (can't evaluate)
-        if not entry.image_path or not Path(entry.image_path).exists():
+        if not reference_path or not Path(reference_path).exists():
             result.error = "reference image not found"
             logger.warning("Skipping entry: no reference image", id=entry.id)
+            return result
+
+        # Prevent path traversal: entry.id is used as a single path component
+        # for eval-only lookups and vanilla-mode output directories.
+        if (eval_only_dir or mode == "vanilla") and (".." in entry.id or os.sep in entry.id):
+            result.error = "invalid entry id for filesystem path"
+            logger.warning("Skipping entry: invalid id", id=entry.id)
             return result
 
         # Generation (or locate existing output for eval-only mode)
         image_path: Optional[str] = None
 
         if eval_only_dir:
-            # Prevent path traversal: entry.id must be a single path component
-            if ".." in entry.id or os.sep in entry.id:
-                result.error = "invalid entry id for eval-only path"
-                logger.warning("Skipping entry: invalid id", id=entry.id)
-                return result
             base = Path(eval_only_dir)
             candidate = base / entry.id / "final_output.png"
             if not candidate.exists():
@@ -327,6 +427,25 @@ class BenchmarkRunner:
                 result.error = f"generated image not found in {eval_only_dir}"
                 logger.warning("Skipping eval-only entry: image not found", id=entry.id)
                 return result
+        elif mode == "vanilla":
+            try:
+                gen_start = time.perf_counter()
+                image_path = await self._vanilla_generate(
+                    entry_id=entry.id,
+                    source_context=entry.source_context,
+                    caption=entry.caption,
+                    diagram_type=diagram_type,
+                    raw_data=raw_data,
+                    aspect_ratio=aspect_ratio,
+                    run_dir=run_dir,
+                )
+                result.generation_seconds = round(time.perf_counter() - gen_start, 1)
+                result.image_path = image_path
+                result.iteration_count = 1
+            except Exception as e:
+                result.error = str(e)
+                logger.error("Vanilla generation failed", id=entry.id, error=str(e))
+                return result
         else:
             try:
                 gen_start = time.perf_counter()
@@ -335,7 +454,9 @@ class BenchmarkRunner:
                     GenerationInput(
                         source_context=entry.source_context,
                         communicative_intent=entry.caption,
-                        diagram_type=DiagramType.METHODOLOGY,
+                        diagram_type=diagram_type,
+                        raw_data=raw_data,
+                        aspect_ratio=aspect_ratio,
                     )
                 )
                 result.generation_seconds = round(time.perf_counter() - gen_start, 1)
@@ -354,7 +475,8 @@ class BenchmarkRunner:
                 image_path=image_path,
                 source_context=entry.source_context,
                 caption=entry.caption,
-                reference_path=entry.image_path,
+                reference_path=reference_path,
+                task=diagram_type,
             )
             result.evaluation = scores_to_dict(scores)
         except Exception as e:
@@ -362,6 +484,44 @@ class BenchmarkRunner:
             logger.error("Evaluation failed", id=entry.id, error=str(e))
 
         return result
+
+    async def _vanilla_generate(
+        self,
+        *,
+        entry_id: str,
+        source_context: str,
+        caption: str,
+        diagram_type: DiagramType,
+        raw_data: Optional[dict],
+        aspect_ratio: Optional[str],
+        run_dir: Path,
+    ) -> str:
+        """No-pipeline baseline: one direct Visualizer call per entry.
+
+        Skips Retriever/Planner/Stylist/Critic entirely. The visualizer receives
+        the raw caption + source context (for plots, the raw data table is
+        appended by the visualizer itself), mirroring the upstream 'vanilla'
+        ablation mode.
+        """
+        visualizer = self.visualizer_factory(self.settings)
+        out_dir = ensure_dir(run_dir / entry_id)
+        visualizer.set_output_dir(out_dir)
+
+        if diagram_type == DiagramType.STATISTICAL_PLOT:
+            # Raw data is appended to the description by the visualizer.
+            description = caption or source_context
+        else:
+            description = f"{caption}\n\n{source_context}" if caption else source_context
+
+        return await visualizer.run(
+            description=description,
+            diagram_type=diagram_type,
+            raw_data=raw_data,
+            output_path=str(out_dir / "final_output.png"),
+            iteration=1,
+            seed=self.settings.seed,
+            aspect_ratio=aspect_ratio,
+        )
 
 
 # ── Helpers ──────────────────────────────────────────────────────

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -409,3 +409,84 @@ class TestResolveImageUnicode:
         images = tmp_path / "images"
         images.mkdir()
         assert _resolve_image(images, "nope.jpg") is None
+
+
+class TestOfficialTestSplit:
+    """Import + load round-trip for the official test split (issue #235)."""
+
+    def _make_bench_dir(self, tmp_path):
+        import json
+
+        bench = tmp_path / "PaperBananaBench"
+        for task in ("diagram", "plot"):
+            (bench / task / "images").mkdir(parents=True)
+        (bench / "diagram" / "images" / "fig1.jpg").write_bytes(b"img1")
+        (bench / "diagram" / "test.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "d1",
+                        "category": "vision",
+                        "content": "methodology text",
+                        "visual_intent": "Overview figure",
+                        "path_to_gt_image": "fig1.jpg",
+                        "split": "test",
+                        "additional_info": {"rounded_ratio": "16:9", "width": 1600, "height": 900},
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        (bench / "plot" / "images" / "p1.jpg").write_bytes(b"img2")
+        (bench / "plot" / "test.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "p1",
+                        "category": "bar",
+                        "content": {"x": [1, 2], "y": [3, 4]},
+                        "visual_intent": "Bar chart",
+                        "path_to_gt_image": "p1.jpg",
+                        "difficulty": "easy",
+                        "additional_info": {"rounded_ratio": "3:2", "gt_code": "plt.bar(x, y)"},
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return bench
+
+    def test_import_and_load_round_trip(self, tmp_path):
+        from paperbanana.data.manager import DatasetManager, _import_test_split
+
+        bench = self._make_bench_dir(tmp_path)
+        dm = DatasetManager(cache_dir=tmp_path / "cache")
+        count = _import_test_split(bench, "both", dm.test_split_dir)
+        assert count == 2
+
+        diagram_cases = dm.load_test_split("diagram")
+        assert len(diagram_cases) == 1
+        case = diagram_cases[0]
+        assert case.id == "d1"
+        assert case.aspect_ratio == "16:9"
+        assert case.task == "diagram"
+        assert Path(case.gt_image_path).exists()
+
+        plot_cases = dm.load_test_split("plot")
+        assert plot_cases[0].gt_code == "plt.bar(x, y)"
+        assert plot_cases[0].difficulty == "easy"
+        assert plot_cases[0].raw_data == {"x": [1, 2], "y": [3, 4]}
+
+    def test_load_missing_split_raises_with_hint(self, tmp_path):
+        from paperbanana.data.manager import DatasetManager
+
+        dm = DatasetManager(cache_dir=tmp_path / "cache")
+        with pytest.raises(RuntimeError, match="data download"):
+            dm.load_test_split("diagram")
+
+    def test_load_rejects_unknown_task(self, tmp_path):
+        from paperbanana.data.manager import DatasetManager
+
+        dm = DatasetManager(cache_dir=tmp_path / "cache")
+        with pytest.raises(ValueError, match="diagram"):
+            dm.load_test_split("poster")

--- a/tests/test_evaluation/test_benchmark.py
+++ b/tests/test_evaluation/test_benchmark.py
@@ -434,3 +434,113 @@ async def test_benchmark_runner_eval_only_rejects_path_traversal(tmp_path):
     assert report.completed == 0
     assert report.entries[0].error is not None
     assert "invalid entry id" in report.entries[0].error.lower()
+
+
+# ── Official test split (issue #235) ─────────────────────────────
+
+
+def _make_test_cases() -> list:
+    from paperbanana.core.types import TestCase
+
+    return [
+        TestCase(
+            id="t1",
+            task="diagram",
+            category="vision",
+            source_context="methodology text",
+            caption="Overview of the framework",
+            gt_image_path="/gt/t1.jpg",
+            aspect_ratio="16:9",
+        ),
+        TestCase(
+            id="t2",
+            task="plot",
+            source_context='{"x": [1, 2]}',
+            caption="Bar chart",
+            gt_image_path="/gt/t2.jpg",
+            aspect_ratio="3:2",
+            raw_data={"x": [1, 2]},
+            gt_code="plt.bar([1], [2])",
+            difficulty="easy",
+        ),
+    ]
+
+
+def test_testcase_filtering_works_like_reference():
+    cases = _make_test_cases()
+    assert len(filter_examples(cases, category="vision")) == 1
+    assert filter_examples(cases, ids=["t2"])[0].id == "t2"
+    assert len(filter_examples(cases, limit=1)) == 1
+
+
+def test_run_rejects_unknown_mode():
+    import asyncio
+
+    runner = BenchmarkRunner(Settings(), judge_factory=lambda s: object())
+    with pytest.raises(ValueError, match="mode must be"):
+        asyncio.run(runner.run([], mode="bogus"))
+
+
+class _MockVisualizer:
+    """Captures vanilla-mode calls and writes a fake output image."""
+
+    def __init__(self):
+        self.calls = []
+
+    def set_output_dir(self, path):
+        self.out_dir = path
+
+    async def run(self, **kwargs):
+        self.calls.append(kwargs)
+        from pathlib import Path
+
+        out = Path(kwargs["output_path"])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"img")
+        return str(out)
+
+
+class _MockJudge:
+    async def evaluate(self, **kwargs):
+        dim = DimensionResult(score=8, rationale="ok", winner="Both are good")
+        return EvaluationScore(
+            faithfulness=dim,
+            conciseness=dim,
+            readability=dim,
+            aesthetics=dim,
+            overall_winner="Both are good",
+            overall_score=8.0,
+        )
+
+
+async def test_vanilla_mode_single_visualizer_call(tmp_path):
+    """Vanilla mode makes exactly one direct visualizer call per entry,
+
+    threading the official aspect ratio, and never builds the pipeline."""
+    visualizer = _MockVisualizer()
+
+    def _fail_pipeline(settings):
+        raise AssertionError("pipeline must not be constructed in vanilla mode")
+
+    runner = BenchmarkRunner(
+        Settings(output_dir=str(tmp_path)),
+        pipeline_factory=_fail_pipeline,
+        judge_factory=lambda s: _MockJudge(),
+        visualizer_factory=lambda s: visualizer,
+    )
+    gt = tmp_path / "gt.jpg"
+    gt.write_bytes(b"gt-image")
+    diagram_case = _make_test_cases()[0].model_copy(update={"gt_image_path": str(gt)})
+    report = await runner.run(
+        [diagram_case], output_dir=tmp_path / "run", mode="vanilla", split="test", task="diagram"
+    )
+
+    assert len(visualizer.calls) == 1
+    call = visualizer.calls[0]
+    assert call["aspect_ratio"] == "16:9"
+    assert call["iteration"] == 1
+    entry_result = report.entries[0]
+    assert entry_result.error is None
+    assert entry_result.iteration_count == 1
+    assert report.mode == "vanilla"
+    assert report.split == "test"


### PR DESCRIPTION
Fixes #235 — our benchmark numbers become comparable to the paper (arXiv:2601.23265):

- **Typed `TestCase`** mirroring upstream `test.json` (292 diagram / 240 plot entries; verified against the real mirrored data), including `gt_code` and `difficulty` for plots
- **DatasetManager** caches the split during `paperbanana data download` (ID-named images sidestep the #234 Unicode issue) and exposes `load_test_split(task)` — clear error with the fix command when not downloaded
- **BenchmarkRunner**: `--split test` runs the official split with the official `rounded_ratio` threaded into generation; `--mode vanilla` is a single direct Visualizer call for ablation parity with upstream's baseline; report records split/task/mode
- 9 new tests (loader round-trip, vanilla single-call with mocked providers, validation); suite at 794 passing

Note: a full official run is API-budget-heavy (292 generations + judge calls) — `--limit` supports smoke runs; we should do a funded full run before publishing numbers.