### PR TITLE
feat: corpus-grounded style-guide synthesis (paperbanana guidelines synthesize)

### DIFF
--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -88,6 +88,14 @@ runs_app = typer.Typer(
 )
 app.add_typer(runs_app, name="runs")
 
+# ── Guidelines subcommand group ───────────────────────────────────
+guidelines_app = typer.Typer(
+    name="guidelines",
+    help="Manage style guides (synthesize from reference corpus).",
+    no_args_is_help=True,
+)
+app.add_typer(guidelines_app, name="guidelines")
+
 
 def _require_pdf_dep() -> None:
     """Raise a clean error if PyMuPDF is not installed."""
@@ -3871,6 +3879,199 @@ def references_categories(
     table.add_section()
     table.add_row("[bold]Total[/bold]", f"[bold]{sum(counts.values())}[/bold]")
     console.print(table)
+
+
+# ── Guidelines subcommands ────────────────────────────────────────
+
+
+@guidelines_app.command(name="synthesize")
+def guidelines_synthesize(
+    guide_type: str = typer.Option(
+        "methodology",
+        "--type",
+        help="Guide type to synthesize: methodology or plot",
+    ),
+    venue: Optional[str] = typer.Option(
+        None,
+        "--venue",
+        help=(
+            "Write the guide into the guidelines layout: "
+            "data/guidelines/<venue>/{methodology|plot}_style_guide.md"
+        ),
+    ),
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Explicit output path for the synthesized guide (e.g. ./style_guide.md)",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Overwrite the target guide file if it already exists",
+    ),
+    reference_set: Optional[str] = typer.Option(
+        None,
+        "--reference-set",
+        help="Path to a reference set directory (defaults to the configured/cached set)",
+    ),
+    sample_size: int = typer.Option(
+        50,
+        "--sample-size",
+        help="Maximum number of reference figures to analyze",
+    ),
+    batch_size: int = typer.Option(
+        20,
+        "--batch-size",
+        help="Number of figures per VLM analysis call",
+    ),
+    seed: Optional[int] = typer.Option(
+        None,
+        "--seed",
+        help="Sampling seed for a reproducible corpus subset",
+    ),
+    vlm_provider: Optional[str] = typer.Option(None, "--vlm-provider", help="VLM provider"),
+    vlm_model: Optional[str] = typer.Option(None, "--vlm-model", help="VLM model name"),
+    budget: Optional[float] = typer.Option(
+        None,
+        "--budget",
+        help="Budget cap in USD; synthesis aborts gracefully when exceeded",
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed progress"),
+    config: Optional[str] = typer.Option(None, "--config", help="Path to config YAML file"),
+):
+    """Synthesize a corpus-grounded style guide from reference figures.
+
+    Samples up to --sample-size reference figures, VLM-analyzes them in
+    batches of --batch-size (palettes, layout, line/shape semantics,
+    typography), then merges the analyses into one markdown style guide
+    that preserves multiple accepted options and domain-conditional rules.
+    """
+    from paperbanana.guidelines.synthesis import GUIDE_TYPES, synthesize_style_guide
+
+    if guide_type not in GUIDE_TYPES:
+        console.print(
+            f"[red]Error: --type must be 'methodology' or 'plot'. Got: {guide_type}[/red]"
+        )
+        raise typer.Exit(1)
+    if venue is None and output is None:
+        console.print(
+            "[red]Error: Pass --venue NAME (write into the guidelines layout) "
+            "or --output PATH (e.g. --output ./style_guide.md).[/red]\n"
+            "Built-in guides are never overwritten implicitly."
+        )
+        raise typer.Exit(1)
+    if venue is not None and output is not None:
+        console.print("[red]Error: --venue and --output are mutually exclusive.[/red]")
+        raise typer.Exit(1)
+    if venue is not None and venue.lower() not in ("neurips", "icml", "acl", "ieee"):
+        console.print(
+            f"[red]Error: --venue must be neurips, icml, acl, or ieee. Got: {venue}[/red]\n"
+            "For a custom guide location, use --output PATH and point "
+            "GUIDELINES_PATH (or reference.guidelines_path) at its directory."
+        )
+        raise typer.Exit(1)
+
+    configure_logging(verbose=verbose)
+
+    overrides: dict = {}
+    if vlm_provider:
+        overrides["vlm_provider"] = vlm_provider
+    if vlm_model:
+        overrides["vlm_model"] = vlm_model
+    if reference_set:
+        overrides["reference_set_path"] = reference_set
+
+    if config:
+        settings = Settings.from_yaml(config, **overrides)
+    else:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+        settings = Settings(**overrides)
+
+    if venue is not None:
+        target = Path(settings.guidelines_path) / venue.lower() / f"{guide_type}_style_guide.md"
+    else:
+        target = Path(output)  # type: ignore[arg-type]
+    if target.exists() and not force:
+        console.print(
+            f"[red]Error: {target} already exists.[/red] "
+            "Pass --force to overwrite it, or choose another --output path."
+        )
+        raise typer.Exit(1)
+
+    from paperbanana.core.cost_tracker import CostTracker
+    from paperbanana.providers.registry import ProviderRegistry
+    from paperbanana.reference.store import ReferenceStore
+
+    store = ReferenceStore.from_settings(settings)
+    examples = store.get_all()
+    if not examples:
+        console.print(
+            "[red]Error: No reference examples found.[/red]\n"
+            "Download the reference set with: [bold]paperbanana data download[/bold]"
+        )
+        raise typer.Exit(1)
+
+    try:
+        vlm = ProviderRegistry.create_vlm(settings)
+    except (ValueError, ImportError) as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    cost_tracker: Optional[CostTracker] = None
+    if budget is not None:
+        cost_tracker = CostTracker(budget=budget)
+        if hasattr(vlm, "cost_tracker"):
+            vlm.cost_tracker = cost_tracker
+            cost_tracker.set_agent("guidelines_synthesis")
+
+    console.print(
+        Panel.fit(
+            f"[bold]PaperBanana[/bold] - Synthesizing Style Guide\n\n"
+            f"Type: {guide_type}\n"
+            f"Corpus: {store.count} examples\n"
+            f"Sample: up to {sample_size} figures (batches of {batch_size})\n"
+            f"VLM: {settings.vlm_provider} / {settings.effective_vlm_model}\n"
+            f"Output: {target}",
+            border_style="green",
+        )
+    )
+
+    async def _run() -> str:
+        return await synthesize_style_guide(
+            vlm,
+            examples,
+            guide_type=guide_type,
+            batch_size=batch_size,
+            sample_size=sample_size,
+            seed=seed,
+            prompt_dir=settings.prompt_dir,
+            progress_callback=lambda msg: console.print(f"  [dim]●[/dim] {msg}"),
+        )
+
+    try:
+        guide = asyncio.run(_run())
+    except Exception as e:
+        console.print(f"\n[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(guide, encoding="utf-8")
+    except OSError as e:
+        console.print(
+            f"\n[red]Error: Cannot write to {target} ({e}).[/red]\n"
+            "Re-run with --output pointing to a writable path."
+        )
+        raise typer.Exit(1)
+
+    console.print(f"\n[green]Done![/green] Style guide saved to: [bold]{target}[/bold]")
+    if venue is not None:
+        console.print(f"  Use it with: [bold]--venue {venue.lower()}[/bold]")
+    if cost_tracker is not None:
+        console.print(f"  Cost: [bold]${cost_tracker.total_cost:.4f}[/bold]")
 
 
 @app.command()

--- a/paperbanana/guidelines/synthesis.py
+++ b/paperbanana/guidelines/synthesis.py
@@ -1,0 +1,222 @@
+"""Corpus-grounded style-guide synthesis via VLM map-reduce.
+
+Ports the upstream ``generate_category_style_guide`` pattern: sample up to
+``sample_size`` reference figures, VLM-analyze them in batches of
+``batch_size`` (map step), then merge the batch analyses into a single
+markdown style guide (reduce step). The resulting guide preserves multiple
+accepted design options and domain-conditional styling (hex palettes,
+line/arrow semantics, shape semantics) rather than averaging everything
+into one style.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+import structlog
+
+from paperbanana.core.types import ReferenceExample
+from paperbanana.core.utils import find_prompt_dir, load_image
+from paperbanana.providers.base import VLMProvider
+
+logger = structlog.get_logger()
+
+GUIDE_TYPES = ("methodology", "plot")
+
+_GUIDE_TYPE_LABELS = {
+    "methodology": "methodology / architecture diagrams",
+    "plot": "statistical plots and charts",
+}
+
+
+class StyleGuideSynthesisError(RuntimeError):
+    """Raised when style-guide synthesis cannot proceed (no images, over budget)."""
+
+
+def _check_budget(vlm: VLMProvider, stage: str) -> None:
+    """Abort synthesis if the provider's cost tracker reports budget exhaustion."""
+    tracker = getattr(vlm, "cost_tracker", None)
+    if tracker is not None and tracker.is_over_budget:
+        raise StyleGuideSynthesisError(
+            f"Budget exceeded {stage} "
+            f"(spent ${tracker.total_cost:.4f} of ${tracker.budget:.4f}). "
+            "Increase --budget or reduce --sample-size."
+        )
+
+
+def _load_template(name: str, prompt_dir: str | None) -> str:
+    """Load a prompt template from ``{prompt_dir}/guidelines/{name}.txt``."""
+    base = Path(prompt_dir) if prompt_dir else Path(find_prompt_dir())
+    path = base / "guidelines" / f"{name}.txt"
+    if not path.exists():
+        raise FileNotFoundError(f"Prompt template not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _fill(template: str, **values: str) -> str:
+    """Substitute ``{placeholder}`` tokens without str.format brace pitfalls.
+
+    Batch analyses and captions routinely contain literal braces (LaTeX,
+    JSON snippets), so ``str.format`` would raise. Plain replacement keeps
+    the established ``{placeholder}`` template convention while staying
+    robust to arbitrary corpus text.
+    """
+    for key, value in values.items():
+        template = template.replace("{" + key + "}", value)
+    return template
+
+
+def sample_examples(
+    examples: Sequence[ReferenceExample],
+    sample_size: int,
+    seed: int | None = None,
+) -> list[ReferenceExample]:
+    """Deterministically sample up to ``sample_size`` examples with existing images.
+
+    Args:
+        examples: Candidate reference examples.
+        sample_size: Maximum number of examples to keep.
+        seed: Seed for ``random.Random`` — same seed and corpus yield the
+            same sample.
+
+    Returns:
+        Sampled examples in stable (corpus) order.
+    """
+    eligible = [e for e in examples if e.image_path and Path(e.image_path).exists()]
+    if len(eligible) <= sample_size:
+        return eligible
+    rng = random.Random(seed)
+    sampled = rng.sample(eligible, sample_size)
+    # Preserve corpus order so batches are stable and reviewable.
+    order = {id(e): i for i, e in enumerate(eligible)}
+    sampled.sort(key=lambda e: order[id(e)])
+    return sampled
+
+
+def _figure_listing(batch: Sequence[ReferenceExample]) -> str:
+    """Describe the images attached to a batch call, in attachment order."""
+    lines = []
+    for i, example in enumerate(batch, start=1):
+        caption = example.caption.strip().replace("\n", " ")
+        if len(caption) > 200:
+            caption = caption[:197] + "..."
+        category = example.category or "uncategorized"
+        lines.append(f"{i}. [{example.id}] category: {category} — {caption}")
+    return "\n".join(lines)
+
+
+async def synthesize_style_guide(
+    vlm: VLMProvider,
+    examples: Sequence[ReferenceExample],
+    *,
+    guide_type: str = "methodology",
+    batch_size: int = 20,
+    sample_size: int = 50,
+    seed: int | None = None,
+    prompt_dir: str | None = None,
+    progress_callback: Callable[[str], None] | None = None,
+) -> str:
+    """Synthesize a markdown style guide from a reference figure corpus.
+
+    Map-reduce over the corpus: each batch of figures is analyzed by the VLM
+    (palettes, layout, line/shape semantics, typography, per-category
+    observations), then a single reduce call merges the batch analyses into
+    one guide that preserves multiple accepted options and
+    domain-conditional rules.
+
+    Args:
+        vlm: VLM provider used for both map and reduce calls.
+        examples: Candidate reference examples (only ones whose image file
+            exists are used).
+        guide_type: ``"methodology"`` or ``"plot"``.
+        batch_size: Number of figures per map call.
+        sample_size: Maximum number of figures analyzed overall.
+        seed: Sampling seed for reproducible corpus subsets.
+        prompt_dir: Override for the prompts directory (defaults to
+            auto-discovery via :func:`find_prompt_dir`).
+        progress_callback: Optional ``callback(message)`` for console progress.
+
+    Returns:
+        The synthesized style guide as markdown text.
+
+    Raises:
+        ValueError: On invalid ``guide_type``, ``batch_size`` or ``sample_size``.
+        StyleGuideSynthesisError: If no examples have images, or the budget
+            cap is exhausted mid-run.
+    """
+    if guide_type not in GUIDE_TYPES:
+        raise ValueError(f"guide_type must be one of {GUIDE_TYPES}, got: {guide_type}")
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got: {batch_size}")
+    if sample_size < 1:
+        raise ValueError(f"sample_size must be >= 1, got: {sample_size}")
+
+    def _progress(message: str) -> None:
+        if progress_callback is not None:
+            progress_callback(message)
+
+    sampled = sample_examples(examples, sample_size, seed=seed)
+    if not sampled:
+        raise StyleGuideSynthesisError(
+            "No reference examples with existing image files were found. "
+            "Run `paperbanana data download` or point --reference-set at a "
+            "directory with an index.json and images."
+        )
+
+    guide_type_label = _GUIDE_TYPE_LABELS[guide_type]
+    batch_template = _load_template("batch_analysis", prompt_dir)
+    reduce_template = _load_template("synthesize", prompt_dir)
+
+    batches = [sampled[i : i + batch_size] for i in range(0, len(sampled), batch_size)]
+    logger.info(
+        "Synthesizing style guide",
+        guide_type=guide_type,
+        figures=len(sampled),
+        batches=len(batches),
+        batch_size=batch_size,
+    )
+    _progress(f"Analyzing {len(sampled)} reference figures in {len(batches)} batch(es)")
+
+    # Map step: one VLM call per batch, with the batch's images attached.
+    analyses: list[str] = []
+    for batch_num, batch in enumerate(batches, start=1):
+        _check_budget(vlm, f"before batch {batch_num}/{len(batches)}")
+        images = [load_image(e.image_path) for e in batch]
+        prompt = _fill(
+            batch_template,
+            guide_type_label=guide_type_label,
+            figure_count=str(len(batch)),
+            figure_listing=_figure_listing(batch),
+        )
+        _progress(f"Batch {batch_num}/{len(batches)}: analyzing {len(batch)} figures")
+        analysis = await vlm.generate(
+            prompt=prompt,
+            images=images,
+            temperature=0.3,
+            max_tokens=8192,
+        )
+        analyses.append(analysis.strip())
+
+    # Reduce step: merge all batch analyses into the final guide.
+    _check_budget(vlm, "before final synthesis")
+    _progress("Synthesizing final style guide from batch analyses")
+    joined = "\n\n".join(
+        f"### Batch {i} analysis\n\n{analysis}" for i, analysis in enumerate(analyses, start=1)
+    )
+    reduce_prompt = _fill(
+        reduce_template,
+        guide_type_label=guide_type_label,
+        batch_count=str(len(analyses)),
+        total_figures=str(len(sampled)),
+        batch_analyses=joined,
+    )
+    guide = await vlm.generate(
+        prompt=reduce_prompt,
+        temperature=0.3,
+        max_tokens=8192,
+    )
+
+    logger.info("Style guide synthesized", length=len(guide))
+    return guide.strip() + "\n"

--- a/prompts/guidelines/batch_analysis.txt
+++ b/prompts/guidelines/batch_analysis.txt
@@ -1,0 +1,19 @@
+You are a Lead Visual Designer auditing figures from top-tier AI conference papers (NeurIPS, ICML, ICLR, CVPR, ACL). You are building a corpus-grounded style guide for {guide_type_label}.
+
+You are given {figure_count} published reference figures (attached as images, in order). For each visual dimension below, record the CONCRETE design decisions you observe across the batch. Report what the corpus actually does — including when different figures make different, equally valid choices. Do NOT average distinct styles into one; enumerate each accepted variant and roughly how common it is in this batch (e.g., "dominant", "~1/3 of figures", "rare").
+
+## Figures in this batch
+{figure_listing}
+
+## Dimensions to analyze
+
+1. **Color palettes**: Exact or closely estimated hex codes for backgrounds, fills, borders, accents (e.g., #E8F0FE pale blue fill with #4285F4 border). Group recurring palettes. Note saturation/opacity conventions and which colors carry meaning (e.g., warm = trainable, cool = frozen, red = loss/error).
+2. **Layout & composition**: Flow direction, grid alignment, grouping/zoning strategies, macro-micro patterns, whitespace usage, multi-panel arrangements, aspect-ratio tendencies.
+3. **Line & arrow semantics**: What solid vs dashed vs dotted lines mean; arrowhead styles; straight vs orthogonal/elbow vs curved routing and when each is used; line colors/weights; operators or labels placed on lines.
+4. **Shape semantics**: Which shapes encode which concepts (rounded rectangles for processes, cylinders for storage, 3D stacks for tensors, circles for operations, etc.); border styles (solid vs dashed) and what they signal; container/grouping shapes.
+5. **Typography & icons**: Font families (serif vs sans-serif), where bold/italics are used, label sizing hierarchy, math notation styling, icon vocabulary and conventional meanings (e.g., snowflake = frozen, flame = trainable).
+6. **Per-category observations**: Using the category labels in the figure listing, note styling that is conditional on the paper domain (e.g., agent/LLM figures use cartoon icons and chat bubbles; vision figures use frustums and RGB coding; theory figures stay minimalist/grayscale).
+
+## Output format
+
+Markdown notes with one `##` section per dimension above (1-6). Under each section, use bullet points with concrete values (hex codes, shape names, line styles) and prevalence estimates. Reference figures by their listing number where helpful. Do not include any conversational preamble.

--- a/prompts/guidelines/synthesize.txt
+++ b/prompts/guidelines/synthesize.txt
@@ -1,0 +1,20 @@
+You are a Lead Visual Designer writing the definitive style guide for {guide_type_label} at top-tier AI conferences. Below are {batch_count} batch analyses produced by auditing {total_figures} published reference figures.
+
+Merge these analyses into ONE complete, self-contained markdown style guide that a designer (or an AI illustration agent) can follow without seeing the original figures.
+
+## Critical requirements
+
+1. **Preserve plurality**: The corpus contains MULTIPLE accepted styles, not one. When the batch analyses report distinct valid options (e.g., three different background palette families, or both orthogonal and curved arrow routing), the guide MUST present each as a named option with guidance on when to choose it. NEVER average competing styles into a single bland compromise.
+2. **Keep it concrete**: Carry forward exact hex codes, named palettes, shape names, line styles, and font conventions from the analyses. Replace vague advice ("use pleasant colors") with corpus-grounded specifics ("pale blue #E8F0FE fill with #4285F4 border, ~15% opacity zones").
+3. **Preserve semantics**: Document what visual choices MEAN, not just how they look — line semantics (solid = data flow, dashed = gradients/auxiliary), shape semantics (cylinder = storage, rounded rectangle = process), color semantics (warm = trainable, cool = frozen), and icon vocabulary.
+4. **Domain-conditional rules**: Include a dedicated section of per-domain styling rules derived from the per-category observations (e.g., "AGENT/LLM papers: illustrative, cartoony, chat bubbles" vs "THEORY papers: minimalist, grayscale plus one accent"). These rules must stay conditional on the paper's domain — do not promote one domain's style to a universal rule.
+5. **Resolve conflicts honestly**: Where batch analyses disagree, prefer the option reported as more prevalent, but keep genuinely common minority variants as alternatives. Drop one-off outliers.
+6. **Note pitfalls**: Include a short "Common Pitfalls" section for anti-patterns implied by the corpus (e.g., harsh saturated backgrounds, mixed font families, ambiguous arrow styles).
+
+## Output structure
+
+A markdown document with: a title; a short overview of the prevailing look; detailed sections for Color Palettes, Layout & Composition, Lines & Arrows, Shapes & Containers, Typography & Icons (each listing the accepted options); a Domain-Specific Styles section; and a Common Pitfalls section. Output ONLY the markdown guide — no conversational preamble or commentary about the synthesis process.
+
+## Batch analyses
+
+{batch_analyses}

--- a/tests/test_guidelines_synthesis.py
+++ b/tests/test_guidelines_synthesis.py
@@ -1,0 +1,234 @@
+"""Tests for corpus-grounded style-guide synthesis."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from typer.testing import CliRunner
+
+from paperbanana.cli import app
+from paperbanana.core.types import ReferenceExample
+from paperbanana.guidelines.synthesis import (
+    StyleGuideSynthesisError,
+    sample_examples,
+    synthesize_style_guide,
+)
+
+runner = CliRunner()
+
+
+class RecordingVLM:
+    """Mock VLM that records every generate() call."""
+
+    name = "mock"
+    model_name = "mock-model"
+    cost_tracker = None
+
+    def __init__(self, batch_response: str = "BATCH ANALYSIS", reduce_response: str = "# GUIDE"):
+        self.calls: list[dict] = []
+        self._batch_response = batch_response
+        self._reduce_response = reduce_response
+
+    async def generate(
+        self,
+        prompt,
+        images=None,
+        system_prompt=None,
+        temperature=1.0,
+        max_tokens=4096,
+        response_format=None,
+    ):
+        self.calls.append({"prompt": prompt, "images": images})
+        if images:
+            return f"{self._batch_response} {len(self.calls)}"
+        return self._reduce_response
+
+    def is_available(self):
+        return True
+
+
+def _make_examples(tmp_path: Path, n: int, with_images: bool = True) -> list[ReferenceExample]:
+    examples = []
+    for i in range(n):
+        image_path = tmp_path / f"ref_{i:03d}.png"
+        if with_images:
+            Image.new("RGB", (4, 4), color=(200, 220, 240)).save(image_path)
+        examples.append(
+            ReferenceExample(
+                id=f"ref_{i:03d}",
+                source_context=f"Context {i}",
+                caption=f"Caption {i}",
+                image_path=str(image_path),
+                category="agents_llm" if i % 2 == 0 else "vision_perception",
+            )
+        )
+    return examples
+
+
+# ── Sampling ──────────────────────────────────────────────────────
+
+
+def test_sampling_is_deterministic_with_seed(tmp_path):
+    examples = _make_examples(tmp_path, 60)
+    first = sample_examples(examples, sample_size=50, seed=42)
+    second = sample_examples(examples, sample_size=50, seed=42)
+    assert [e.id for e in first] == [e.id for e in second]
+    assert len(first) == 50
+
+
+def test_sampling_returns_all_when_corpus_small(tmp_path):
+    examples = _make_examples(tmp_path, 10)
+    sampled = sample_examples(examples, sample_size=50, seed=1)
+    assert [e.id for e in sampled] == [e.id for e in examples]
+
+
+def test_sampling_excludes_missing_images(tmp_path):
+    examples = _make_examples(tmp_path, 5)
+    missing = _make_examples(tmp_path / "nowhere", 3, with_images=False)
+    sampled = sample_examples(examples + missing, sample_size=50, seed=1)
+    assert len(sampled) == 5
+    assert all(Path(e.image_path).exists() for e in sampled)
+
+
+# ── Map-reduce synthesis ─────────────────────────────────────────
+
+
+async def test_batching_math_and_reduce_output(tmp_path):
+    """45 examples with batch_size 20 -> 3 map calls + 1 reduce call."""
+    examples = _make_examples(tmp_path, 45)
+    vlm = RecordingVLM(reduce_response="# Final Style Guide")
+
+    result = await synthesize_style_guide(
+        vlm,
+        examples,
+        guide_type="methodology",
+        batch_size=20,
+        sample_size=50,
+        seed=7,
+    )
+
+    assert len(vlm.calls) == 4
+    map_calls, reduce_call = vlm.calls[:3], vlm.calls[3]
+    assert [len(c["images"]) for c in map_calls] == [20, 20, 5]
+    assert reduce_call["images"] is None
+    # The final output is the reduce result, not a map result.
+    assert result == "# Final Style Guide\n"
+    # The reduce prompt embeds every batch analysis.
+    for i in range(1, 4):
+        assert f"BATCH ANALYSIS {i}" in reduce_call["prompt"]
+    assert "45" in reduce_call["prompt"]  # total figures
+
+
+async def test_map_prompt_lists_figures_and_categories(tmp_path):
+    examples = _make_examples(tmp_path, 3)
+    vlm = RecordingVLM()
+
+    await synthesize_style_guide(vlm, examples, guide_type="plot", batch_size=20)
+
+    map_prompt = vlm.calls[0]["prompt"]
+    assert "ref_000" in map_prompt
+    assert "agents_llm" in map_prompt
+    assert "statistical plots" in map_prompt
+    assert "{figure_listing}" not in map_prompt  # placeholder substituted
+
+
+async def test_sample_size_caps_figures_analyzed(tmp_path):
+    examples = _make_examples(tmp_path, 30)
+    vlm = RecordingVLM()
+
+    await synthesize_style_guide(vlm, examples, batch_size=20, sample_size=10, seed=3)
+
+    assert len(vlm.calls) == 2  # one map batch of 10 + one reduce
+    assert len(vlm.calls[0]["images"]) == 10
+
+
+async def test_no_examples_with_images_raises(tmp_path):
+    missing = _make_examples(tmp_path / "nowhere", 3, with_images=False)
+    vlm = RecordingVLM()
+
+    with pytest.raises(StyleGuideSynthesisError, match="No reference examples"):
+        await synthesize_style_guide(vlm, missing)
+    assert vlm.calls == []
+
+
+async def test_invalid_guide_type_raises(tmp_path):
+    examples = _make_examples(tmp_path, 1)
+    with pytest.raises(ValueError, match="guide_type"):
+        await synthesize_style_guide(RecordingVLM(), examples, guide_type="poster")
+
+
+async def test_progress_callback_invoked(tmp_path):
+    examples = _make_examples(tmp_path, 3)
+    messages: list[str] = []
+
+    await synthesize_style_guide(
+        RecordingVLM(),
+        examples,
+        batch_size=2,
+        progress_callback=messages.append,
+    )
+
+    assert any("2 batch(es)" in m for m in messages)
+    assert any("Batch 1/2" in m for m in messages)
+    assert any("final style guide" in m for m in messages)
+
+
+# ── CLI smoke tests (network-free) ───────────────────────────────
+
+
+def test_cli_synthesize_rejects_invalid_type():
+    result = runner.invoke(
+        app,
+        ["guidelines", "synthesize", "--type", "poster", "--output", "x.md"],
+    )
+    assert result.exit_code == 1
+    assert "methodology" in result.output
+
+
+def test_cli_synthesize_refuses_without_output_or_venue():
+    result = runner.invoke(app, ["guidelines", "synthesize", "--type", "methodology"])
+    assert result.exit_code == 1
+    assert "--venue" in result.output
+    assert "--output" in result.output
+
+
+def test_cli_synthesize_rejects_venue_and_output_together(tmp_path):
+    result = runner.invoke(
+        app,
+        [
+            "guidelines",
+            "synthesize",
+            "--venue",
+            "icml",
+            "--output",
+            str(tmp_path / "guide.md"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.output
+
+
+def test_cli_synthesize_rejects_unknown_venue():
+    result = runner.invoke(app, ["guidelines", "synthesize", "--venue", "bogusconf"])
+    assert result.exit_code == 1
+    assert "neurips, icml, acl, or ieee" in result.output
+
+
+def test_cli_synthesize_refuses_existing_output_without_force(tmp_path):
+    existing = tmp_path / "guide.md"
+    existing.write_text("existing guide")
+    result = runner.invoke(
+        app,
+        ["guidelines", "synthesize", "--output", str(existing)],
+    )
+    assert result.exit_code == 1
+    assert "already exists" in result.output
+    assert existing.read_text() == "existing guide"
+
+
+def test_cli_guidelines_help_lists_synthesize():
+    result = runner.invoke(app, ["guidelines", "--help"], env={"NO_COLOR": "1", "TERM": "dumb"})
+    assert result.exit_code == 0
+    assert "synthesize" in result.output


### PR DESCRIPTION
Fixes #236 — ports the upstream map-reduce style-guide generator onto our reference store and venue system:

- `paperbanana/guidelines/synthesis.py`: deterministic sampling (seeded, capped at `--sample-size`), per-batch VLM analysis with images attached (hex palettes, layout, line/arrow semantics, shape semantics, typography, per-category observations with prevalence estimates), one reduce call merging into a final markdown guide. Prompts demand **plurality preservation** — multiple named style options with when-to-choose guidance and domain-conditional rules, never a single averaged style.
- Output structure mirrors the existing handwritten guides so synthesized ones drop into the loader unchanged.
- `paperbanana guidelines synthesize --type {methodology,plot}` with `--venue` (writes into `data/guidelines/<venue>/`) or `--output`; refuses to overwrite without `--force`; `--budget` wires the existing CostTracker guard through every VLM call.
- Safe `{placeholder}` substitution (literal braces in captions/LaTeX won't crash formatting).
- 15 network-free tests (batching math, seed determinism, CLI refusals); suite at 809 passing.