### PR TITLE
feat: multi-candidate generation with --num-candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ paperbanana generate \
 | `--caption` | `-c` | Figure caption / communicative intent (required for new runs) |
 | `--output` | `-o` | Output image path (default: auto-generated in `outputs/`) |
 | `--iterations` | `-n` | Number of Visualizer-Critic refinement rounds (default: 3) |
+| `--num-candidates` | `-k` | Generate N candidate images in parallel, 1-8 (default: 1). Planning runs once; refinement fans out per candidate with seed offsets. Outputs land in `candidates/cand_<i>/`; the run-root `final_output` is candidate 1. Cost estimates and `--budget` account for the fan-out |
 | `--auto` | | Loop until critic is satisfied (with `--max-iterations` safety cap) |
 | `--max-iterations` | | Safety cap for `--auto` mode (default: 30) |
 | `--optimize` | | Preprocess inputs with parallel context enrichment and caption sharpening |

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -306,6 +306,17 @@ def generate(
         "--budget",
         help="Budget cap in USD; pipeline aborts gracefully when exceeded",
     ),
+    num_candidates: Optional[int] = typer.Option(
+        None,
+        "--num-candidates",
+        "-k",
+        min=1,
+        max=8,
+        help=(
+            "Generate N candidate images in parallel (1-8). Planning runs once; "
+            "the Visualizer-Critic refinement fans out per candidate"
+        ),
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -506,6 +517,8 @@ def generate(
         overrides["seed"] = seed
     if budget is not None:
         overrides["budget_usd"] = budget
+    if num_candidates is not None:
+        overrides["num_candidates"] = num_candidates
     if venue:
         overrides["venue"] = venue
     if vector_export is not None:
@@ -720,6 +733,10 @@ def generate(
             f"Image: {settings.image_provider} / {settings.effective_image_model}",
             f"Iterations: {iter_est}",
             f"Optimize: {'yes' if settings.optimize_inputs else 'no'}",
+        ]
+        if settings.num_candidates > 1:
+            lines.append(f"Candidates: {settings.num_candidates} (parallel)")
+        lines += [
             "",
             f"Estimated VLM calls: {estimate['vlm_calls']}",
             f"Estimated image calls: {estimate['image_calls']}",
@@ -757,13 +774,16 @@ def generate(
     else:
         iter_label = str(settings.refinement_iterations)
 
+    candidates_label = (
+        f"\nCandidates: {settings.num_candidates} (parallel)" if settings.num_candidates > 1 else ""
+    )
     if not progress_json:
         console.print(
             Panel.fit(
                 f"[bold]PaperBanana[/bold] - Generating Methodology Diagram\n\n"
                 f"VLM: {settings.vlm_provider} / {settings.effective_vlm_model}\n"
                 f"Image: {settings.image_provider} / {settings.effective_image_model}\n"
-                f"Iterations: {iter_label}",
+                f"Iterations: {iter_label}{candidates_label}",
                 border_style="blue",
             )
         )
@@ -848,9 +868,10 @@ def generate(
                         else " [green]✓[/green]"
                     )
             elif event.stage == PipelineProgressStage.VISUALIZER_START:
-                if event.iteration == 1:
-                    console.print("[bold]Phase 2[/bold] — Iterative Refinement")
                 extra = event.extra or {}
+                candidate = extra.get("candidate")
+                if event.iteration == 1 and candidate in (None, 1):
+                    console.print("[bold]Phase 2[/bold] — Iterative Refinement")
                 total = extra.get("total_iterations", 0)
                 if event.iteration and total:
                     label = f"{event.iteration}/{total}"
@@ -858,6 +879,8 @@ def generate(
                     label = str(event.iteration or "")
                 if settings.auto_refine:
                     label += " (auto)"
+                if candidate is not None:
+                    label = f"cand {candidate} · {label}"
                 console.print(f"  [dim]●[/dim] Generating image [{label}]...", end="")
             elif event.stage == PipelineProgressStage.VISUALIZER_END:
                 console.print(
@@ -919,6 +942,14 @@ def generate(
         f" · {len(result.iterations)} iterations[/dim]\n"
     )
     console.print(f"  Output: [bold]{result.image_path}[/bold]")
+    for cand in result.metadata.get("candidates") or []:
+        if cand.get("error"):
+            console.print(
+                f"  Candidate {cand['index']}: [yellow]failed[/yellow] "
+                f"[dim]{str(cand['error'])[:120]}[/dim]"
+            )
+        elif cand.get("image_path"):
+            console.print(f"  Candidate {cand['index']}: {cand['image_path']}")
     if result.tikz_path:
         console.print(f"  TikZ:   [bold]{result.tikz_path}[/bold]")
     elif settings.export_tikz:

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -82,6 +82,12 @@ class Settings(BaseSettings):
     exemplar_retrieval_max_retries: int = 2
     venue: Venue = "neurips"
     vector_export: VectorExportMode = "none"
+    num_candidates: int = Field(
+        default=1,
+        ge=1,
+        le=8,
+        description="Number of parallel Phase-2 candidate branches (1-8)",
+    )
 
     # Reference settings
     reference_set_path: str = "data/reference_sets"
@@ -309,6 +315,7 @@ def _flatten_yaml(config: dict, prefix: str = "") -> dict:
         "pipeline.optimize_inputs": "optimize_inputs",
         "pipeline.output_resolution": "output_resolution",
         "pipeline.seed": "seed",
+        "pipeline.num_candidates": "num_candidates",
         "pipeline.exemplar_retrieval_enabled": "exemplar_retrieval_enabled",
         "pipeline.exemplar_retrieval_endpoint": "exemplar_retrieval_endpoint",
         "pipeline.exemplar_retrieval_mode": "exemplar_retrieval_mode",

--- a/paperbanana/core/cost_estimator.py
+++ b/paperbanana/core/cost_estimator.py
@@ -41,6 +41,8 @@ def estimate_cost(
     else:
         iterations = settings.refinement_iterations
 
+    num_candidates = max(1, getattr(settings, "num_candidates", 1))
+
     # Count expected API calls
     vlm_calls = 0
     image_calls = 0
@@ -75,10 +77,12 @@ def estimate_cost(
     if diagram_type == DiagramType.METHODOLOGY and ve != "none":
         breakdown["structurer"] = _vlm_cost("structurer")
 
-    # Phase 2: Iterative refinement
+    # Phase 2: Iterative refinement. Multi-candidate fan-out runs Phase 2
+    # once per candidate (Phase 1 planning is shared), so visualizer and
+    # critic costs scale by num_candidates.
     vis_total = 0.0
     critic_total = 0.0
-    for _ in range(iterations):
+    for _ in range(iterations * num_candidates):
         if diagram_type == DiagramType.STATISTICAL_PLOT:
             vis_total += _vlm_cost("visualizer_vlm")
         else:
@@ -98,11 +102,17 @@ def estimate_cost(
             f"Auto-refine: estimated for max {iterations} iterations; "
             "actual cost may be lower if critic is satisfied early"
         )
+    if num_candidates > 1:
+        notes.append(
+            f"Multi-candidate: visualizer/critic costs scaled by "
+            f"{num_candidates} parallel candidates"
+        )
 
     return {
         "estimated_total_usd": round(total, 6),
         "vlm_calls": vlm_calls,
         "image_calls": image_calls,
+        "num_candidates": num_candidates,
         "breakdown_by_agent": {k: round(v, 6) for k, v in breakdown.items()},
         "pricing_note": "; ".join(notes) if notes else None,
     }

--- a/paperbanana/core/pipeline.py
+++ b/paperbanana/core/pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import time
 from pathlib import Path
@@ -230,6 +231,7 @@ class PaperBananaPipeline:
 
         # Initialize agents
         prompt_dir = self._find_prompt_dir()
+        self._prompt_dir = prompt_dir
         self.optimizer = InputOptimizerAgent(
             self._vlm, prompt_dir=prompt_dir, prompt_recorder=self._prompt_recorder
         )
@@ -413,6 +415,7 @@ class PaperBananaPipeline:
         iteration: int,
         rollback_to: Optional[int],
         run_dir: Path,
+        visualizer: Optional[VisualizerAgent] = None,
         **visualizer_kwargs: Any,
     ) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
         """Run the visualizer for one refinement iteration, rolling back on failure.
@@ -423,11 +426,16 @@ class PaperBananaPipeline:
         returned so the caller stops the loop and keeps the previous best
         image as the final output.  Without a prior image (first round) the
         exception propagates, preserving existing error behavior.
+
+        ``visualizer`` selects the agent instance to run (defaults to
+        ``self.visualizer``); multi-candidate fan-out passes a per-branch
+        instance so concurrent branches never share output paths.
         """
+        visualizer = visualizer or self.visualizer
         try:
             image_path = await _call_with_retry(
                 "visualizer",
-                self.visualizer.run,
+                visualizer.run,
                 iteration=iteration,
                 **visualizer_kwargs,
             )
@@ -467,6 +475,376 @@ class PaperBananaPipeline:
                 )
             return None, rollback_info
         return image_path, None
+
+    async def _run_refinement_branch(
+        self,
+        *,
+        input: GenerationInput,
+        initial_description: str,
+        effective_ratio: Optional[str],
+        vector_formats: Optional[list[str]],
+        total_iters: int,
+        run_dir: Path,
+        visualizer: VisualizerAgent,
+        seed: Optional[int],
+        candidate_index: Optional[int] = None,
+        progress_callback: Optional[Callable[[PipelineProgressEvent], None]] = None,
+    ) -> Dict[str, Any]:
+        """Run one Phase-2 Visualizer<->Critic refinement loop.
+
+        Used both for the standard single run (``candidate_index=None``,
+        ``run_dir=self._run_dir``, ``visualizer=self.visualizer``) and for
+        each branch of multi-candidate fan-out (per-candidate run dir,
+        per-branch ``VisualizerAgent`` instance, per-candidate seed).
+
+        The shared ``CostTracker`` is safe to accumulate from concurrent
+        branches (single event loop, synchronous appends), so the budget
+        guard stops every branch at its next checkpoint once exceeded.
+        Per-agent cost attribution may interleave across branches; totals
+        and budget enforcement are unaffected.
+        """
+
+        def _extra(**payload: Any) -> Dict[str, Any]:
+            if candidate_index is not None:
+                payload["candidate"] = candidate_index
+            return payload
+
+        current_description = initial_description
+        iterations: list[IterationRecord] = []
+        iteration_timings: list[dict[str, float | int]] = []
+        rollback_info: Optional[Dict[str, Any]] = None
+
+        # Check budget after pre-iteration phases (retriever, planner, stylist)
+        budget_exceeded = self._check_budget("after planning phases")
+
+        for i in range(total_iters):
+            if budget_exceeded:
+                break
+
+            iter_index = i + 1
+            logger.info(
+                f"Phase 2: Iteration {iter_index}/{total_iters}"
+                + (" (auto)" if self.settings.auto_refine else "")
+                + (f" [candidate {candidate_index}]" if candidate_index is not None else "")
+            )
+            self._emit_progress(
+                "iteration_started",
+                **_extra(
+                    iteration=iter_index,
+                    total_iterations=total_iters,
+                    auto=self.settings.auto_refine,
+                ),
+            )
+
+            # Step 4: Visualizer — generate image
+            if self._cost_tracker:
+                self._cost_tracker.set_agent("visualizer")
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.VISUALIZER_START,
+                    message=f"Generating image (iteration {iter_index}/{total_iters})",
+                    iteration=iter_index,
+                    extra=_extra(total_iterations=total_iters),
+                ),
+            )
+            visualizer_start = time.perf_counter()
+            image_path, rollback_info = await self._visualize_with_rollback(
+                iteration=iter_index,
+                rollback_to=iterations[-1].iteration if iterations else None,
+                run_dir=run_dir,
+                visualizer=visualizer,
+                description=current_description,
+                diagram_type=input.diagram_type,
+                raw_data=input.raw_data,
+                seed=seed,
+                aspect_ratio=effective_ratio,
+                vector_formats=vector_formats,
+            )
+            visualizer_seconds = time.perf_counter() - visualizer_start
+            if image_path is None:
+                _emit_progress(
+                    progress_callback,
+                    PipelineProgressEvent(
+                        stage=PipelineProgressStage.VISUALIZER_END,
+                        message=(
+                            f"Visualizer iteration {iter_index} failed; keeping previous best image"
+                        ),
+                        seconds=visualizer_seconds,
+                        iteration=iter_index,
+                        extra=_extra(rollback=True, error=rollback_info["error"]),
+                    ),
+                )
+                break
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.VISUALIZER_END,
+                    message=f"Visualizer iteration {iter_index} done",
+                    seconds=visualizer_seconds,
+                    iteration=iter_index,
+                    extra=_extra(),
+                ),
+            )
+            logger.info(
+                f"[Visualizer] Iteration {iter_index}/{total_iters} done",
+                seconds=round(visualizer_seconds, 1),
+            )
+            self._emit_progress(
+                "visualizer_completed",
+                **_extra(iteration=iter_index, seconds=round(visualizer_seconds, 1)),
+            )
+
+            # Step 5: Critic — evaluate and provide feedback
+            if self._cost_tracker:
+                self._cost_tracker.set_agent("critic")
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.CRITIC_START,
+                    message="Critic reviewing",
+                    iteration=iter_index,
+                    extra=_extra(),
+                ),
+            )
+            critic_start = time.perf_counter()
+            try:
+                critique = await _call_with_retry(
+                    "critic",
+                    self.critic.run,
+                    image_path=image_path,
+                    description=current_description,
+                    source_context=input.source_context,
+                    caption=input.communicative_intent,
+                    diagram_type=input.diagram_type,
+                )
+            except Exception:
+                logger.warning(
+                    "Critic failed after retries, accepting current image",
+                    iteration=iter_index,
+                    exc_info=True,
+                )
+                critique = CritiqueResult()
+            critic_seconds = time.perf_counter() - critic_start
+            _emit_progress(
+                progress_callback,
+                PipelineProgressEvent(
+                    stage=PipelineProgressStage.CRITIC_END,
+                    message="Critic done",
+                    seconds=critic_seconds,
+                    iteration=iter_index,
+                    extra=_extra(
+                        needs_revision=critique.needs_revision,
+                        summary=critique.summary,
+                        critic_suggestions=critique.critic_suggestions[:3],
+                    ),
+                ),
+            )
+            self._emit_progress(
+                "critic_completed",
+                **_extra(
+                    iteration=iter_index,
+                    seconds=round(critic_seconds, 1),
+                    needs_revision=critique.needs_revision,
+                ),
+            )
+
+            iteration_record = IterationRecord(
+                iteration=iter_index,
+                description=current_description,
+                image_path=image_path,
+                critique=critique,
+            )
+            iteration_timings.append(
+                {
+                    "iteration": iter_index,
+                    "visualizer_seconds": visualizer_seconds,
+                    "critic_seconds": critic_seconds,
+                }
+            )
+            iterations.append(iteration_record)
+
+            # Save iteration artifacts
+            if self.settings.save_iterations:
+                iter_dir = ensure_dir(run_dir / f"iter_{iter_index}")
+                save_json(
+                    {
+                        "description": current_description,
+                        "critique": critique.model_dump(),
+                    },
+                    iter_dir / "details.json",
+                )
+
+            # Check if revision needed
+            if critique.needs_revision and critique.revised_description:
+                logger.info(
+                    "Revision needed",
+                    iteration=iter_index,
+                    summary=critique.summary,
+                )
+                current_description = critique.revised_description
+            else:
+                logger.info(
+                    "No further revision needed",
+                    iteration=iter_index,
+                    summary=critique.summary,
+                )
+                self._emit_progress(
+                    "iteration_completed",
+                    **_extra(
+                        iteration=iter_index,
+                        total_iterations=len(iterations),
+                        needs_revision=critique.needs_revision,
+                    ),
+                )
+                break
+
+            self._emit_progress(
+                "iteration_completed",
+                **_extra(
+                    iteration=iter_index,
+                    total_iterations=len(iterations),
+                    needs_revision=critique.needs_revision,
+                ),
+            )
+
+            # Check budget between iterations
+            if self._check_budget("between iterations", iteration=iter_index):
+                budget_exceeded = True
+                break
+
+        return {
+            "iterations": iterations,
+            "iteration_timings": iteration_timings,
+            "rollback_info": rollback_info,
+            "final_description": current_description,
+            "budget_exceeded": budget_exceeded,
+            "vector_paths": dict(visualizer._last_vector_paths),
+        }
+
+    async def _fan_out_candidates(
+        self,
+        *,
+        input: GenerationInput,
+        initial_description: str,
+        effective_ratio: Optional[str],
+        vector_formats: Optional[list[str]],
+        total_iters: int,
+        num_candidates: int,
+        progress_callback: Optional[Callable[[PipelineProgressEvent], None]] = None,
+    ) -> tuple[Dict[str, Any], int, list[Dict[str, Any]]]:
+        """Run Phase 2 ``num_candidates`` times in parallel.
+
+        Each branch gets its own output directory
+        (``<run_dir>/candidates/cand_<i>``), its own ``VisualizerAgent``
+        instance (the agent keeps per-run mutable state: ``output_dir`` and
+        ``_last_vector_paths``), and a deterministic seed offset
+        (``settings.seed + i - 1`` when a seed is set, else ``None``).
+
+        A failed branch does not affect the others; if every branch fails,
+        a ``RuntimeError`` is raised. Returns ``(primary_branch,
+        primary_index, candidates_meta)`` where the primary is the
+        lowest-index successful candidate (candidate 1 unless it failed).
+        """
+        candidates_root = ensure_dir(self._run_dir / "candidates")
+        seeds: list[Optional[int]] = []
+        tasks = []
+        for idx in range(1, num_candidates + 1):
+            cand_dir = ensure_dir(candidates_root / f"cand_{idx}")
+            seed = self.settings.seed + (idx - 1) if self.settings.seed is not None else None
+            seeds.append(seed)
+            branch_visualizer = VisualizerAgent(
+                self._image_gen,
+                self._vlm,
+                prompt_dir=self._prompt_dir,
+                output_dir=str(cand_dir),
+                prompt_recorder=self._prompt_recorder,
+                output_resolution=self.settings.output_resolution,
+                image_quality=self.settings.image_quality,
+            )
+            tasks.append(
+                self._run_refinement_branch(
+                    input=input,
+                    initial_description=initial_description,
+                    effective_ratio=effective_ratio,
+                    vector_formats=vector_formats,
+                    total_iters=total_iters,
+                    run_dir=cand_dir,
+                    visualizer=branch_visualizer,
+                    seed=seed,
+                    candidate_index=idx,
+                    progress_callback=progress_callback,
+                )
+            )
+
+        self._emit_progress("candidates_fanout_started", num_candidates=num_candidates)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Candidate final outputs are always raster; the run-root final
+        # output carries the canonical requested format (including svg).
+        output_format = getattr(self.settings, "output_format", "png").lower()
+        cand_format = "png" if output_format == "svg" else output_format
+        cand_ext = "jpg" if cand_format == "jpeg" else cand_format
+
+        candidates_meta: list[Dict[str, Any]] = []
+        errors: list[tuple[int, BaseException]] = []
+        primary: Optional[Dict[str, Any]] = None
+        primary_index = 0
+        for idx, result in enumerate(results, start=1):
+            if isinstance(result, BaseException):
+                errors.append((idx, result))
+                logger.warning(
+                    "Candidate branch failed",
+                    candidate=idx,
+                    error=str(result),
+                )
+                self._emit_progress("candidate_failed", candidate=idx, error=str(result))
+                candidates_meta.append(
+                    {
+                        "index": idx,
+                        "seed": seeds[idx - 1],
+                        "image_path": None,
+                        "iterations": 0,
+                        "critic_satisfied": False,
+                        "error": str(result),
+                    }
+                )
+                continue
+
+            image_path: Optional[str] = None
+            if result["iterations"]:
+                cand_final = str(candidates_root / f"cand_{idx}" / f"final_output.{cand_ext}")
+                img = load_image(result["iterations"][-1].image_path)
+                save_image(img, cand_final, format=cand_format)
+                image_path = cand_final
+            last_critique = result["iterations"][-1].critique if result["iterations"] else None
+            entry: Dict[str, Any] = {
+                "index": idx,
+                "seed": seeds[idx - 1],
+                "image_path": image_path,
+                "iterations": len(result["iterations"]),
+                "critic_satisfied": bool(last_critique and not last_critique.needs_revision),
+                "budget_exceeded": result["budget_exceeded"],
+                "error": None,
+            }
+            if result["rollback_info"] is not None:
+                entry["rollback"] = result["rollback_info"]
+            candidates_meta.append(entry)
+            self._emit_progress(
+                "candidate_completed",
+                candidate=idx,
+                iterations=len(result["iterations"]),
+                image_path=image_path,
+            )
+            if primary is None:
+                primary = result
+                primary_index = idx
+
+        if primary is None:
+            detail = "; ".join(f"cand_{i}: {e}" for i, e in errors)
+            raise RuntimeError(f"All {num_candidates} candidate branches failed: {detail}")
+
+        return primary, primary_index, candidates_meta
 
     def _effective_vector_export(self, input: GenerationInput) -> str:
         """Resolve vector export mode from input override or settings."""
