### PR TITLE
fix: roll back to previous best image when a refinement round fails

### DIFF
--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -407,6 +407,67 @@ class PaperBananaPipeline:
 
         return final_output_path
 
+    async def _visualize_with_rollback(
+        self,
+        *,
+        iteration: int,
+        rollback_to: Optional[int],
+        run_dir: Path,
+        **visualizer_kwargs: Any,
+    ) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
+        """Run the visualizer for one refinement iteration, rolling back on failure.
+
+        When the visualizer fails after retries (or returns no image) and a
+        previous best image exists (``rollback_to`` is not ``None``), the
+        failure is logged and recorded, and ``(None, rollback_info)`` is
+        returned so the caller stops the loop and keeps the previous best
+        image as the final output.  Without a prior image (first round) the
+        exception propagates, preserving existing error behavior.
+        """
+        try:
+            image_path = await _call_with_retry(
+                "visualizer",
+                self.visualizer.run,
+                iteration=iteration,
+                **visualizer_kwargs,
+            )
+            if not image_path:
+                raise RuntimeError("Visualizer returned no image path")
+        except Exception as e:
+            if rollback_to is None:
+                raise
+            rollback_info: Dict[str, Any] = {
+                "rollback_occurred": True,
+                "failed_iteration": iteration,
+                "rolled_back_to_iteration": rollback_to,
+                "stage": "visualizer",
+                "error": str(e),
+            }
+            logger.warning(
+                "Visualizer failed after retries; rolling back to previous best image",
+                iteration=iteration,
+                rolled_back_to_iteration=rollback_to,
+                error=str(e),
+            )
+            self._emit_progress(
+                "visualizer_rollback",
+                iteration=iteration,
+                rolled_back_to_iteration=rollback_to,
+                error=str(e),
+            )
+            if self.settings.save_iterations:
+                save_json(
+                    {
+                        "failed": True,
+                        "stage": "visualizer",
+                        "error": str(e),
+                        "rolled_back_to_iteration": rollback_to,
+                    },
+                    ensure_dir(run_dir / f"iter_{iteration}") / "failure.json",
+                )
+            return None, rollback_info
+        return image_path, None
+
     def _effective_vector_export(self, input: GenerationInput) -> str:
         """Resolve vector export mode from input override or settings."""
         if input.vector_export is not None:
@@ -553,6 +614,7 @@ class PaperBananaPipeline:
         current_description = format_diagram_ir_for_regeneration(diagram_ir)
         iterations: list[IterationRecord] = []
         iteration_timings: list[dict[str, float | int]] = []
+        rollback_info: Optional[Dict[str, Any]] = None
         budget_exceeded = self._check_budget("before regenerate-from-ir iterations")
         vector_formats = ["svg", "pdf"] if self.settings.vector_export else None
         total_iters = (
@@ -595,18 +657,32 @@ class PaperBananaPipeline:
                 ),
             )
             visualizer_start = time.perf_counter()
