### PR TITLE
docs: ground venue format facts in current official author instructions

### DIFF
--- a/data/guidelines/acl/methodology_style_guide.md
+++ b/data/guidelines/acl/methodology_style_guide.md
@@ -1,5 +1,25 @@
 # ACL Method Diagram Aesthetics Guide
 
+## Venue Format Facts (grounded)
+
+* **Layout:** Two-column. Column width 7.7 cm, with 0.6 cm between
+  columns and a column height of 24.7 cm. Wide figures may run across
+  both columns (~16.0 cm full text width).
+* **Body font:** 11 pt Times Roman (Times New Roman or Computer Modern
+  Roman if Times Roman is unavailable).
+* **Captions:** 10 pt roman type, placed below the figure, in the form
+  "Figure 1: Caption of the Figure." One-line captions are centered;
+  longer captions are left-aligned.
+* **Color/accessibility (official wording):** "To accommodate people who
+  are color-blind (as well as those printing with black-and-white
+  printers), grayscale readability is strongly encouraged. Color is not
+  forbidden, but authors should ensure that tables and figures do not
+  rely solely on color to convey critical distinctions."
+* **Margins:** All figures must fit within the page margins (2.5 cm on
+  all sides).
+
+---
+
 ## 1. The "ACL Look"
 
 ACL diagrams reflect the NLP community's preference for **narrative
@@ -104,3 +124,13 @@ the text examples embedded in diagrams.*
 **Retrieval-Augmented Generation:**
 * Document retrieval shown as a search step with ranked results.
 * Retrieved passages flowing into the generation module.
+
+---
+
+## Sources
+
+Venue format facts verified against the official ACL style files and
+ACLPUB formatting guidelines, accessed 2026-06-11:
+
+* https://github.com/acl-org/acl-style-files (formatting.md)
+* https://acl-org.github.io/ACLPUB/formatting.html

--- a/data/guidelines/acl/plot_style_guide.md
+++ b/data/guidelines/acl/plot_style_guide.md
@@ -1,5 +1,25 @@
 # ACL Statistical Plot Aesthetics Guide
 
+## Venue Format Facts (grounded)
+
+* **Layout:** Two-column. Column width 7.7 cm, with 0.6 cm between
+  columns and a column height of 24.7 cm. Wide figures may run across
+  both columns (~16.0 cm full text width).
+* **Body font:** 11 pt Times Roman (Times New Roman or Computer Modern
+  Roman if Times Roman is unavailable).
+* **Captions:** 10 pt roman type, placed below the figure, in the form
+  "Figure 1: Caption of the Figure." One-line captions are centered;
+  longer captions are left-aligned.
+* **Color/accessibility (official wording):** "To accommodate people who
+  are color-blind (as well as those printing with black-and-white
+  printers), grayscale readability is strongly encouraged. Color is not
+  forbidden, but authors should ensure that tables and figures do not
+  rely solely on color to convey critical distinctions."
+* **Margins:** All figures must fit within the page margins (2.5 cm on
+  all sides).
+
+---
+
 ## 1. The "ACL Look"
 
 ACL plots emphasize **readability and comparison**. Papers frequently
@@ -26,8 +46,9 @@ are the most common plot types.
 
 * **Grid lines:** Light grey dashed lines, behind data elements.
 * **Spines:** Boxed (all four sides) is most common in ACL papers.
-* **Axis labels:** Clear, with units. Font size must survive two-column
-  scaling (minimum 8 pt at print).
+* **Axis labels:** Clear, with units. Font size must survive scaling to
+  the 7.7 cm column width — as a reference point, ACL captions are set
+  in 10 pt type.
 
 ### **Layout & Typography**
 
@@ -73,3 +94,13 @@ are the most common plot types.
 * **Overcrowded legends** — simplify or use direct annotation.
 * **Missing significance indicators** — use asterisks or brackets
   for statistical significance where applicable.
+
+---
+
+## Sources
+
+Venue format facts verified against the official ACL style files and
+ACLPUB formatting guidelines, accessed 2026-06-11:
+
+* https://github.com/acl-org/acl-style-files (formatting.md)
+* https://acl-org.github.io/ACLPUB/formatting.html

--- a/data/guidelines/acl/venue.yaml
+++ b/data/guidelines/acl/venue.yaml
@@ -1,3 +1,6 @@
 display_name: "ACL"
-# ACL *ACL venues are two-column; compact figures read better.
+# ACL *ACL venues are two-column (7.7 cm columns); compact figures read better.
 aspect_ratio: "4:3"