@@ -1182,10 +1560,6 @@ class PaperBananaPipeline:
                 source=ratio_source,
             )
 
-        current_description = optimized_description
-        iterations: list[IterationRecord] = []
-        iteration_timings = []
-        rollback_info: Optional[Dict[str, Any]] = None
         vector_formats = ["svg", "pdf"] if self.settings.vector_export != "none" else None
 
         if self.settings.auto_refine:
@@ -1193,195 +1567,44 @@ class PaperBananaPipeline:
         else:
             total_iters = self.settings.refinement_iterations
 
-        # Check budget after pre-iteration phases (retriever, planner, stylist)
-        budget_exceeded = self._check_budget("after planning phases")
+        num_candidates = self.settings.num_candidates
+        if not 1 <= num_candidates <= 8:
+            raise ValueError(f"num_candidates must be between 1 and 8, got {num_candidates}")
 
-        for i in range(total_iters):
-            if budget_exceeded:
-                break
-
-            iter_index = i + 1
-            logger.info(
-                f"Phase 2: Iteration {iter_index}/{total_iters}"
-                + (" (auto)" if self.settings.auto_refine else "")
-            )
-            self._emit_progress(
-                "iteration_started",
-                iteration=iter_index,
-                total_iterations=total_iters,
-                auto=self.settings.auto_refine,
-            )
-
-            # Step 4: Visualizer — generate image
-            if self._cost_tracker:
-                self._cost_tracker.set_agent("visualizer")
-            _emit_progress(
-                progress_callback,
-                PipelineProgressEvent(
-                    stage=PipelineProgressStage.VISUALIZER_START,
-                    message=f"Generating image (iteration {i + 1}/{total_iters})",
-                    iteration=i + 1,
-                    extra={"total_iterations": total_iters},
-                ),
-            )
-            visualizer_start = time.perf_counter()
-            image_path, rollback_info = await self._visualize_with_rollback(
-                iteration=iter_index,
-                rollback_to=iterations[-1].iteration if iterations else None,
-                run_dir=self._run_dir,
-                description=current_description,
-                diagram_type=input.diagram_type,
-                raw_data=input.raw_data,
-                seed=self.settings.seed,
-                aspect_ratio=effective_ratio,
+        candidates_meta: Optional[list[Dict[str, Any]]] = None
+        primary_candidate_index: Optional[int] = None
+        if num_candidates == 1:
+            branch = await self._run_refinement_branch(
+                input=input,
+                initial_description=optimized_description,
+                effective_ratio=effective_ratio,
                 vector_formats=vector_formats,
+                total_iters=total_iters,
+                run_dir=self._run_dir,
+                visualizer=self.visualizer,
+                seed=self.settings.seed,
+                progress_callback=progress_callback,
             )
-            visualizer_seconds = time.perf_counter() - visualizer_start
-            if image_path is None:
-                _emit_progress(
-                    progress_callback,
-                    PipelineProgressEvent(
-                        stage=PipelineProgressStage.VISUALIZER_END,
-                        message=(
-                            f"Visualizer iteration {iter_index} failed; keeping previous best image"
-                        ),
-                        seconds=visualizer_seconds,
-                        iteration=iter_index,
-                        extra={"rollback": True, "error": rollback_info["error"]},
-                    ),
-                )
-                break
-            _emit_progress(
-                progress_callback,
-                PipelineProgressEvent(
-                    stage=PipelineProgressStage.VISUALIZER_END,
-                    message=f"Visualizer iteration {i + 1} done",
-                    seconds=visualizer_seconds,
-                    iteration=i + 1,
-                ),
-            )
-            logger.info(
-                f"[Visualizer] Iteration {iter_index}/{total_iters} done",
-                seconds=round(visualizer_seconds, 1),
-            )
-            self._emit_progress(
-                "visualizer_completed",
-                iteration=iter_index,
-                seconds=round(visualizer_seconds, 1),
+        else:
+            branch, primary_candidate_index, candidates_meta = await self._fan_out_candidates(
+                input=input,
+                initial_description=optimized_description,
+                effective_ratio=effective_ratio,
+                vector_formats=vector_formats,
+                total_iters=total_iters,
+                num_candidates=num_candidates,
+                progress_callback=progress_callback,
             )
 
-            # Step 5: Critic — evaluate and provide feedback
-            if self._cost_tracker:
-                self._cost_tracker.set_agent("critic")
-            _emit_progress(
-                progress_callback,
-                PipelineProgressEvent(
-                    stage=PipelineProgressStage.CRITIC_START,
-                    message="Critic reviewing",
-                    iteration=i + 1,
-                ),
-            )
-            critic_start = time.perf_counter()
-            try:
-                critique = await _call_with_retry(
-                    "critic",
-                    self.critic.run,
-                    image_path=image_path,
-                    description=current_description,
-                    source_context=input.source_context,
-                    caption=input.communicative_intent,
-                    diagram_type=input.diagram_type,
-                )
-            except Exception:
-                logger.warning(
-                    "Critic failed after retries, accepting current image",
-                    iteration=iter_index,
-                    exc_info=True,
-                )
-                critique = CritiqueResult()
-            critic_seconds = time.perf_counter() - critic_start
-            _emit_progress(
-                progress_callback,
-                PipelineProgressEvent(
-                    stage=PipelineProgressStage.CRITIC_END,
-                    message="Critic done",
-                    seconds=critic_seconds,
-                    iteration=i + 1,
-                    extra={
-                        "needs_revision": critique.needs_revision,
-                        "summary": critique.summary,
-                        "critic_suggestions": critique.critic_suggestions[:3],
-                    },
-                ),
-            )
-            self._emit_progress(
-                "critic_completed",
-                iteration=iter_index,
-                seconds=round(critic_seconds, 1),
-                needs_revision=critique.needs_revision,
-            )
+        iterations: list[IterationRecord] = branch["iterations"]
+        iteration_timings = branch["iteration_timings"]
+        rollback_info: Optional[Dict[str, Any]] = branch["rollback_info"]
+        current_description = branch["final_description"]
+        budget_exceeded = branch["budget_exceeded"]
+        phase2_vector_paths: dict[str, str] = branch["vector_paths"]
 
-            iteration_record = IterationRecord(
-                iteration=iter_index,
-                description=current_description,
-                image_path=image_path,
-                critique=critique,
-            )
-            iteration_timings.append(
-                {
-                    "iteration": iter_index,
-                    "visualizer_seconds": visualizer_seconds,
-                    "critic_seconds": critic_seconds,
-                }
-            )
-            iterations.append(iteration_record)
-
-            # Save iteration artifacts
-            if self.settings.save_iterations:
-                iter_dir = ensure_dir(self._run_dir / f"iter_{i + 1}")
-                save_json(
-                    {
-                        "description": current_description,
-                        "critique": critique.model_dump(),
-                    },
-                    iter_dir / "details.json",
-                )
-
-            # Check if revision needed
-            if critique.needs_revision and critique.revised_description:
-                logger.info(
-                    "Revision needed",
-                    iteration=iter_index,
-                    summary=critique.summary,
-                )
-                current_description = critique.revised_description
-            else:
-                logger.info(
-                    "No further revision needed",
-                    iteration=iter_index,
-                    summary=critique.summary,
-                )
-                self._emit_progress(
-                    "iteration_completed",
-                    iteration=iter_index,
-                    total_iterations=len(iterations),
-                    needs_revision=critique.needs_revision,
-                )
-                break
-
-            self._emit_progress(
-                "iteration_completed",
-                iteration=iter_index,
-                total_iterations=len(iterations),
-                needs_revision=critique.needs_revision,
-            )
-
-            # Check budget between iterations
-            if self._check_budget("between iterations", iteration=iter_index):
-                budget_exceeded = True
-                break
-
-        # Final output
+        # Final output (with multi-candidate fan-out, the run-root output is
+        # the primary candidate: candidate 1 unless it failed)
         output_format = getattr(self.settings, "output_format", "png").lower()
         final_output_path = self._build_final_output(
             iterations,
@@ -1559,6 +1782,10 @@ class PaperBananaPipeline:
         }
         if rollback_info is not None:
             metadata_dict["rollback"] = rollback_info
+        if candidates_meta is not None:
+            metadata_dict["num_candidates"] = num_candidates
+            metadata_dict["primary_candidate"] = primary_candidate_index
+            metadata_dict["candidates"] = candidates_meta
         if generated_caption is not None:
             metadata_dict["generated_caption"] = generated_caption
         if ir_planner_status is not None:
@@ -1582,8 +1809,9 @@ class PaperBananaPipeline:
             metadata_dict["cost"] = cost_summary
 
         # Include vector output paths when vector export was requested
-        if self.settings.vector_export != "none" and self.visualizer._last_vector_paths:
-            metadata_dict["vector_output_paths"] = self.visualizer._last_vector_paths
+        # (from the primary Phase-2 branch's visualizer instance)
+        if self.settings.vector_export != "none" and phase2_vector_paths:
+            metadata_dict["vector_output_paths"] = phase2_vector_paths
 
         # Always write metadata (including cost) to disk for every run
         if tikz_path:

--- a/tests/test_cost_tracking.py
+++ b/tests/test_cost_tracking.py
@@ -329,3 +329,35 @@ class TestCostEstimator:
         result = estimate_cost(settings)
         assert result["pricing_note"] is not None
         assert "unknown" in result["pricing_note"].lower()
+
+    def test_multi_candidate_scales_phase2_costs(self):
+        from paperbanana.core.config import Settings
+
+        base_kwargs = dict(
+            vlm_provider="openai",
+            vlm_model="gpt-5.2",
+            image_provider="openai_imagen",
+            image_model="gpt-image-1.5",
+            refinement_iterations=3,
+        )
+        single = estimate_cost(Settings(**base_kwargs))
+        multi = estimate_cost(Settings(**base_kwargs, num_candidates=4))
+
+        # Image (visualizer) and critic calls scale by N; Phase-1 planning
+        # calls (retriever, planner, stylist) do not.
+        assert multi["num_candidates"] == 4
+        assert multi["image_calls"] == single["image_calls"] * 4
+        phase1_calls = single["vlm_calls"] - 3  # 3 critic calls in single run
+        assert multi["vlm_calls"] == phase1_calls + 3 * 4
+        assert multi["breakdown_by_agent"]["visualizer"] == pytest.approx(
+            single["breakdown_by_agent"]["visualizer"] * 4
+        )
+        assert multi["breakdown_by_agent"]["critic"] == pytest.approx(
+            single["breakdown_by_agent"]["critic"] * 4
+        )
+        assert multi["breakdown_by_agent"]["planner"] == pytest.approx(
+            single["breakdown_by_agent"]["planner"]
+        )
+        assert multi["estimated_total_usd"] > single["estimated_total_usd"]
+        assert "multi-candidate" in multi["pricing_note"].lower()
+        assert single["num_candidates"] == 1

--- a/tests/test_pipeline/test_multi_candidate.py
+++ b/tests/test_pipeline/test_multi_candidate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 import pytest
 
@@ -332,7 +333,11 @@ def test_cli_rejects_out_of_range_num_candidates(tmp_path):
             ],
         )
         assert result.exit_code != 0
