### PR TITLE
feat: polish mode — refine an existing figure with style-guided suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,28 @@ Scores on 4 dimensions (hierarchical aggregation per the paper):
 - **Primary**: Faithfulness, Readability
 - **Secondary**: Conciseness, Aesthetics
 
+### `paperbanana polish` -- Refine an Existing Figure
+
+Bring your own figure: a VLM audits it against the venue style guide and proposes up to 10 concrete, actionable improvements, then an image-edit capable provider applies them to the original figure (guided edit). Suggestions are printed to the console so you can see exactly what changed.
+
+```bash
+paperbanana polish --input figure.png
+paperbanana polish --input figure.png --venue icml --iterations 2 --output polished.png
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--input` | `-i` | Path to the existing figure image (required) |
+| `--output` | `-o` | Output path (default: `outputs/polish_<timestamp>/final_output.png`) |
+| `--venue` | | Venue style guide: `neurips` (default), `icml`, `acl`, `ieee`, `custom` |
+| `--iterations` | `-n` | Polish rounds; each round suggests and applies improvements on the previous result (default: 1) |
+| `--aspect-ratio` | `-ar` | Target aspect ratio (default: preserve the input figure's ratio) |
+| `--num-candidates` | `-k` | Apply each round's suggestions N times in parallel (1-8) |
+| `--budget` | | Budget cap in USD; polishing stops gracefully when exceeded |
+| `--seed` | | Random seed for reproducible edits |
+
+Requires an image provider that supports guided image edits (Google Gemini image models). If the figure already conforms to the style guide, polish exits without making changes.
+
 ### `paperbanana studio` -- Local web UI
 
 Requires `pip install 'paperbanana[studio]'` (Gradio).

--- a/paperbanana/agents/polish.py
+++ b/paperbanana/agents/polish.py
@@ -1,0 +1,218 @@
+"""Polish Agent: improves an existing user-supplied figure via style-guided suggestions."""
+
+from __future__ import annotations
+
+import inspect
+import re
+from pathlib import Path
+from typing import Optional
+
+import structlog
+from PIL import Image
+
+from paperbanana.agents.base import BaseAgent
+from paperbanana.core.utils import load_image, save_image, truncate_text
+from paperbanana.providers.base import ImageGenProvider, VLMProvider
+
+logger = structlog.get_logger()
+
+MAX_SUGGESTIONS = 10
+
+# Matches "1. text", "2) text", "- text", "* text", "• text"
+_LIST_ITEM_RE = re.compile(r"^\s*(?:\d+[.)]\s+|[-*•]\s+)(.+?)\s*$")
+_FENCE_RE = re.compile(r"^\s*```[a-zA-Z0-9_-]*\s*$")
+
+
+class PolishAgent(BaseAgent):
+    """Refines an existing figure in two steps.
+
+    1. ``suggest``: a VLM audits the figure against the venue style guide and
+       returns at most :data:`MAX_SUGGESTIONS` concrete, actionable
+       presentation improvements.
+    2. ``apply``: the suggestions and the original figure are sent to an
+       image-edit capable provider (guided edit) which renders the polished
+       version while preserving the figure's content.
+
+    Prompt templates live in ``prompts/polish/{suggest,apply}.txt``.
+    """
+
+    def __init__(
+        self,
+        image_gen: ImageGenProvider,
+        vlm_provider: VLMProvider,
+        prompt_dir: str = "prompts",
+        output_dir: str = "outputs",
+        prompt_recorder=None,
+        image_quality: str = "auto",
+    ):
+        super().__init__(vlm_provider, prompt_dir, prompt_recorder=prompt_recorder)
+        self.image_gen = image_gen
+        self.output_dir = Path(output_dir)
+        self.image_quality = image_quality
+
+    @property
+    def agent_name(self) -> str:
+        return "polish"
+
+    @staticmethod
+    def supports_guided_edit(image_gen: ImageGenProvider) -> bool:
+        """Whether the provider accepts input images for guided editing.
+
+        Image-edit capable providers declare an ``images`` keyword on
+        ``generate`` (see ``GoogleImagenGen``); the base text-to-image
+        contract does not.
+        """
+        try:
+            return "images" in inspect.signature(image_gen.generate).parameters
+        except (TypeError, ValueError):
+            return False
+
+    def _load_polish_prompt(self, step: str) -> str:
+        """Load a polish prompt template (``suggest`` or ``apply``)."""
+        path = self.prompt_dir / "polish" / f"{step}.txt"
+        if not path.exists():
+            raise FileNotFoundError(f"Prompt template not found: {path}")
+        return path.read_text(encoding="utf-8")
+
+    async def suggest(
+        self,
+        image: Image.Image,
+        style_guide: str,
+        max_suggestions: int = MAX_SUGGESTIONS,
+        iteration: int = 1,
+    ) -> list[str]:
+        """Audit *image* against *style_guide* and return actionable suggestions.
+
+        Returns an empty list when the figure already conforms (the VLM
+        answers ``NO_SUGGESTIONS``) or when no list items can be parsed.
+        """
+        template = self._load_polish_prompt("suggest")
+        prompt = self.format_prompt(
+            template,
+            prompt_label=f"polish_suggest_iter_{iteration}",
+            style_guide=style_guide,
+            max_suggestions=max_suggestions,
+        )
+
+        logger.info("Running polish suggest step", iteration=iteration)
+        response = await self.vlm.generate(
+            prompt=prompt,
+            images=[image],
+            temperature=0.3,
+            max_tokens=2048,
+        )
+        suggestions = self._parse_suggestions(response, max_suggestions=max_suggestions)
+        logger.info("Polish suggestions ready", count=len(suggestions), iteration=iteration)
+        return suggestions
+
+    async def apply(
+        self,
+        image: Image.Image,
+        suggestions: list[str],
+        output_path: str,
+        iteration: int = 1,
+        aspect_ratio: Optional[str] = None,
+        seed: Optional[int] = None,
+    ) -> str:
+        """Apply *suggestions* to *image* via a guided edit and save the result.
+
+        The original figure and the numbered suggestions both go to the image
+        provider, so the model edits the existing figure instead of
+        regenerating from scratch.
+        """
+        if not self.supports_guided_edit(self.image_gen):
+            raise RuntimeError(
+                f"Image provider '{getattr(self.image_gen, 'name', 'unknown')}' does not "
+                "support guided image editing (no 'images' parameter on generate()). "
+                "Polish mode requires an image-edit capable provider such as 'google'."
+            )
+
+        template = self._load_polish_prompt("apply")
+        numbered = "\n".join(f"{i}. {s}" for i, s in enumerate(suggestions, start=1))
+        prompt = self.format_prompt(
+            template,
+            prompt_label=f"polish_apply_iter_{iteration}",
+            suggestions=numbered,
+        )
+
+        logger.info("Running polish apply step", iteration=iteration, suggestions=len(suggestions))
+        polished = await self.image_gen.generate(
+            prompt=prompt,
+            images=[image],
+            width=image.width,
+            height=image.height,
+            seed=seed,
+            aspect_ratio=aspect_ratio,
+            quality=self.image_quality,
+        )
+        save_image(polished, output_path)
+        logger.info("Polished figure saved", path=output_path, iteration=iteration)
+        return output_path
+
+    async def run(
+        self,
+        image_path: str,
+        style_guide: str,
+        output_path: Optional[str] = None,
+        iteration: int = 1,
+        aspect_ratio: Optional[str] = None,
+        seed: Optional[int] = None,
+    ) -> tuple[str, list[str]]:
+        """One polish round: suggest improvements, then apply them.
+
+        Returns:
+            ``(result_path, suggestions)``. When the VLM finds nothing to
+            improve, the original ``image_path`` is returned unchanged with
+            an empty suggestion list and the apply step is skipped.
+        """
+        image = load_image(image_path)
+        suggestions = await self.suggest(image, style_guide, iteration=iteration)
+        if not suggestions:
+            logger.info("No polish suggestions; figure left unchanged", iteration=iteration)
+            return image_path, []
+
+        if output_path is None:
+            output_path = str(self.output_dir / f"polished_iter_{iteration}.png")
+        polished_path = await self.apply(
+            image,
+            suggestions,
+            output_path=output_path,
+            iteration=iteration,
+            aspect_ratio=aspect_ratio,
+            seed=seed,
+        )
+        return polished_path, suggestions
+
+    @staticmethod
+    def _parse_suggestions(
+        response: str | None, max_suggestions: int = MAX_SUGGESTIONS
+    ) -> list[str]:
+        """Parse a VLM response into a list of suggestion strings.
+
+        Handles numbered lists (``1.`` / ``2)``), bulleted lists
+        (``-`` / ``*`` / ``•``), and fenced output (code fences are
+        stripped). Non-list lines (preamble, prose) are ignored.
+        ``NO_SUGGESTIONS`` yields an empty list.
+        """
+        if not response:
+            return []
+        if "NO_SUGGESTIONS" in response:
+            return []
+
+        suggestions: list[str] = []
+        for line in response.splitlines():
+            if _FENCE_RE.match(line):
+                continue
+            match = _LIST_ITEM_RE.match(line)
+            if not match:
+                continue
+            text = match.group(1).replace("**", "").strip()
+            if text:
+                suggestions.append(text)
+
+        if not suggestions:
+            logger.warning(
+                "Could not parse any suggestions from VLM response",
+                raw_response=truncate_text(response, 500),
+            )
+        return suggestions[:max_suggestions]

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -2637,6 +2637,275 @@ def tikz(
 
 
 @app.command()
+def polish(
+    input: str = typer.Option(
+        ..., "--input", "-i", help="Path to the existing figure image to polish"
+    ),
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Output image path (default: outputs/polish_<timestamp>/final_output.png)",
+    ),
+    venue: Optional[str] = typer.Option(
+        None,
+        "--venue",
+        help="Target venue style (neurips, icml, acl, ieee, custom)",
+    ),
+    iterations: int = typer.Option(
+        1,
+        "--iterations",
+        "-n",
+        min=1,
+        help="Polish rounds: each round suggests improvements and applies them to the result",
+    ),
+    aspect_ratio: Optional[str] = typer.Option(
+        None,
+        "--aspect-ratio",
+        "-ar",
+        help="Target aspect ratio: 1:1, 2:3, 3:2, 3:4, 4:3, 9:16, 16:9, 21:9 "
+        "(default: preserve the input figure's ratio)",
+    ),
+    vlm_provider: Optional[str] = typer.Option(
+        None, "--vlm-provider", help="VLM provider (gemini)"
+    ),
+    vlm_model: Optional[str] = typer.Option(None, "--vlm-model", help="VLM model name"),
+    image_provider: Optional[str] = typer.Option(
+        None, "--image-provider", help="Image gen provider (must support guided image edits)"
+    ),
+    image_model: Optional[str] = typer.Option(None, "--image-model", help="Image gen model name"),
+    budget: Optional[float] = typer.Option(
+        None,
+        "--budget",
+        help="Budget cap in USD; polishing stops gracefully when exceeded",
+    ),
+    num_candidates: Optional[int] = typer.Option(
+        None,
+        "--num-candidates",
+        "-k",
+        min=1,
+        max=8,
+        help=(
+            "Apply each round's suggestions N times in parallel (1-8); the first "
+            "successful candidate is kept as the primary result"
+        ),
+    ),
+    seed: Optional[int] = typer.Option(
+        None, "--seed", help="Random seed for reproducible image generation"
+    ),
+    config: Optional[str] = typer.Option(None, "--config", help="Path to config YAML file"),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show detailed agent progress and timing"
+    ),
+):
+    """Polish an existing figure: style-guided suggestions applied as a guided image edit."""
+    configure_logging(verbose=verbose)
+
+    if venue and venue.lower() not in ("neurips", "icml", "acl", "ieee", "custom"):
+        console.print(
+            f"[red]Error: --venue must be neurips, icml, acl, ieee, or custom. Got: {venue}[/red]"
+        )
+        raise typer.Exit(1)
+
+    input_path = Path(input)
+    if not input_path.exists():
+        console.print(f"[red]Error: Input image not found: {input}[/red]")
+        raise typer.Exit(1)
+
+    from PIL import Image as PILImage
+    from PIL import UnidentifiedImageError
+
+    try:
+        with PILImage.open(input_path) as probe:
+            probe.verify()
+    except (UnidentifiedImageError, OSError, ValueError) as e:
+        console.print(f"[red]Error: Input is not a readable image: {input} ({e})[/red]")
+        raise typer.Exit(1)
+
+    # Build settings — only override values explicitly passed via CLI
+    overrides = {}
+    if vlm_provider:
+        overrides["vlm_provider"] = vlm_provider
+    if vlm_model:
+        overrides["vlm_model"] = vlm_model
+    if image_provider:
+        overrides["image_provider"] = image_provider
+    if image_model:
+        overrides["image_model"] = image_model
+    if budget is not None:
+        overrides["budget_usd"] = budget
+    if num_candidates is not None:
+        overrides["num_candidates"] = num_candidates
+    if seed is not None:
+        overrides["seed"] = seed
+    if venue:
+        overrides["venue"] = venue
+
+    if config:
+        settings = Settings.from_yaml(config, **overrides)
+    else:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+        settings = Settings(**overrides)
+
+    import datetime
+
+    from paperbanana.agents.polish import PolishAgent
+    from paperbanana.core.cost_tracker import CostTracker
+    from paperbanana.core.utils import find_prompt_dir, load_image, save_image
+    from paperbanana.guidelines.methodology import load_methodology_guidelines
+    from paperbanana.providers.registry import ProviderRegistry
+
+    if output:
+        final_path = Path(output)
+        run_dir = ensure_dir(final_path.parent)
+    else:
+        ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        run_dir = ensure_dir(Path(settings.output_dir) / f"polish_{ts}")
+        final_path = run_dir / "final_output.png"
+
+    vlm = ProviderRegistry.create_vlm(settings)
+    image_gen = ProviderRegistry.create_image_gen(settings)
+
+    if not PolishAgent.supports_guided_edit(image_gen):
+        console.print(
+            f"[red]Error: image provider '{getattr(image_gen, 'name', 'unknown')}' does not "
+            "support guided image editing required by polish mode. "
+            "Use --image-provider google.[/red]"
+        )
+        raise typer.Exit(1)
+
+    cost_tracker = CostTracker(budget=settings.budget_usd)
+    if hasattr(vlm, "cost_tracker"):
+        vlm.cost_tracker = cost_tracker
+    if hasattr(image_gen, "cost_tracker"):
+        image_gen.cost_tracker = cost_tracker
+    cost_tracker.set_agent("polish")
+
+    style_guide = load_methodology_guidelines(settings.guidelines_path, venue=settings.venue)
+
+    agent = PolishAgent(
+        image_gen,
+        vlm,
+        prompt_dir=settings.prompt_dir or find_prompt_dir(),
+        output_dir=str(run_dir),
+        image_quality=settings.image_quality,
+    )
+
+    console.print(
+        Panel.fit(
+            f"[bold]PaperBanana[/bold] - Polish Mode\n\n"
+            f"Input:      {input_path}\n"
+            f"Venue:      {settings.venue}\n"
+            f"Rounds:     {iterations}\n"
+            f"Candidates: {settings.num_candidates}\n"
+            f"Output:     {final_path}",
+            border_style="yellow",
+        )
+    )
+
+    async def _apply_fanned_out(image, suggestions, round_idx: int) -> str:
+        """Fan the apply step out over num_candidates parallel guided edits."""
+        candidates_root = ensure_dir(run_dir / "candidates")
+        tasks = []
+        for k in range(1, settings.num_candidates + 1):
+            cand_dir = ensure_dir(candidates_root / f"cand_{k}")
+            cand_seed = settings.seed + (k - 1) if settings.seed is not None else None
+            tasks.append(
+                agent.apply(
+                    image,
+                    suggestions,
+                    output_path=str(cand_dir / f"polished_iter_{round_idx}.png"),
+                    iteration=round_idx,
+                    aspect_ratio=aspect_ratio,
+                    seed=cand_seed,
+                )
+            )
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        primary: Optional[str] = None
+        for k, res in enumerate(results, start=1):
+            if isinstance(res, BaseException):
+                console.print(f"  [yellow]![/yellow] Candidate {k} failed: {res}")
+            else:
+                console.print(f"  [green]✓[/green] Candidate {k}: {res}")
+                if primary is None:
+                    primary = res
+        if primary is None:
+            raise RuntimeError(f"All {settings.num_candidates} polish candidates failed")
+        return primary
+
+    async def _run() -> tuple[str, int]:
+        current_path = str(input_path)
+        rounds_applied = 0
+        for round_idx in range(1, iterations + 1):
+            image = load_image(current_path)
+            console.print(f"\n  [dim]●[/dim] Round {round_idx}/{iterations}: analyzing figure...")
+            suggestions = await agent.suggest(image, style_guide, iteration=round_idx)
+            if not suggestions:
+                console.print(
+                    f"  [green]✓[/green] Round {round_idx}: no further suggestions — "
+                    "figure already conforms to the style guide"
+                )
+                break
+
+            console.print(f"\n[bold]Round {round_idx} suggestions:[/bold]")
+            for j, suggestion in enumerate(suggestions, start=1):
+                console.print(f"  {j}. {suggestion}")
+
+            console.print("  [dim]●[/dim] Applying suggestions (guided edit)...")
+            if settings.num_candidates > 1:
+                current_path = await _apply_fanned_out(image, suggestions, round_idx)
+            else:
+                current_path = await agent.apply(
+                    image,
+                    suggestions,
+                    output_path=str(run_dir / f"polished_iter_{round_idx}.png"),
+                    iteration=round_idx,
+                    aspect_ratio=aspect_ratio,
+                    seed=settings.seed,
+                )
+            rounds_applied += 1
+
+            if cost_tracker.is_over_budget:
+                console.print(
+                    f"  [yellow]Budget exceeded (${cost_tracker.total_cost:.4f} / "
+                    f"${settings.budget_usd}); stopping after round {round_idx}[/yellow]"
+                )
+                break
+        return current_path, rounds_applied
+
+    try:
+        result_path, rounds_applied = asyncio.run(_run())
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    if rounds_applied == 0:
+        console.print(
+            "\n[green]Done![/green] No changes applied — "
+            "the figure already matches the style guide."
+        )
+    else:
+        final_image = load_image(result_path)
+        save_image(final_image, str(final_path))
+        console.print(f"\n[green]Done![/green] Polished figure saved to: [bold]{final_path}[/bold]")
+        console.print(f"Rounds applied: {rounds_applied}")
+
+    cost_summary = cost_tracker.summary()
+    if cost_summary["num_vlm_calls"] or cost_summary["num_image_calls"]:
+        console.print(
+            f"  Cost: [bold]${cost_summary['total_usd']:.4f}[/bold]"
+            f" [dim](VLM: ${cost_summary['vlm_usd']:.4f},"
+            f" Image: ${cost_summary['image_usd']:.4f})[/dim]"
+        )
+        if not cost_summary.get("pricing_complete", True):
+            console.print(
+                "  [yellow]Note: Some model prices unknown; actual cost may differ[/yellow]"
+            )
+
+
+@app.command()
 def setup():
     """Interactive setup wizard — get generating in 2 minutes with FREE APIs."""
     console.print(

--- a/paperbanana/providers/base.py
+++ b/paperbanana/providers/base.py
@@ -72,6 +72,12 @@ class ImageGenProvider(ABC):
 
     Used by the Visualizer agent to generate methodology diagrams
     and other academic illustrations.
+
+    Guided edits (image-conditioned generation): providers that can edit an
+    existing image declare an additional ``images: Optional[list[Image.Image]]``
+    keyword on ``generate`` (see ``GoogleImagenGen``). Callers detect support
+    by inspecting the provider's ``generate`` signature — the base contract
+    below is text-to-image only.
     """
 
     cost_tracker: CostTracker | None = None

--- a/paperbanana/providers/image_gen/google_imagen.py
+++ b/paperbanana/providers/image_gen/google_imagen.py
@@ -104,7 +104,16 @@ class GoogleImagenGen(ImageGenProvider):
         seed: Optional[int] = None,
         aspect_ratio: Optional[str] = None,
         quality: Optional[str] = None,
+        images: Optional[list[Image.Image]] = None,
     ) -> Image.Image:
+        """Generate an image; when ``images`` is given, perform a guided edit.
+
+        Args:
+            images: Optional input images used as the edit base. The model
+                receives them alongside the prompt (image-conditioned
+                generation), which is how polish mode applies suggestions
+                to an existing figure.
+        """
         from google.genai import types
 
         self._get_client()
@@ -120,9 +129,10 @@ class GoogleImagenGen(ImageGenProvider):
             ),
         )
 
+        contents = [*images, prompt] if images else prompt
         response = self._client.models.generate_content(
             model=self._model,
-            contents=prompt,
+            contents=contents,
             config=config,
         )
 

--- a/prompts/polish/apply.txt
+++ b/prompts/polish/apply.txt
@@ -1,0 +1,11 @@
+You are an expert scientific figure editor. The provided image is an existing academic figure. Produce an improved version of this exact figure by applying ONLY the numbered improvements listed below.
+
+CRITICAL CONSTRAINTS:
+- Preserve the figure's content, structure, layout, and meaning: every component, connection, label, and data element of the original must remain present and unchanged unless an improvement explicitly targets it.
+- All text must stay in clear, readable English with the EXACT same wording as the original. Do not generate garbled, misspelled, or non-English text.
+- Do not add new content, captions, titles, watermarks, or decorative elements.
+- Apply every listed improvement; make no other changes.
+
+## IMPROVEMENTS TO APPLY
+
+{suggestions}

--- a/prompts/polish/suggest.txt
+++ b/prompts/polish/suggest.txt
@@ -1,0 +1,28 @@
+## ROLE
+
+You are a Lead Visual Designer for top-tier AI conferences (e.g., NeurIPS 2025).
+
+## TASK
+
+You are given an existing academic figure (provided as an image) and the target venue's style guide. Audit the figure against the style guide and produce a short list of concrete, actionable presentation improvements that an image editing model can apply directly.
+
+## RULES
+
+1. Return at most {max_suggestions} suggestions.
+2. Each suggestion must be specific and directly executable by an image editing model (e.g., "Replace the saturated red module backgrounds with a pale blue fill at ~10% opacity", not "improve the colors").
+3. Only suggest presentation changes: color palette, typography, line and arrow styles, alignment, spacing, grouping containers, legends, iconography.
+4. Never suggest adding, removing, or rewording the figure's content, labels, data, or meaning. The figure must stay factually identical.
+5. Order suggestions by visual impact, most impactful first.
+
+## STYLE GUIDE
+
+{style_guide}
+
+## OUTPUT
+
+Return ONLY a numbered list with one suggestion per line:
+1. <first suggestion>
+2. <second suggestion>
+
+If the figure already conforms to the style guide and needs no changes, return exactly:
+NO_SUGGESTIONS

--- a/tests/test_agents/test_polish.py
+++ b/tests/test_agents/test_polish.py
@@ -1,0 +1,267 @@
+"""Tests for PolishAgent: suggestion parsing, suggest/apply flow, guided-edit gating."""
+
+from __future__ import annotations
+
+import pytest
+from PIL import Image
+
+from paperbanana.agents.polish import MAX_SUGGESTIONS, PolishAgent
+
+
+class _FakeVLM:
+    """VLM stub that records calls and returns a canned response."""
+
+    def __init__(self, response: str):
+        self.response = response
+        self.calls: list[dict] = []
+
+    async def generate(self, prompt, images=None, **kwargs):
+        self.calls.append({"prompt": prompt, "images": images, **kwargs})
+        return self.response
+
+
+class _FakeEditImageGen:
+    """Image gen stub that supports guided edits (declares an images kwarg)."""
+
+    name = "fake_edit"
+    model_name = "fake-edit-model"
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def generate(
+        self,
+        prompt,
+        negative_prompt=None,
+        width=1024,
+        height=1024,
+        seed=None,
+        aspect_ratio=None,
+        quality=None,
+        images=None,
+    ):
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "images": images,
+                "width": width,
+                "height": height,
+                "seed": seed,
+                "aspect_ratio": aspect_ratio,
+            }
+        )
+        return Image.new("RGB", (64, 48), color=(240, 240, 240))
+
+
+class _TextOnlyImageGen:
+    """Image gen stub matching the base text-to-image contract (no images kwarg)."""
+
+    name = "text_only"
+    model_name = "text-only-model"
+
+    async def generate(
+        self,
+        prompt,
+        negative_prompt=None,
+        width=1024,
+        height=1024,
+        seed=None,
+        aspect_ratio=None,
+        quality=None,
+    ):
+        return Image.new("RGB", (8, 8))
+
+
+@pytest.fixture
+def prompt_dir(tmp_path):
+    polish_dir = tmp_path / "prompts" / "polish"
+    polish_dir.mkdir(parents=True)
+    (polish_dir / "suggest.txt").write_text(
+        "STYLE GUIDE:\n{style_guide}\nMax: {max_suggestions}", encoding="utf-8"
+    )
+    (polish_dir / "apply.txt").write_text(
+        "Apply these improvements:\n{suggestions}", encoding="utf-8"
+    )
+    return str(tmp_path / "prompts")
+
+
+@pytest.fixture
+def figure(tmp_path):
+    path = tmp_path / "figure.png"
+    Image.new("RGB", (64, 48), color=(255, 255, 255)).save(path)
+    return path
+
+
+def _make_agent(prompt_dir, tmp_path, vlm_response="NO_SUGGESTIONS", image_gen=None):
+    return PolishAgent(
+        image_gen=image_gen if image_gen is not None else _FakeEditImageGen(),
+        vlm_provider=_FakeVLM(vlm_response),
+        prompt_dir=prompt_dir,
+        output_dir=str(tmp_path / "out"),
+    )
+
+
+# ── Suggestion parsing ────────────────────────────────────────────────────────
+
+
+def test_parse_suggestions_numbered_list():
+    response = "1. Use pastel fills for module backgrounds\n2) Align arrows to a grid"
+    assert PolishAgent._parse_suggestions(response) == [
+        "Use pastel fills for module backgrounds",
+        "Align arrows to a grid",
+    ]
+
+
+def test_parse_suggestions_bulleted_list():
+    response = "- Soften the box corners\n* Use sans-serif labels\n• Reserve red for the loss"
+    assert PolishAgent._parse_suggestions(response) == [
+        "Soften the box corners",
+        "Use sans-serif labels",
+        "Reserve red for the loss",
+    ]
+
+
+def test_parse_suggestions_fenced_output():
+    response = "```\n1. Use a single accent color\n2. Increase label font size\n```"
+    assert PolishAgent._parse_suggestions(response) == [
+        "Use a single accent color",
+        "Increase label font size",
+    ]
+
+
+def test_parse_suggestions_ignores_preamble_prose():
+    response = "Here are my suggestions for the figure:\n1. Use thinner arrows"
+    assert PolishAgent._parse_suggestions(response) == ["Use thinner arrows"]
+
+
+def test_parse_suggestions_strips_bold_markers():
+    response = "1. **Colors**: replace saturated red with pale blue"
+    assert PolishAgent._parse_suggestions(response) == [
+        "Colors: replace saturated red with pale blue"
+    ]
+
+
+def test_parse_suggestions_no_suggestions_sentinel():
+    assert PolishAgent._parse_suggestions("NO_SUGGESTIONS") == []
+
+
+def test_parse_suggestions_empty_and_none():
+    assert PolishAgent._parse_suggestions("") == []
+    assert PolishAgent._parse_suggestions(None) == []
+
+
+def test_parse_suggestions_caps_at_max():
+    response = "\n".join(f"{i}. Suggestion {i}" for i in range(1, 15))
+    parsed = PolishAgent._parse_suggestions(response)
+    assert len(parsed) == MAX_SUGGESTIONS
+    assert parsed[0] == "Suggestion 1"
+    assert parsed[-1] == f"Suggestion {MAX_SUGGESTIONS}"
+
+
+def test_parse_suggestions_unparseable_prose_returns_empty():
+    assert PolishAgent._parse_suggestions("The figure looks somewhat busy overall.") == []
+
+
+# ── Suggest step ──────────────────────────────────────────────────────────────
+
+
+async def test_suggest_sends_image_and_style_guide_to_vlm(prompt_dir, tmp_path):
+    agent = _make_agent(prompt_dir, tmp_path, vlm_response="1. Use pastel fills")
+    image = Image.new("RGB", (32, 32))
+
+    suggestions = await agent.suggest(image, style_guide="Pastel palettes only")
+
+    assert suggestions == ["Use pastel fills"]
+    call = agent.vlm.calls[0]
+    assert call["images"] == [image]
+    assert "Pastel palettes only" in call["prompt"]
+    assert str(MAX_SUGGESTIONS) in call["prompt"]
+
+
+# ── Apply step ────────────────────────────────────────────────────────────────
+
+
+async def test_apply_sends_original_image_and_suggestions_to_image_gen(prompt_dir, tmp_path):
+    image_gen = _FakeEditImageGen()
+    agent = _make_agent(prompt_dir, tmp_path, image_gen=image_gen)
+    image = Image.new("RGB", (64, 48))
+    output_path = str(tmp_path / "out" / "polished.png")
+
+    result = await agent.apply(
+        image,
+        ["Use pastel fills", "Align arrows"],
+        output_path=output_path,
+        aspect_ratio="16:9",
+        seed=7,
+    )
+
+    assert result == output_path
+    call = image_gen.calls[0]
+    # The original figure is the edit base
+    assert call["images"] == [image]
+    # Numbered suggestions are embedded in the edit prompt
+    assert "1. Use pastel fills" in call["prompt"]
+    assert "2. Align arrows" in call["prompt"]
+    assert call["aspect_ratio"] == "16:9"
+    assert call["seed"] == 7
+    # Dimensions default to the input figure's size
+    assert (call["width"], call["height"]) == (64, 48)
+    # Polished image is saved to disk
+    from pathlib import Path
+
+    assert Path(output_path).exists()
+
+
+async def test_apply_rejects_provider_without_guided_edit_support(prompt_dir, tmp_path):
+    agent = _make_agent(prompt_dir, tmp_path, image_gen=_TextOnlyImageGen())
+
+    with pytest.raises(RuntimeError, match="guided image editing"):
+        await agent.apply(Image.new("RGB", (8, 8)), ["x"], output_path=str(tmp_path / "p.png"))
+
+
+def test_supports_guided_edit_detection():
+    assert PolishAgent.supports_guided_edit(_FakeEditImageGen())
+    assert not PolishAgent.supports_guided_edit(_TextOnlyImageGen())
+
+
+def test_google_imagen_supports_guided_edit():
+    from paperbanana.providers.image_gen.google_imagen import GoogleImagenGen
+
+    assert PolishAgent.supports_guided_edit(GoogleImagenGen(api_key="test"))
+
+
+# ── Run orchestration ─────────────────────────────────────────────────────────
+
+
+async def test_run_suggests_then_applies(prompt_dir, tmp_path, figure):
+    image_gen = _FakeEditImageGen()
+    agent = _make_agent(
+        prompt_dir, tmp_path, vlm_response="1. Use pastel fills", image_gen=image_gen
+    )
+
+    result_path, suggestions = await agent.run(str(figure), style_guide="guide")
+
+    assert suggestions == ["Use pastel fills"]
+    assert result_path == str(tmp_path / "out" / "polished_iter_1.png")
+    assert len(image_gen.calls) == 1
+
+
+async def test_run_skips_apply_when_no_suggestions(prompt_dir, tmp_path, figure):
+    image_gen = _FakeEditImageGen()
+    agent = _make_agent(prompt_dir, tmp_path, vlm_response="NO_SUGGESTIONS", image_gen=image_gen)
+
+    result_path, suggestions = await agent.run(str(figure), style_guide="guide")
+
+    assert suggestions == []
+    assert result_path == str(figure)
+    assert image_gen.calls == []
+
+
+def test_missing_prompt_template_raises(tmp_path):
+    agent = PolishAgent(
+        image_gen=_FakeEditImageGen(),
+        vlm_provider=_FakeVLM(""),
+        prompt_dir=str(tmp_path),
+    )
+    with pytest.raises(FileNotFoundError):
+        agent._load_polish_prompt("suggest")

--- a/tests/test_cli_polish.py
+++ b/tests/test_cli_polish.py
@@ -1,0 +1,211 @@
+"""Tests for the `paperbanana polish` CLI command (network-free)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from PIL import Image
+from typer.testing import CliRunner
+
+from paperbanana.cli import app
+from paperbanana.providers.registry import ProviderRegistry
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    """rich colorizes output in CI; strip ANSI escapes before asserting."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _write_figure(path: Path) -> None:
+    Image.new("RGB", (64, 48), color=(255, 255, 255)).save(path)
+
+
+class _FakeVLM:
+    name = "fake_vlm"
+    model_name = "fake-vlm"
+    cost_tracker = None
+
+    def __init__(self, response: str = "1. Use pastel module fills\n2. Align arrows to a grid"):
+        self.response = response
+        self.calls = 0
+
+    async def generate(self, prompt, images=None, **kwargs):
+        self.calls += 1
+        return self.response
+
+
+class _FakeEditImageGen:
+    name = "fake_edit"
+    model_name = "fake-edit"
+    cost_tracker = None
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def generate(self, prompt, images=None, **kwargs):
+        self.calls.append({"prompt": prompt, "images": images})
+        return Image.new("RGB", (64, 48), color=(240, 240, 240))
+
+
+class _TextOnlyImageGen:
+    name = "text_only"
+    model_name = "text-only"
+    cost_tracker = None
+
+    async def generate(self, prompt, negative_prompt=None, width=1024, height=1024):
+        return Image.new("RGB", (8, 8))
+
+
+def _patch_providers(monkeypatch, vlm, image_gen):
+    monkeypatch.setattr(ProviderRegistry, "create_vlm", lambda settings: vlm)
+    monkeypatch.setattr(ProviderRegistry, "create_image_gen", lambda settings: image_gen)
+
+
+def test_polish_rejects_missing_input_file():
+    result = runner.invoke(app, ["polish", "--input", "/nonexistent/figure.png"])
+    assert result.exit_code == 1
+    assert "not found" in _strip_ansi(result.output)
+
+
+def test_polish_rejects_non_image_input(tmp_path):
+    bogus = tmp_path / "figure.png"
+    bogus.write_text("this is not an image", encoding="utf-8")
+
+    result = runner.invoke(app, ["polish", "--input", str(bogus)])
+    assert result.exit_code == 1
+    assert "not a readable image" in _strip_ansi(result.output)
+
+
+def test_polish_rejects_bad_venue(tmp_path):
+    figure = tmp_path / "figure.png"
+    _write_figure(figure)
+
+    result = runner.invoke(app, ["polish", "--input", str(figure), "--venue", "siggraph"])
+    assert result.exit_code == 1
+    assert "--venue must be" in _strip_ansi(result.output)
+
+
+def test_polish_rejects_text_only_image_provider(tmp_path, monkeypatch):
+    figure = tmp_path / "figure.png"
+    _write_figure(figure)
+    _patch_providers(monkeypatch, _FakeVLM(), _TextOnlyImageGen())
+
+    result = runner.invoke(app, ["polish", "--input", str(figure)])
+    assert result.exit_code == 1
+    assert "does not support guided image editing" in _strip_ansi(result.output)
+
+
+def test_polish_single_round_prints_suggestions_and_saves_output(tmp_path, monkeypatch):
+    figure = tmp_path / "figure.png"
+    _write_figure(figure)
+    output = tmp_path / "out" / "final.png"
+    vlm = _FakeVLM()
+    image_gen = _FakeEditImageGen()
+    _patch_providers(monkeypatch, vlm, image_gen)
+
+    result = runner.invoke(app, ["polish", "--input", str(figure), "--output", str(output)])
+
+    out = _strip_ansi(result.output)
+    assert result.exit_code == 0, out
+    # Suggestions are printed to the console so users see what changed
+    assert "Use pastel module fills" in out
+    assert "Align arrows to a grid" in out
+    assert "Done!" in out
+    assert output.exists()
+    # One suggest call, one apply call
+    assert vlm.calls == 1
+    assert len(image_gen.calls) == 1
+    # The apply step received the original figure as the edit base
+    assert len(image_gen.calls[0]["images"]) == 1
+    assert "1. Use pastel module fills" in image_gen.calls[0]["prompt"]
+
+
+def test_polish_iterations_repeat_suggest_apply(tmp_path, monkeypatch):
+    figure = tmp_path / "figure.png"
+    _write_figure(figure)
+    output = tmp_path / "out" / "final.png"
+    vlm = _FakeVLM()
+    image_gen = _FakeEditImageGen()
+    _patch_providers(monkeypatch, vlm, image_gen)
+
+    result = runner.invoke(
+        app,
+        ["polish", "--input", str(figure), "--output", str(output), "--iterations", "3"],
+    )
+
+    assert result.exit_code == 0, _strip_ansi(result.output)
+    assert vlm.calls == 3
+    assert len(image_gen.calls) == 3
+    assert output.exists()
+    # Intermediate round outputs land next to the final output
+    assert (tmp_path / "out" / "polished_iter_1.png").exists()
+    assert (tmp_path / "out" / "polished_iter_3.png").exists()
+
+
+def test_polish_stops_when_no_more_suggestions(tmp_path, monkeypatch):
+    figure = tmp_path / "figure.png"
+    _write_figure(figure)
+    output = tmp_path / "out" / "final.png"
+    vlm = _FakeVLM(response="NO_SUGGESTIONS")
+    image_gen = _FakeEditImageGen()
+    _patch_providers(monkeypatch, vlm, image_gen)
+
+    result = runner.invoke(
+        app,
+        ["polish", "--input", str(figure), "--output", str(output), "--iterations", "5"],
+    )
+
+    out = _strip_ansi(result.output)
+    assert result.exit_code == 0, out
+    # Suggest ran once, found nothing, and the loop stopped without editing
+    assert vlm.calls == 1
+    assert image_gen.calls == []
+    assert "already" in out
+    assert not output.exists()
+
+
+def test_polish_multi_candidate_fans_out_apply_step(tmp_path, monkeypatch):
+    figure = tmp_path / "figure.png"
+    _write_figure(figure)
+    output = tmp_path / "out" / "final.png"
+    vlm = _FakeVLM()
+    image_gen = _FakeEditImageGen()
+    _patch_providers(monkeypatch, vlm, image_gen)
+
+    result = runner.invoke(
+        app,
+        [
+            "polish",
+            "--input",
+            str(figure),
+            "--output",
+            str(output),
+            "--num-candidates",
+            "3",
+        ],
+    )
+
+    assert result.exit_code == 0, _strip_ansi(result.output)
+    # One suggest call, three parallel apply calls
+    assert vlm.calls == 1
+    assert len(image_gen.calls) == 3
+    assert output.exists()
+    for k in range(1, 4):
+        assert (tmp_path / "out" / "candidates" / f"cand_{k}" / "polished_iter_1.png").exists()
+
+
+def test_polish_help_documents_flags():
+    result = runner.invoke(
+        app,
+        ["polish", "--help"],
+        terminal_width=200,
+        color=False,
+        env={"COLUMNS": "200", "NO_COLOR": "1", "TERM": "dumb"},
+    )
+    assert result.exit_code == 0
+    out = _strip_ansi(result.output)
+    for flag in ("--input", "--venue", "--output", "--iterations", "--aspect-ratio", "--budget"):
+        assert flag in out


### PR DESCRIPTION
Fixes #238 (rollback half shipped in #243; this is polish mode).

`paperbanana polish --input figure.png` — bring your own figure:
1. **Suggest**: VLM audits the figure against the venue style guide (`--venue`, picks up `guidelines synthesize` output) and proposes ≤10 concrete improvements (robust parsing: numbered/bulleted/fenced; `NO_SUGGESTIONS` sentinel exits unchanged)
2. **Apply**: true guided edit — `GoogleImagenGen` gained an optional `images` kwarg so Gemini edits the actual figure rather than regenerating from text. Providers without guided-edit support are rejected with an actionable error (capability detected by signature; contract documented in the base class). No silent fallbacks.

`--iterations N` repeats suggest→apply; `--num-candidates` fans out the apply step in parallel; budget guard + cost summary wired like `generate`.

Design note: the issue assumed the refinement loop already passed images to image-gen — it doesn't (the loop conditions on images only via the Critic's VLM call), hence the small additive provider extension. 2K/4K upscaling is out of scope (provider-dependent, tracked separately if wanted).

26 new tests; suite at 853 passing.