### PR TITLE
docs: add SPONSORS.md

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,98 @@
+# Sponsoring PaperBanana
+
+PaperBanana is open-source software, released under the MIT License and developed by **LLMs Research Inc.** We rely on sponsors to keep the project moving — compute credits to test new providers, time to ship new features, and infrastructure for public demos and benchmarks.
+
+If your company builds AI infrastructure, sells inference, or wants to reach the ML researchers and applied AI engineers who use PaperBanana every day, we'd like to work with you.
+
+---
+
+## Current sponsors
+
+### Featured Partners
+*Slot available — be the first.*
+
+### Compute Sponsors
+- **Atlas Cloud** — full-modal AI inference platform. Sponsors API credits powering PaperBanana's CI, demos, and integration testing. [atlascloud.ai](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=paperbanana)
+
+### Supported Providers
+PaperBanana ships with first-class support for OpenAI, Azure OpenAI / Foundry, Google Gemini, OpenRouter, Anthropic, AWS Bedrock, Ollama, and Atlas Cloud. See the [Providers](README.md#providers) section of the README.
+
+---
+
+## Sponsorship tiers
+
+We offer three sponsorship tiers plus a separate research-compute grant track. All sponsorships are **non-exclusive within their tier** — multiple partners can hold the same tier at the same time. Sponsorship does not influence project direction, evaluation results, or default provider selection.
+
+### Featured Partner
+For companies that want PaperBanana to be a meaningful distribution and credibility channel for their product.
+
+Includes:
+- Logo and one-line description in the README **Featured Partners** block (above-the-fold, immediately under the hero image).
+- One **dedicated technical case study** per year on the LLMs Research newsletter (13,000+ ML researchers and AI engineers). We implement a recent paper using your infrastructure and publish the setup, evaluation, and results. You get a technical review pass for accuracy; you may reuse the write-up on your own channels.
+- Two additional mentions in the LLMs Research newsletter over the sponsorship year.
+- 1–3 posts on the [@llmsresearch](https://x.com/llmsresearch) X account tied to the case study or related research.
+- Listed on the LLMs Research sponsors page at [llmsresearch.com](https://llmsresearch.com).
+- Priority on integration review and bug triage for your provider.
+
+### Compute Sponsor
+For infrastructure and inference providers that integrate with PaperBanana as a supported provider.
+
+Includes:
+- Logo in the README **Compute Sponsors** grid.
+- Dedicated integration guide under `docs/providers/` with setup, supported models, and pricing notes.
+- One launch announcement on the [@llmsresearch](https://x.com/llmsresearch) X account when your integration ships.
+- Mention in the release notes for the version that includes your provider.
+
+### Supported Provider
+For community contributors and providers that integrate via a pull request without commercial sponsorship.
+
+Includes:
+- Listing in the README providers table.
+- Community-maintained integration page under `docs/providers/`.
+- No marketing placement, social posts, or newsletter mentions.
+
+### Research Compute Grant *(separate track)*
+For cloud and inference providers with a research budget rather than a marketing budget.
+
+PaperBanana runs research projects — specialized model training, open benchmarks, and reproducibility studies. A research compute grant typically funds one such project in exchange for:
+- Acknowledgement as the compute partner in the published research, the model card, and any associated blog posts.
+- Workshop or arXiv co-mention where appropriate.
+- A technical write-up of the work running on your infrastructure.
+
+Research grants are negotiated per project and have a separate budget profile from marketing sponsorships. Many teams find this an easier internal sell than a marketing line item.
+
+---
+
+## What sponsorship does not buy
+
+To keep PaperBanana trustworthy as an open project, the following are off the table at every tier:
+
+- **Influence over the default provider.** The default `vlm_provider` and `image_provider` in `configs/config.yaml` are chosen on technical merit and free-tier accessibility, not sponsorship.
+- **Removal or burial of competing providers.** Every supported provider gets equal listing in the providers table.
+- **Editorial control over evaluation results.** When PaperBanana publishes benchmarks or case studies, the numbers are the numbers. Sponsors may review for technical accuracy; they cannot require changes that misrepresent results.
+- **Exclusivity beyond your tier.** Featured Partners share the Featured Partners block with any other Featured Partners.
+- **Hidden integrations.** All sponsor relationships are listed publicly on this page.
+
+---
+
+## How to sponsor
+
+Email **dip@llmsresearch.com** with:
+
+1. The tier you're interested in (or "let's talk" if you're not sure).
+2. A short description of your product and what success looks like for you (developer signups, integration mentions, research output, etc.).
+3. Your budget profile if you have one — marketing budget, research compute grant, credits in lieu of cash, or a mix. All are workable.
+
+We'll respond within two business days with a proposal and next steps. Sponsorships are typically structured as annual agreements; shorter pilots are available for first-time sponsors.
+
+Pricing varies by tier, term length, and the specific deliverables you need. We do not publish a fixed rate card because every partnership looks slightly different, and we'd rather match the structure to your goals than force you into a template.
+
+---
+
+## About LLMs Research
+
+PaperBanana is a project of **LLMs Research Inc.**, an applied AI research lab focused on reproducible research and practical code for ML researchers and AI engineers.
+
+- Newsletter: [llmsresearch.com](https://llmsresearch.com) — 13,000+ subscribers
+- X: [@llmsresearch](https://x.com/llmsresearch)
+- Contact: **dip@llmsresearch.com**


### PR DESCRIPTION
## What

Adds `SPONSORS.md`, the project sponsorship doc (sponsorship tiers, what sponsorship does **not** buy, how to sponsor).

## Why

`CONTRIBUTING.md` already references `SPONSORS.md` ("a sponsorship that funds its maintenance — see SPONSORS.md"), but the file was never committed — leaving a dangling link in the repo. This adds it alongside the other top-level docs (README, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT).

No code changes.