-        assert "num-candidates" in result.output
+        # Strip ANSI escapes — rich colorizes CLI errors in CI, splitting
+        # the flag name across style codes.
+        plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+        assert "num-candidates" in plain
+        assert "1<=x<=8" in plain
 
 
 def test_cli_accepts_valid_num_candidates(tmp_path):

--- a/tests/test_pipeline/test_multi_candidate.py
+++ b/tests/test_pipeline/test_multi_candidate.py
@@ -1,0 +1,360 @@
+"""Tests for multi-candidate generation (--num-candidates, issue #237)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytest.importorskip("PIL", reason="PIL/Pillow required for pipeline image mock")
+from pathlib import Path
+
+from PIL import Image
+
+from paperbanana.core import pipeline as pipeline_mod
+from paperbanana.core.config import Settings
+from paperbanana.core.pipeline import PaperBananaPipeline
+from paperbanana.core.types import DiagramType, GenerationInput
+
+# ── Shared mocks ─────────────────────────────────────────────────
+
+
+class _MockVLM:
+    name = "mock-vlm"
+    model_name = "mock-model"
+
+    def __init__(self, responses: list[str]):
+        self._responses = responses
+        self._idx = 0
+
+    async def generate(self, *args, **kwargs):
+        idx = min(self._idx, len(self._responses) - 1)
+        self._idx += 1
+        return self._responses[idx]
+
+
+class _SeedRecordingImageGen:
+    """Image-gen mock that records seeds and can fail for specific seeds."""
+
+    name = "mock-image-gen"
+    model_name = "mock-image-model"
+
+    def __init__(self, fail_seeds: tuple[int | None, ...] = ()):
+        self.seeds: list[int | None] = []
+        self.fail_seeds = set(fail_seeds)
+
+    async def generate(self, *args, **kwargs):
+        seed = kwargs.get("seed")
+        self.seeds.append(seed)
+        if seed in self.fail_seeds:
+            raise RuntimeError(f"image gen exploded for seed {seed}")
+        return Image.new("RGB", (64, 64), color=(255, 255, 255))
+
+
+def _make_settings(tmp_path, **overrides):
+    defaults = dict(
+        output_dir=str(tmp_path / "outputs"),
+        reference_set_path=str(tmp_path / "empty_refs"),
+        refinement_iterations=1,
+        save_iterations=True,
+        save_prompts=False,
+    )
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+def _default_input():
+    return GenerationInput(
+        source_context="Test methodology text",
+        communicative_intent="Test caption",
+        diagram_type=DiagramType.METHODOLOGY,
+    )
+
+
+_ACCEPT_CRITIQUE = json.dumps({"critic_suggestions": [], "revised_description": None})
+
+
+@pytest.fixture(autouse=True)
+def _fast_retry(monkeypatch):
+    """Replace _call_with_retry with a zero-wait version for fast tests."""
+
+    async def _fast_call_with_retry(label, fn, *args, max_attempts=3, **kwargs):
+        last_exc = None
+        for attempt_num in range(1, max_attempts + 1):
+            try:
+                return await fn(*args, **kwargs)
+            except Exception as exc:
+                last_exc = exc
+                if attempt_num >= max_attempts:
+                    raise
+        raise last_exc  # unreachable but satisfies type checker
+
+    monkeypatch.setattr(pipeline_mod, "_call_with_retry", _fast_call_with_retry)
+
+
+def _make_pipeline(settings, image_gen=None):
+    vlm = _MockVLM(responses=["Plan description", "Styled description", _ACCEPT_CRITIQUE])
+    return PaperBananaPipeline(
+        settings=settings,
+        vlm_client=vlm,
+        image_gen_fn=image_gen or _SeedRecordingImageGen(),
+    )
+
+
+# ── Fan-out produces N candidate dirs and metadata entries ────────
+
+
+@pytest.mark.asyncio
+async def test_fanout_produces_candidate_dirs_and_metadata(tmp_path):
+    settings = _make_settings(tmp_path, num_candidates=3)
+    pipeline = _make_pipeline(settings)
+
+    result = await pipeline.generate(_default_input())
+
+    run_dir = Path(settings.output_dir) / pipeline.run_id
+    for idx in (1, 2, 3):
+        cand_dir = run_dir / "candidates" / f"cand_{idx}"
+        assert (cand_dir / "final_output.png").exists()
+        assert (cand_dir / "iter_1" / "details.json").exists()
+
+    # Run-root final output is still produced (primary = candidate 1)
+    assert result.image_path == str(run_dir / "final_output.png")
+    assert Path(result.image_path).exists()
+
+    metadata = json.loads((run_dir / "metadata.json").read_text())
+    assert metadata["num_candidates"] == 3
+    assert metadata["primary_candidate"] == 1
+    candidates = metadata["candidates"]
+    assert [c["index"] for c in candidates] == [1, 2, 3]
+    for cand in candidates:
+        assert cand["error"] is None
+        assert cand["iterations"] == 1
+        assert cand["critic_satisfied"] is True
+        assert Path(cand["image_path"]).exists()
+
+
+# ── Single-candidate runs keep the existing layout ────────────────
+
+
+@pytest.mark.asyncio
+async def test_single_candidate_has_no_candidates_metadata(tmp_path):
+    settings = _make_settings(tmp_path)
+    pipeline = _make_pipeline(settings)
+
+    result = await pipeline.generate(_default_input())
+
+    run_dir = Path(settings.output_dir) / pipeline.run_id
+    assert not (run_dir / "candidates").exists()
+    assert "candidates" not in result.metadata
+    assert Path(result.image_path).exists()
+
+
+# ── One failing branch does not kill the others ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_one_branch_fails_others_survive(tmp_path):
+    settings = _make_settings(tmp_path, num_candidates=3, seed=42)
+    image_gen = _SeedRecordingImageGen(fail_seeds=(43,))  # candidate 2
+    pipeline = _make_pipeline(settings, image_gen=image_gen)
+
+    result = await pipeline.generate(_default_input())
+
+    candidates = result.metadata["candidates"]
+    assert candidates[0]["error"] is None
+    assert Path(candidates[0]["image_path"]).exists()
+    assert "image gen exploded" in candidates[1]["error"]
+    assert candidates[1]["image_path"] is None
+    assert candidates[2]["error"] is None
+    assert Path(candidates[2]["image_path"]).exists()
+
+    # Primary stays candidate 1; root output exists
+    assert result.metadata["primary_candidate"] == 1
+    assert Path(result.image_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_primary_falls_back_when_candidate_1_fails(tmp_path):
+    settings = _make_settings(tmp_path, num_candidates=2, seed=42)
+    image_gen = _SeedRecordingImageGen(fail_seeds=(42,))  # candidate 1
+    pipeline = _make_pipeline(settings, image_gen=image_gen)
+
+    result = await pipeline.generate(_default_input())
+
+    assert result.metadata["primary_candidate"] == 2
+    assert Path(result.image_path).exists()
+    assert result.metadata["candidates"][0]["error"] is not None
+
+
+# ── All branches failing raises ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_all_branches_fail_raises(tmp_path):
+    settings = _make_settings(tmp_path, num_candidates=2, seed=7)
+    image_gen = _SeedRecordingImageGen(fail_seeds=(7, 8))
+    pipeline = _make_pipeline(settings, image_gen=image_gen)
+
+    with pytest.raises(RuntimeError, match="All 2 candidate branches failed"):
+        await pipeline.generate(_default_input())
+
+
+# ── Seed offsets are distinct per candidate ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_seed_offsets_distinct(tmp_path):
+    settings = _make_settings(tmp_path, num_candidates=3, seed=100)
+    image_gen = _SeedRecordingImageGen()
+    pipeline = _make_pipeline(settings, image_gen=image_gen)
+
+    result = await pipeline.generate(_default_input())
+
+    assert sorted(image_gen.seeds) == [100, 101, 102]
+    assert [c["seed"] for c in result.metadata["candidates"]] == [100, 101, 102]
+
+
+@pytest.mark.asyncio
+async def test_no_seed_means_no_offsets(tmp_path):
+    settings = _make_settings(tmp_path, num_candidates=2)
+    image_gen = _SeedRecordingImageGen()
+    pipeline = _make_pipeline(settings, image_gen=image_gen)
+
+    result = await pipeline.generate(_default_input())
+
+    assert image_gen.seeds == [None, None]
+    assert [c["seed"] for c in result.metadata["candidates"]] == [None, None]
+
+
+# ── Progress events carry the candidate index ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_progress_events_include_candidate_index(tmp_path):
+    settings = _make_settings(tmp_path, num_candidates=2)
+    pipeline = _make_pipeline(settings)
+
+    events = []
+
+    def on_progress(event):
+        events.append(event)
+
+    await pipeline.generate(_default_input(), progress_callback=on_progress)
+
+    from paperbanana.core.types import PipelineProgressStage
+
+    visualizer_starts = [e for e in events if e.stage == PipelineProgressStage.VISUALIZER_START]
+    assert sorted((e.extra or {}).get("candidate") for e in visualizer_starts) == [1, 2]
+
+
+# ── Budget guard aborts gracefully mid-fan-out ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_budget_guard_stops_fanout_branches(tmp_path):
+    """Once the shared tracker is over budget, every branch stops at its
+    next between-iterations checkpoint instead of running to total_iters."""
+    from paperbanana.core.cost_tracker import CostTracker
+
+    settings = _make_settings(
+        tmp_path, num_candidates=2, refinement_iterations=3, budget_usd=0.0000001
+    )
+    tracker = CostTracker(budget=0.0000001)
+
+    class _CostlyImageGen(_SeedRecordingImageGen):
+        async def generate(self, *args, **kwargs):
+            img = await super().generate(*args, **kwargs)
+            # Simulate a paid image call against the shared tracker.
+            tracker.record_image_call("openai_imagen", "gpt-image-1.5", agent="visualizer")
+            return img
+
+    revision = json.dumps(
+        {
+            "critic_suggestions": ["More contrast"],
+            "revised_description": "Revised description",
+        }
+    )
+    vlm = _MockVLM(responses=["Plan description", "Styled description", revision])
+    pipeline = PaperBananaPipeline(
+        settings=settings, vlm_client=vlm, image_gen_fn=_CostlyImageGen()
+    )
+    pipeline._cost_tracker = tracker
+
+    result = await pipeline.generate(_default_input())
+
+    # Critic always asks for revision, so without the budget guard each
+    # branch would run 3 iterations; the shared tracker stops every branch
+    # at its next checkpoint (candidate 2 may abort before its first image).
+    candidates = result.metadata["candidates"]
+    for cand in candidates:
+        assert cand["error"] is None
+        assert cand["iterations"] <= 1
+        assert cand["budget_exceeded"] is True
+    assert candidates[0]["iterations"] == 1
+    assert result.metadata["cost"]["budget_exceeded"] is True
+    assert Path(result.image_path).exists()
+
+
+# ── Settings validation caps N at 8 ───────────────────────────────
+
+
+def test_settings_rejects_invalid_num_candidates(tmp_path):
+    with pytest.raises(ValueError):
+        _make_settings(tmp_path, num_candidates=0)
+    with pytest.raises(ValueError):
+        _make_settings(tmp_path, num_candidates=9)
+
+
+# ── CLI validation: 0 and >8 are rejected ─────────────────────────
+
+
+def test_cli_rejects_out_of_range_num_candidates(tmp_path):
+    from typer.testing import CliRunner
+
+    from paperbanana.cli import app
+
+    runner = CliRunner()
+    input_file = tmp_path / "method.txt"
+    input_file.write_text("Sample methodology text.")
+
+    for bad in ("0", "9"):
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--input",
+                str(input_file),
+                "--caption",
+                "test",
+                "--num-candidates",
+                bad,
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "num-candidates" in result.output
+
+
+def test_cli_accepts_valid_num_candidates(tmp_path):
+    from typer.testing import CliRunner
+
+    from paperbanana.cli import app
+
+    runner = CliRunner()
+    input_file = tmp_path / "method.txt"
+    input_file.write_text("Sample methodology text.")
+
+    result = runner.invoke(
+        app,
+        [
+            "generate",
+            "--input",
+            str(input_file),
+            "--caption",
+            "test",
+            "--num-candidates",
+            "4",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
Fixes #237 — generate N candidate images in parallel (1–8):

- **Planning runs once** (Retriever→Planner→Stylist); Phase-2 refinement fans out per candidate via `asyncio.gather`, with seed offsets for diversity
- **State safety**: `VisualizerAgent` was the only branch-unsafe component (mutable `output_dir` + `_last_vector_paths`) — each branch gets a fresh instance writing under `candidates/cand_<i>/`; providers/critic/CostTracker are shared safely (single event loop, synchronous accumulation — budget guard verified to halt all branches mid-fan-out)
- **Compatibility**: run-root `final_output` = candidate 1 (lowest-index success promoted if it fails, recorded as `metadata.primary_candidate`); single-candidate layout is byte-identical — all 82 pre-existing pipeline tests pass unmodified
- **Cost**: estimator scales Phase-2 costs ×N; `--cost-only -k 4` shows the fan-out upfront
- One failed candidate doesn't kill the rest; all-fail raises; per-candidate errors in metadata
- 12 new tests; suite at 812 passing.