+# ACL style files mandate 11 pt Times Roman for the body
+# (Times New Roman or Computer Modern Roman if unavailable).
+fonts: ["Times New Roman", "Times Roman"]

--- a/data/guidelines/icml/methodology_style_guide.md
+++ b/data/guidelines/icml/methodology_style_guide.md
@@ -1,5 +1,26 @@
 # ICML Method Diagram Aesthetics Guide
 
+## Venue Format Facts (grounded)
+
+* **Layout:** Two-column on US letter paper. Overall text area is
+  6.75 inches wide by 9.0 inches high with 0.25 inches between columns
+  (single column = 3.25 inches wide).
+* **Body font:** 10 pt Times.
+* **Captions:** Set in 9 pt type, placed below the figure with at least
+  0.1 inches of space before and after; centered unless the caption runs
+  two or more lines, in which case it is flush left. Do not include a
+  title inside the figure — the caption serves that function.
+* **Artwork:** Lines should be dark and at least 0.5 pt thick for
+  reproduction; text should not appear on a gray background. Label all
+  distinct components; graphs need a name for each axis and a legend
+  that briefly describes each curve.
+* **Wide figures:** May span both columns (`figure*`), and two-column
+  figures always go at the top or bottom of the page.
+* **Graphics format:** Vector graphics (EPS or PDF) are encouraged for
+  plots; bitmaps should be limited to illustrations.
+
+---
+
 ## 1. The "ICML Look"
 
 ICML diagrams favor **clarity and density**. The style leans toward
@@ -77,7 +98,9 @@ Each color should map to a distinct semantic role.*
 
 * **Overly wide diagrams** that lose detail when scaled to column width.
 * **Too many colors** without a legend or consistent mapping.
-* **Tiny text** that becomes unreadable at print scale (minimum 7 pt).
+* **Tiny text** that becomes unreadable when scaled to the 3.25 inch
+  column width (ICML sets figure captions in 9 pt type — figure text
+  should remain comparably legible).
 * **Inconsistent line styles** between data flow and gradient flow.
 * **Decorative elements** (shadows, gradients, 3D effects) that add
   clutter without information.
@@ -97,3 +120,13 @@ Each color should map to a distinct semantic role.*
 **Reinforcement Learning:**
 * Agent-environment loop diagrams with clear state/action/reward labels.
 * Dashed lines for policy updates, solid for environment transitions.
+
+---
+
+## Sources
+
+Venue format facts verified against the official ICML 2026 style kit
+(`icml2026.sty` / `example_paper.tex`), accessed 2026-06-11:
+
+* https://icml.cc/Conferences/2026/AuthorInstructions
+* https://media.icml.cc/Conferences/ICML2026/Styles/icml2026.zip

--- a/data/guidelines/icml/plot_style_guide.md
+++ b/data/guidelines/icml/plot_style_guide.md
@@ -1,5 +1,25 @@
 # ICML Statistical Plot Aesthetics Guide
 
+## Venue Format Facts (grounded)
+
+* **Layout:** Two-column on US letter paper. Overall text area is
+  6.75 inches wide by 9.0 inches high with 0.25 inches between columns
+  (single column = 3.25 inches wide).
+* **Body font:** 10 pt Times.
+* **Captions:** Set in 9 pt type, placed below the figure with at least
+  0.1 inches of space before and after; centered unless the caption runs
+  two or more lines, in which case it is flush left. Do not include a
+  title inside the figure — the caption serves that function.
+* **Artwork:** Lines should be dark and at least 0.5 pt thick for
+  reproduction; text should not appear on a gray background. Graphs need
+  a name for each axis and a legend that briefly describes each curve.
+* **Wide figures:** May span both columns (`figure*`), and two-column
+  figures always go at the top or bottom of the page.
+* **Graphics format:** Vector graphics (EPS or PDF) are encouraged for
+  plots; bitmaps should be limited to illustrations.
+
+---
+
 ## 1. The "ICML Look"
 
 ICML plots prioritize **precision and compactness**. The two-column
@@ -26,7 +46,8 @@ that does not encode information.
 * **Grid lines:** Light grey dashed lines behind data. Never solid black.
 * **Spines:** Either all four sides (boxed) or remove top and right
   (open). Be consistent across figures in the same paper.
-* **Tick labels:** Sans-serif, minimum 7 pt at final print size.
+* **Tick labels:** Sans-serif, sized to stay legible at the 3.25 inch
+  column width (ICML captions are 9 pt — keep tick labels comparable).
   Avoid rotated labels when horizontal fits.
 
 ### **Layout & Typography**