-            image_path = await _call_with_retry(
-                "visualizer",
-                self.visualizer.run,
+            image_path, rollback_info = await self._visualize_with_rollback(
+                iteration=iter_index,
+                rollback_to=iterations[-1].iteration if iterations else None,
+                run_dir=self._run_dir,
                 description=current_description,
                 diagram_type=DiagramType.METHODOLOGY,
                 raw_data=None,
-                iteration=iter_index,
                 seed=self.settings.seed,
                 aspect_ratio=aspect_ratio,
                 vector_formats=vector_formats,
             )
             visualizer_seconds = time.perf_counter() - visualizer_start
+            if image_path is None:
+                _emit_progress(
+                    progress_callback,
+                    PipelineProgressEvent(
+                        stage=PipelineProgressStage.VISUALIZER_END,
+                        message=(
+                            f"Visualizer iteration {iter_index} failed; keeping previous best image"
+                        ),
+                        seconds=visualizer_seconds,
+                        iteration=iter_index,
+                        extra={"rollback": True, "error": rollback_info["error"]},
+                    ),
+                )
+                break
             _emit_progress(
                 progress_callback,
                 PipelineProgressEvent(
@@ -758,6 +834,8 @@ class PaperBananaPipeline:
             "locked_edges": len(diagram_ir.locks.locked_edge_refs),
             "locked_groups": len(diagram_ir.locks.locked_group_ids),
         }
+        if rollback_info is not None:
+            metadata_dict["rollback"] = rollback_info
         if generated_caption is not None:
             metadata_dict["generated_caption"] = generated_caption
         if self._cost_tracker:
@@ -1107,6 +1185,7 @@ class PaperBananaPipeline:
         current_description = optimized_description
         iterations: list[IterationRecord] = []
         iteration_timings = []
+        rollback_info: Optional[Dict[str, Any]] = None
         vector_formats = ["svg", "pdf"] if self.settings.vector_export != "none" else None
 
         if self.settings.auto_refine:
@@ -1146,18 +1225,32 @@ class PaperBananaPipeline:
                 ),
             )
             visualizer_start = time.perf_counter()
-            image_path = await _call_with_retry(
-                "visualizer",
-                self.visualizer.run,
+            image_path, rollback_info = await self._visualize_with_rollback(
+                iteration=iter_index,
+                rollback_to=iterations[-1].iteration if iterations else None,
+                run_dir=self._run_dir,
                 description=current_description,
                 diagram_type=input.diagram_type,
                 raw_data=input.raw_data,
-                iteration=iter_index,
                 seed=self.settings.seed,
                 aspect_ratio=effective_ratio,
                 vector_formats=vector_formats,
             )
             visualizer_seconds = time.perf_counter() - visualizer_start
+            if image_path is None:
+                _emit_progress(
+                    progress_callback,
+                    PipelineProgressEvent(
+                        stage=PipelineProgressStage.VISUALIZER_END,
+                        message=(
+                            f"Visualizer iteration {iter_index} failed; keeping previous best image"
+                        ),
+                        seconds=visualizer_seconds,
+                        iteration=iter_index,
+                        extra={"rollback": True, "error": rollback_info["error"]},
+                    ),
+                )
+                break
             _emit_progress(
                 progress_callback,
                 PipelineProgressEvent(
@@ -1464,6 +1557,8 @@ class PaperBananaPipeline:
             "external_enabled": self.settings.exemplar_retrieval_enabled,
             "external_candidate_ids": external_candidate_ids,
         }
+        if rollback_info is not None:
+            metadata_dict["rollback"] = rollback_info
         if generated_caption is not None:
             metadata_dict["generated_caption"] = generated_caption
         if ir_planner_status is not None:
@@ -1566,6 +1661,7 @@ class PaperBananaPipeline:
         iterations: list[IterationRecord] = []
         iteration_timings = []
         budget_exceeded = False
+        rollback_info: Optional[Dict[str, Any]] = None
         vector_formats = ["svg", "pdf"] if self.settings.vector_export != "none" else None
 
         for i in range(total_iters):
@@ -1596,19 +1692,40 @@ class PaperBananaPipeline:
                     extra={"total_iterations": total_iters},
                 ),
             )
+            if iterations:
+                rollback_to = iterations[-1].iteration
+            elif resume_state.last_image_path:
+                # The run being continued already produced an image.
+                rollback_to = start_iter
+            else:
+                rollback_to = None
             visualizer_start = time.perf_counter()
