### PR TITLE
chore: v0.3.0 release prep

### DIFF
--- a/paperbanana/__init__.py
+++ b/paperbanana/__init__.py
@@ -7,7 +7,7 @@ if sys.platform == "win32":
         if hasattr(_stream, "reconfigure"):
             _stream.reconfigure(encoding="utf-8", errors="replace")
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 from paperbanana.core.pipeline import PaperBananaPipeline
 from paperbanana.core.types import DiagramType, GenerationInput, GenerationOutput

--- a/paperbanana/providers/registry.py
+++ b/paperbanana/providers/registry.py
@@ -36,7 +36,8 @@ _API_KEY_HINTS = {
     "ATLASCLOUD_API_KEY": (
         "ATLASCLOUD_API_KEY not found.\n\n"
         "To fix this:\n"
-        "  1. Get an API key at: https://www.atlascloud.ai/console/api-keys\n"
+        "  1. Get an API key at: "
+        "https://www.atlascloud.ai/console/api-keys?utm_source=github&utm_medium=link&utm_campaign=paperbanana\n"
         "  2. Set the environment variable:\n\n"
         "  export ATLASCLOUD_API_KEY=your-key-here"
     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "paperbanana"
-version = "0.2.0"
+version = "0.3.0"
 description = "Agentic framework for automated academic illustration generation"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.llmsresearch/paperbanana",
   "title": "PaperBanana",
   "description": "Generate academic diagrams and statistical plots from text using multi-agent AI.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "paperbanana",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Version bumps to 0.3.0 across pyproject/package/server.json (the release workflow enforces consistency), plus UTM tracking on the Atlas Cloud api-keys CLI hint — the last bare marketing-relevant link, and the highest-intent one (shown when a user is about to create an Atlas key).