@@ -71,3 +92,13 @@ that does not encode information.
 * **Missing units** on axes.
 * **Rainbow colormaps** (Jet) — use perceptually uniform alternatives.
 * **Legends that obscure data** — reposition or use direct labeling.
+
+---
+
+## Sources
+
+Venue format facts verified against the official ICML 2026 style kit
+(`icml2026.sty` / `example_paper.tex`), accessed 2026-06-11:
+
+* https://icml.cc/Conferences/2026/AuthorInstructions
+* https://media.icml.cc/Conferences/ICML2026/Styles/icml2026.zip

--- a/data/guidelines/icml/venue.yaml
+++ b/data/guidelines/icml/venue.yaml
@@ -1,4 +1,6 @@
 display_name: "ICML"
-# ICML is two-column; column-width figures favor compact ratios.
+# ICML is two-column (3.25 in columns); column-width figures favor compact ratios.
 aspect_ratio: "4:3"
-fonts: ["Helvetica", "Arial"]
+# The ICML style kit mandates 10 pt Times for the paper body
+# (icml2026.sty loads the LaTeX `times` package).
+fonts: ["Times New Roman", "Times"]

--- a/data/guidelines/ieee/methodology_style_guide.md
+++ b/data/guidelines/ieee/methodology_style_guide.md
@@ -1,5 +1,27 @@
 # IEEE Method Diagram Aesthetics Guide
 
+## Venue Format Facts (grounded)
+
+* **Layout:** Two-column. One column width is 3.5 inches (88.9 mm /
+  21 picas); figures spanning both columns are 7.16 inches (182 mm /
+  43 picas) wide. Large figures may span both columns but must not
+  extend into the page margins.
+* **Body font:** 10 pt Times Roman / Times New Roman (a proportional
+  serif typeface).
+* **Captions:** Placed below figures (table heads go above tables).
+  "Fig." is abbreviated with a period after the figure number. Captions
+  and figure text are set in 8 pt type.
+* **Figure labels:** The IEEE conference template specifies 8 pt
+  Times New Roman for figure labels; use words rather than symbols or
+  abbreviations for axis labels.
+* **Resolution:** Greater than 300 dpi for color/grayscale images and
+  greater than 600 dpi for black-and-white line art; acceptable vector
+  formats are PS, EPS, and PDF.
+* **Placement:** Figures and tables go at the top or bottom of columns;
+  avoid placing them in the middle of columns.
+
+---
+
 ## 1. The "IEEE Look"
 
 IEEE diagrams follow a **formal, engineering-oriented** aesthetic.
@@ -60,8 +82,9 @@ supplementary, not the sole differentiator.*
 
 ### **D. Typography & Icons**
 
-* **Labels:** Sans-serif (Arial, Helvetica) or the paper's body font.
-  All caps for major subsystem names is common.
+* **Labels:** The paper's body font (Times New Roman / Times Roman) is
+  the safe default — the IEEE conference template sets figure labels in
+  8 pt Times New Roman. All caps for major subsystem names is common.
 * **Signal labels:** Placed directly on or adjacent to arrows.
 * **Math:** LaTeX-style variables in serif italic, consistent with
   equation numbering in the paper.
@@ -112,3 +135,14 @@ supplementary, not the sole differentiator.*
 * Network architecture as a linear chain of labeled blocks.
 * Keep the ML diagram style but with sharper corners, less color,
   and more formal labeling than NeurIPS or ICML conventions.
+
+---
+
+## Sources
+
+Venue format facts verified against official IEEE author resources,
+accessed 2026-06-11:
+
+* https://journals.ieeeauthorcenter.ieee.org/create-your-ieee-journal-article/create-graphics-for-your-article/resolution-and-size/
+* https://www.overleaf.com/latex/templates/ieee-conference-template/grfzhhncsfqn (official IEEE conference template, via https://www.ieee.org/conferences/publishing/templates)
+* https://ieee-pes.org/publications/authors-kit/preparation-of-a-formatted-technical-work/

--- a/data/guidelines/ieee/plot_style_guide.md
+++ b/data/guidelines/ieee/plot_style_guide.md
@@ -1,5 +1,28 @@
 # IEEE Statistical Plot Aesthetics Guide
 