-            image_path = await _call_with_retry(
-                "visualizer",
-                self.visualizer.run,
+            image_path, rollback_info = await self._visualize_with_rollback(
+                iteration=iter_num,
+                rollback_to=rollback_to,
+                run_dir=run_dir,
                 description=current_description,
                 diagram_type=resume_state.diagram_type,
                 raw_data=resume_state.raw_data,
-                iteration=iter_num,
                 seed=self.settings.seed,
                 aspect_ratio=resume_state.aspect_ratio,
                 vector_formats=vector_formats,
             )
             visualizer_seconds = time.perf_counter() - visualizer_start
+            if image_path is None:
+                _emit_progress(
+                    progress_callback,
+                    PipelineProgressEvent(
+                        stage=PipelineProgressStage.VISUALIZER_END,
+                        message=(
+                            f"Visualizer iteration {iter_num} failed; keeping previous best image"
+                        ),
+                        seconds=visualizer_seconds,
+                        iteration=iter_num,
+                        extra={"rollback": True, "error": rollback_info["error"]},
+                    ),
+                )
+                break
             _emit_progress(
                 progress_callback,
                 PipelineProgressEvent(
@@ -1743,8 +1860,19 @@ class PaperBananaPipeline:
 
         # Final output
         output_format = getattr(self.settings, "output_format", "png").lower()
+        final_iterations = iterations
+        if not iterations and rollback_info is not None and resume_state.last_image_path:
+            # Rolled back before any new image was produced: keep the
+            # previous run's best image as the final output.
+            final_iterations = [
+                IterationRecord(
+                    iteration=start_iter,
+                    description=current_description,
+                    image_path=resume_state.last_image_path,
+                )
+            ]
         final_output_path = self._build_final_output(
-            iterations,
+            final_iterations,
             run_dir,
             "No iterations completed — budget exceeded before first iteration",
         )
@@ -1845,6 +1973,8 @@ class PaperBananaPipeline:
         if resume_state.diagram_type == DiagramType.METHODOLOGY and vector_mode != "none":
             metadata_dict["timing"]["structurer_seconds"] = structurer_seconds
         metadata_dict["continued_from_iteration"] = start_iter
+        if rollback_info is not None:
+            metadata_dict["rollback"] = rollback_info
         if ir_planner_status is not None:
             metadata_dict["ir_planner"] = {
                 "status": ir_planner_status,

--- a/tests/test_pipeline/test_rollback.py
+++ b/tests/test_pipeline/test_rollback.py
@@ -1,0 +1,270 @@
+"""Tests for refinement-loop rollback to the previous best image (issue #238)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("PIL", reason="PIL/Pillow required for pipeline image mock")
+from pathlib import Path
+
+from PIL import Image
+
+from paperbanana.core import pipeline as pipeline_mod
+from paperbanana.core.config import Settings
+from paperbanana.core.pipeline import PaperBananaPipeline
+from paperbanana.core.resume import ResumeState
+from paperbanana.core.types import (
+    DiagramType,
+    GenerationInput,
+)
+
+# ── Shared mocks ─────────────────────────────────────────────────
+
+
+class _MockVLM:
+    name = "mock-vlm"
+    model_name = "mock-model"
+
+    def __init__(self, responses: list[str]):
+        self._responses = responses
+        self._idx = 0
+
+    async def generate(self, *args, **kwargs):
+        idx = min(self._idx, len(self._responses) - 1)
+        self._idx += 1
+        return self._responses[idx]
+
+
+class _MockImageGen:
+    name = "mock-image-gen"
+    model_name = "mock-image-model"
+
+    async def generate(self, *args, **kwargs):
+        return Image.new("RGB", (128, 128), color=(255, 255, 255))
+
+
+def _make_settings(tmp_path, **overrides):
+    defaults = dict(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "empty_refs"),
+        refinement_iterations=3,
+        save_iterations=False,
+    )
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+def _default_input():
+    return GenerationInput(
+        source_context="Test methodology text",
+        communicative_intent="Test caption",
+        diagram_type=DiagramType.METHODOLOGY,
+    )
+
+
+_REVISION_CRITIQUE = json.dumps(
+    {
+        "critic_suggestions": ["Increase label font size"],
+        "revised_description": "Revised description",
+    }
+)
+_ACCEPT_CRITIQUE = json.dumps({"critic_suggestions": [], "revised_description": None})
+
+
+def _fail_visualizer_at(pipeline, fail_iteration: int):
+    """Patch the visualizer to raise on a specific iteration, delegating otherwise."""
+    original_run = pipeline.visualizer.run
+
+    async def flaky_visualizer(**kwargs):
+        if kwargs.get("iteration") == fail_iteration:
+            raise RuntimeError("image gen exploded")
+        return await original_run(**kwargs)
+
+    pipeline.visualizer.run = flaky_visualizer
+
+
+# ── Fixture: fast retries (no waiting) ───────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _fast_retry(monkeypatch):
+    """Replace _call_with_retry with a zero-wait version for fast tests."""
+
+    async def _fast_call_with_retry(label, fn, *args, max_attempts=3, **kwargs):
+        last_exc = None
+        for attempt_num in range(1, max_attempts + 1):
+            try:
+                return await fn(*args, **kwargs)
+            except Exception as exc:
+                last_exc = exc
+                if attempt_num >= max_attempts:
+                    raise
+        raise last_exc  # unreachable but satisfies type checker
+
+    monkeypatch.setattr(pipeline_mod, "_call_with_retry", _fast_call_with_retry)
+
+
+# ── Test: round-2 visualizer failure rolls back to iteration 1 ───
+
+
+@pytest.mark.asyncio
+async def test_visualizer_failure_round2_rolls_back_to_previous_image(tmp_path):
+    """Iteration 2 visualizer failure keeps iteration 1's image as final output."""
+    settings = _make_settings(tmp_path, save_iterations=True)
+    # VLM responses: planner, stylist, critic iter 1 (requests revision)
+    vlm = _MockVLM(
+        responses=[
+            "Plan description",
+            "Styled description",
+            _REVISION_CRITIQUE,
+        ]
+    )
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
+    _fail_visualizer_at(pipeline, fail_iteration=2)
+
+    result = await pipeline.generate(_default_input())
+
+    # Final output exists and comes from iteration 1
+    assert result.image_path
+    assert Path(result.image_path).exists()
+    assert len(result.iterations) == 1
+    assert result.iterations[0].iteration == 1
+
+    # Metadata flags the rollback
+    rollback = result.metadata["rollback"]
+    assert rollback["rollback_occurred"] is True
+    assert rollback["failed_iteration"] == 2
+    assert rollback["rolled_back_to_iteration"] == 1
+    assert rollback["stage"] == "visualizer"
+    assert "image gen exploded" in rollback["error"]
+
+    # Failure note is persisted alongside iteration artifacts
+    run_dir = Path(settings.output_dir) / pipeline.run_id
+    failure_note = json.loads((run_dir / "iter_2" / "failure.json").read_text())
+    assert failure_note["failed"] is True
+    assert failure_note["rolled_back_to_iteration"] == 1
+
+    # Metadata on disk matches
+    metadata = json.loads((run_dir / "metadata.json").read_text())
+    assert metadata["rollback"]["rollback_occurred"] is True
+
+
+# ── Test: round-1 visualizer failure still raises ────────────────
+
+
+@pytest.mark.asyncio
+async def test_visualizer_failure_round1_still_raises(tmp_path):
+    """With no prior image, a first-round visualizer failure propagates."""
+    settings = _make_settings(tmp_path)
+    vlm = _MockVLM(responses=["Plan description", "Styled description"])
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
+    pipeline.visualizer.run = AsyncMock(side_effect=RuntimeError("image gen exploded"))
+
+    with pytest.raises(RuntimeError, match="image gen exploded"):
+        await pipeline.generate(_default_input())
+
+
+# ── Test: no rollback metadata on a clean run ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_rollback_metadata_on_clean_run(tmp_path):
+    """A run without visualizer failures has no rollback section in metadata."""
+    settings = _make_settings(tmp_path, refinement_iterations=1)
+    vlm = _MockVLM(
+        responses=[
+            "Plan description",
+            "Styled description",
+            _ACCEPT_CRITIQUE,
+        ]
+    )
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
+
+    result = await pipeline.generate(_default_input())
+
+    assert result.image_path
+    assert "rollback" not in result.metadata
+
+
+# ── Test: critic crash mid-loop keeps the current best image ─────
+
+
+@pytest.mark.asyncio
+async def test_critic_crash_mid_loop_keeps_best_image(tmp_path):
+    """A critic exception in round 2 accepts round 2's image instead of failing."""
+    settings = _make_settings(tmp_path)
+    # VLM responses: planner, stylist (critic is patched below)
+    vlm = _MockVLM(responses=["Plan description", "Styled description"])
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
+
+    from paperbanana.core.types import CritiqueResult
+
+    critic_calls = 0
+
+    async def flaky_critic(**kwargs):
+        nonlocal critic_calls
+        critic_calls += 1
+        if critic_calls == 1:
+            return CritiqueResult(
+                critic_suggestions=["Fix arrows"],
+                revised_description="Revised description",
+            )
+        raise RuntimeError("critic exploded")
+
+    pipeline.critic.run = flaky_critic
+
+    result = await pipeline.generate(_default_input())
+
+    # Run completed with both iterations; round 2's image is the final output
+    assert result.image_path
+    assert Path(result.image_path).exists()
+    assert len(result.iterations) == 2
+    assert not result.iterations[1].critique.needs_revision
+    assert "rollback" not in result.metadata
+
+
+# ── Test: continue_run rolls back to the previous run's image ────
+
+
+@pytest.mark.asyncio
+async def test_continue_run_rollback_keeps_previous_runs_image(tmp_path):
+    """First continue iteration failing keeps the resumed run's last image."""
+    settings = _make_settings(tmp_path)
+    vlm = _MockVLM(responses=[])
+    pipeline = PaperBananaPipeline(settings=settings, vlm_client=vlm, image_gen_fn=_MockImageGen())
+
+    # Simulate a previous run with an existing image
+    run_dir = Path(settings.output_dir) / "run_prev"
+    run_dir.mkdir(parents=True)
+    prev_image = run_dir / "iteration_2.png"
+    Image.new("RGB", (128, 128), color=(0, 0, 0)).save(prev_image)
+    resume_state = ResumeState(
+        run_dir=str(run_dir),
+        run_id="run_prev",
+        source_context="Test methodology text",
+        communicative_intent="Test caption",
+        diagram_type=DiagramType.METHODOLOGY,
+        last_description="Previous description",
+        last_iteration=2,
+        last_image_path=str(prev_image),
+    )
+
+    pipeline.visualizer.run = AsyncMock(side_effect=RuntimeError("image gen exploded"))
+
+    result = await pipeline.continue_run(resume_state, additional_iterations=2)
+
+    # Final output exists and was rebuilt from the previous run's image
+    assert result.image_path
+    assert Path(result.image_path).exists()
+    assert len(result.iterations) == 0
+
+    rollback = result.metadata["rollback"]
+    assert rollback["rollback_occurred"] is True
+    assert rollback["failed_iteration"] == 3
+    assert rollback["rolled_back_to_iteration"] == 2
+
+    metadata = json.loads((run_dir / "metadata_continued.json").read_text())
+    assert metadata["rollback"]["rollback_occurred"] is True


### PR DESCRIPTION
Part of #238 (the rollback slice; polish mode tracked separately).

When a refinement round's visualization fails after retries — or returns an unusable empty path — the pipeline now keeps the previous best image instead of killing the run: structured warning + `visualizer_rollback` progress event + `iter_N/failure.json`, with `metadata.rollback` recording `failed_iteration`/`rolled_back_to_iteration`. Implemented once (`_visualize_with_rollback`, extending #146's retry handling) and applied to all three loop copies: `generate`, `continue_run`, `regenerate_from_ir`. Round-1 failures in `generate` still raise (no prior image); `continue_run` round-1 rolls back to the resumed run's last image. Critic-crash handling already existed and is untouched.

5 new tests; suite at 793 passing.