+## Venue Format Facts (grounded)
+
+* **Layout:** Two-column. One column width is 3.5 inches (88.9 mm /
+  21 picas); figures spanning both columns are 7.16 inches (182 mm /
+  43 picas) wide. Large figures may span both columns but must not
+  extend into the page margins.
+* **Body font:** 10 pt Times Roman / Times New Roman (a proportional
+  serif typeface).
+* **Captions:** Placed below figures (table heads go above tables).
+  "Fig." is abbreviated with a period after the figure number. Captions
+  and figure text are set in 8 pt type.
+* **Figure labels:** The IEEE conference template specifies 8 pt
+  Times New Roman for figure labels; use words rather than symbols or
+  abbreviations for axis labels, with units in parentheses (e.g.,
+  "Magnetization (A/m)") — do not label axes only with units.
+* **Resolution:** Greater than 300 dpi for color/grayscale images and
+  greater than 600 dpi for black-and-white line art; acceptable vector
+  formats are PS, EPS, and PDF.
+* **Placement:** Figures and tables go at the top or bottom of columns;
+  avoid placing them in the middle of columns.
+
+---
+
 ## 1. The "IEEE Look"
 
 IEEE plots follow a **formal, print-first** aesthetic. Since many IEEE
@@ -26,13 +49,15 @@ labeling, high contrast, and conservative decoration.
 * **Grid lines:** Light grey dotted or dashed lines. Subtle but present.
 * **Spines:** Full box (all four sides) is the IEEE convention.
 * **Tick marks:** Inward-facing ticks on all active axes.
-* **Axis labels:** Include units in parentheses, e.g., "Frequency (Hz)".
-  Sans-serif font, matching the paper body.
+* **Axis labels:** Include units in parentheses, e.g., "Frequency (Hz)" —
+  never units alone. Use words rather than symbols or abbreviations.
+  Times New Roman, matching the paper body.
 
 ### **Layout & Typography**
 
-* **Font:** Sans-serif (Arial, Helvetica). Match the paper typeface.
-  Minimum 8 pt at final print size.
+* **Font:** Times New Roman, matching the IEEE body typeface — the
+  official conference template sets figure labels in 8 pt Times New
+  Roman, and captions/figure text in 8 pt type.
 * **Legends:** Boxed legends inside the plot area, or below the figure.
   Include line style and marker descriptions, not just color swatches.
 * **Figure numbering:** IEEE uses "Fig. 1." format in captions.
@@ -77,3 +102,14 @@ labeling, high contrast, and conservative decoration.
 * **Inconsistent figure style** across the paper.
 * **3D effects or shadows** — IEEE style is strictly flat and clean.
 * **Missing panel labels** in multi-panel figures.
+
+---
+
+## Sources
+
+Venue format facts verified against official IEEE author resources,
+accessed 2026-06-11:
+
+* https://journals.ieeeauthorcenter.ieee.org/create-your-ieee-journal-article/create-graphics-for-your-article/resolution-and-size/
+* https://www.overleaf.com/latex/templates/ieee-conference-template/grfzhhncsfqn (official IEEE conference template, via https://www.ieee.org/conferences/publishing/templates)
+* https://ieee-pes.org/publications/authors-kit/preparation-of-a-formatted-technical-work/

--- a/data/guidelines/ieee/venue.yaml
+++ b/data/guidelines/ieee/venue.yaml
@@ -1,4 +1,6 @@
 display_name: "IEEE"
-# Most IEEE transactions are two-column; design for column width.
+# Most IEEE publications are two-column (3.5 in columns); design for column width.
 aspect_ratio: "4:3"
-fonts: ["Arial", "Helvetica"]
+# IEEE templates set the body in 10 pt Times Roman / Times New Roman, and
+# the conference template specifies 8 pt Times New Roman for figure labels.
+fonts: ["Times New Roman", "Times Roman"]

--- a/data/guidelines/methodology_style_guide.md
+++ b/data/guidelines/methodology_style_guide.md
@@ -1,5 +1,22 @@
 # NeurIPS 2025 Method Diagram Aesthetics Guide
 
+## Venue Format Facts (grounded)
+
+* **Layout:** Single-column. All text and figures must fit within a text
+  block 5.5 inches (33 picas) wide by 9 inches (54 picas) high.
+* **Body font:** 10 pt Times (Times New Roman is the preferred typeface),
+  with 11 pt leading.
+* **Captions:** The figure number and caption always appear below the
+  figure, with one line space before the caption and one line space after
+  the figure. Captions are lower case except the first word and proper
+  nouns; figures are numbered consecutively.
+* **Artwork:** All artwork must be neat, clean, and legible; lines should
+  be dark enough for reproduction.
+* **Color:** Color figures are allowed, but figure captions and the paper
+  body should remain legible whether printed in black/white or in color.
+
+---
+
 ## 1. The "NeurIPS Look"
 
 The prevailing aesthetic for 2025 is **"Soft Tech & Scientific Pastels."**
@@ -173,3 +190,13 @@ corners are for processes.*
   representations, and distribution visualizations.
 * **Color:** Gradual color transitions to indicate progressive refinement
   or generation stages.
+
+---
+
+## Sources
+
+Venue format facts verified against the official NeurIPS 2026 style kit
+(`neurips_2026.sty` / `neurips_2026.tex`), accessed 2026-06-11:
+
+* https://neurips.cc/Conferences/2026/CallForPapers
+* https://media.neurips.cc/Conferences/NeurIPS2026/Formatting_Instructions_For_NeurIPS_2026.zip

--- a/data/guidelines/plot_style_guide.md
+++ b/data/guidelines/plot_style_guide.md
@@ -1,5 +1,22 @@
 # NeurIPS 2025 Statistical Plot Aesthetics Guide
 
+## Venue Format Facts (grounded)
+
+* **Layout:** Single-column. All text and figures must fit within a text
+  block 5.5 inches (33 picas) wide by 9 inches (54 picas) high.
+* **Body font:** 10 pt Times (Times New Roman is the preferred typeface),
+  with 11 pt leading.
+* **Captions:** The figure number and caption always appear below the
+  figure, with one line space before the caption and one line space after
+  the figure. Captions are lower case except the first word and proper
+  nouns; figures are numbered consecutively.
+* **Artwork:** All artwork must be neat, clean, and legible; lines should
+  be dark enough for reproduction.
+* **Color:** Color figures are allowed, but figure captions and the paper
+  body should remain legible whether printed in black/white or in color.
+
+---
+
 ## 1. The "NeurIPS Look": A High-Level Overview
 
 The prevailing aesthetic for 2025 is defined by **precision, accessibility,
@@ -146,3 +163,13 @@ bare-bones styling toward a more graphic, publication-ready presentation.
   distinguish groups makes the plot inaccessible to colorblind readers.
 * **Cluttered Grids:** Avoid solid black grid lines; they compete with the
   data. Always use light grey/dashed grids.
+
+---
+
+## Sources
+
+Venue format facts verified against the official NeurIPS 2026 style kit
+(`neurips_2026.sty` / `neurips_2026.tex`), accessed 2026-06-11:
+
+* https://neurips.cc/Conferences/2026/CallForPapers
+* https://media.neurips.cc/Conferences/NeurIPS2026/Formatting_Instructions_For_NeurIPS_2026.zip

--- a/tests/test_venue_packs.py
+++ b/tests/test_venue_packs.py
@@ -410,5 +410,7 @@ class TestBuiltinVenueConfigs:
             assert pack.config.aspect_ratio == "4:3", f"{name} should default to 4:3"
 
     def test_font_preferences_loaded(self):
-        assert resolve_venue("icml").config.fonts == ["Helvetica", "Arial"]
-        assert resolve_venue("ieee").config.fonts == ["Arial", "Helvetica"]
+        """Fonts mirror each venue's real body typeface (Times across the board)."""
+        assert resolve_venue("icml").config.fonts == ["Times New Roman", "Times"]
+        assert resolve_venue("ieee").config.fonts == ["Times New Roman", "Times Roman"]
+        assert resolve_venue("acl").config.fonts == ["Times New Roman", "Times Roman"]


### PR DESCRIPTION
Every measurable claim in the venue packs now traces to a primary, current source (all accessed 2026-06-11): the official NeurIPS 2026 style kit, ICML 2026 style kit, the acl-org/acl-style-files formatting guide, and IEEE Author Center / official conference template.

**Corrections this surfaced:**
- `venue.yaml` fonts were wrong for every venue: ICML/IEEE listed Helvetica/Arial, ACL had none — all four venues mandate **Times-family body fonts** (NeurIPS prefers Times New Roman; ICML loads the `times` package; ACL 11pt Times Roman; IEEE 10pt Times). Since the fonts field feeds a 'match the paper's typography' note to the generator, this was actively misleading before.
- Removed invented minimums with no official basis: ICML 'minimum 7pt' (real ICML rules: ≥0.5pt line weight, 9pt captions — now cited), ACL 'minimum 8pt' (ACL has no figure-font minimum; its actual rule is grayscale readability, now quoted verbatim).
- IEEE figure-label guidance corrected to the template's actual '8 point Times New Roman', plus the >300/600dpi resolution rules.
- Each guide gains a clean 'Venue Format Facts (grounded)' section (column geometry with exact widths, fonts, caption rules) and a 'Sources' section with URLs + access date at the bottom.

What was deliberately NOT touched: corpus-derived aesthetic prose (palettes, arrow semantics, shape conventions) — that's design guidance, not venue law.

Test pins updated to the grounded font values; suite at 909 passing.