### PR TITLE
feat(benchmark): separate judge VLM from pipeline VLM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,10 +22,18 @@ OPENAI_IMAGE_MODEL=gpt-image-1.5
 ATLASCLOUD_API_KEY=
 ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
 # Default validated Atlas chat model from the rollout pool.
+# NOTE: DeepSeek-V3 is text-only. The full pipeline (Critic) and the benchmark
+# judge need a vision model, e.g. qwen/qwen3-vl-30b-a3b-instruct.
 ATLASCLOUD_VLM_MODEL=deepseek-ai/DeepSeek-V3-0324
 ATLASCLOUD_IMAGE_BASE_URL=https://api.atlascloud.ai/api/v1
 # Recommended Atlas image default for PaperBanana.
 ATLASCLOUD_IMAGE_MODEL=openai/gpt-image-2/text-to-image
+
+# ── Benchmark judge (optional) ─────────────────────────────────────
+# Use a different (stronger) VLM for the benchmark judge than for the
+# generation pipeline. Both default to the pipeline VLM when unset.
+# JUDGE_VLM_PROVIDER=atlas
+# JUDGE_VLM_MODEL=Qwen/Qwen3-VL-235B-A22B-Instruct
 
 # Google Gemini (free, no credit card): https://makersuite.google.com/app/apikey
 GOOGLE_API_KEY=

--- a/paperbanana/cli.py
+++ b/paperbanana/cli.py
@@ -3542,6 +3542,16 @@ def benchmark(
         None, "--image-provider", help="Image gen provider"
     ),
     image_model: Optional[str] = typer.Option(None, "--image-model", help="Image gen model name"),
+    judge_provider: Optional[str] = typer.Option(
+        None,
+        "--judge-provider",
+        help="VLM provider for the judge (defaults to the pipeline VLM provider)",
+    ),
+    judge_model: Optional[str] = typer.Option(
+        None,
+        "--judge-model",
+        help="VLM model for the judge (defaults to the pipeline VLM model)",
+    ),
     iterations: Optional[int] = typer.Option(
         None, "--iterations", "-n", help="Refinement iterations per entry"
     ),
@@ -3629,6 +3639,10 @@ def benchmark(
         overrides["image_provider"] = image_provider
     if image_model:
         overrides["image_model"] = image_model
+    if judge_provider:
+        overrides["judge_vlm_provider"] = judge_provider
+    if judge_model:
+        overrides["judge_vlm_model"] = judge_model
     if iterations is not None:
         overrides["refinement_iterations"] = iterations
     if auto:

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -127,6 +127,10 @@ class Settings(BaseSettings):
     # Benchmark settings
     benchmark_concurrency: int = 1
 
+    # Judge settings (benchmark/evaluation VLM; defaults to the pipeline VLM)
+    judge_vlm_provider: Optional[str] = Field(default=None, alias="JUDGE_VLM_PROVIDER")
+    judge_vlm_model: Optional[str] = Field(default=None, alias="JUDGE_VLM_MODEL")
+
     # API Keys (loaded from environment)
     google_api_key: Optional[str] = Field(default=None, alias="GOOGLE_API_KEY")
     openrouter_api_key: Optional[str] = Field(default=None, alias="OPENROUTER_API_KEY")
@@ -315,6 +319,8 @@ def _flatten_yaml(config: dict, prefix: str = "") -> dict:
     key_map = {
         "vlm.provider": "vlm_provider",
         "vlm.model": "vlm_model",
+        "judge.provider": "judge_vlm_provider",
+        "judge.model": "judge_vlm_model",
         "image.provider": "image_provider",
         "image.model": "image_model",
         "image.quality": "image_quality",

--- a/paperbanana/evaluation/benchmark.py
+++ b/paperbanana/evaluation/benchmark.py
@@ -209,7 +209,12 @@ class BenchmarkRunner:
     def _default_judge_factory(self, settings: Settings) -> VLMJudge:
         from paperbanana.core.utils import find_prompt_dir
 
-        vlm = ProviderRegistry.create_vlm(settings)
+        judge_settings = settings
+        if settings.judge_vlm_provider:
+            judge_settings = settings.model_copy(
+                update={"vlm_provider": settings.judge_vlm_provider}
+            )
+        vlm = ProviderRegistry.create_vlm(judge_settings, model_override=settings.judge_vlm_model)
         return VLMJudge(vlm, prompt_dir=find_prompt_dir())
 
     def _default_visualizer_factory(self, settings: Settings) -> VisualizerAgent:

--- a/paperbanana/providers/registry.py
+++ b/paperbanana/providers/registry.py
@@ -87,8 +87,24 @@ class ProviderRegistry:
     """Factory for creating VLM and image generation providers from config."""
 
     @staticmethod
-    def create_vlm(settings: Settings) -> VLMProvider:
-        """Create a VLM provider based on settings."""
+    def create_vlm(settings: Settings, model_override: str | None = None) -> VLMProvider:
+        """Create a VLM provider based on settings.
+
+        ``model_override`` takes precedence over both the provider-specific
+        model fields (e.g. ``atlascloud_vlm_model``) and ``vlm_model``.
+        """
+        if model_override:
+            settings = settings.model_copy(
+                update={
+                    "vlm_model": model_override,
+                    "google_vlm_model": None,
+                    "openai_vlm_model": None,
+                    "atlascloud_vlm_model": None,
+                    "bedrock_vlm_model": None,
+                    "ollama_model": None,
+                    "litellm_model": None,
+                }
+            )
         provider = settings.vlm_provider.lower()
         logger.info("Creating VLM provider", provider=provider, model=settings.effective_vlm_model)
 

--- a/tests/test_evaluation/test_benchmark.py
+++ b/tests/test_evaluation/test_benchmark.py
@@ -544,3 +544,52 @@ async def test_vanilla_mode_single_visualizer_call(tmp_path):
     assert entry_result.iteration_count == 1
     assert report.mode == "vanilla"
     assert report.split == "test"
+
+
+# ── judge provider/model separation ──────────────────────────────
+
+
+def _atlas_settings(**overrides) -> Settings:
+    kwargs = {
+        "vlm_provider": "atlas",
+        "atlascloud_api_key": "test-atlas-key",
+        "atlascloud_vlm_model": "qwen/qwen3-vl-30b-a3b-instruct",
+        "judge_vlm_provider": None,
+        "judge_vlm_model": None,
+    }
+    kwargs.update(overrides)
+    return Settings(**kwargs)
+
+
+def test_judge_factory_defaults_to_pipeline_vlm():
+    settings = _atlas_settings()
+    runner = BenchmarkRunner(settings)
+    judge = runner._default_judge_factory(settings)
+
+    assert judge.vlm.name == "atlas"
+    assert judge.vlm.model_name == "qwen/qwen3-vl-30b-a3b-instruct"
+
+
+def test_judge_factory_uses_judge_model_override():
+    settings = _atlas_settings(judge_vlm_model="Qwen/Qwen3-VL-235B-A22B-Instruct")
+    runner = BenchmarkRunner(settings)
+    judge = runner._default_judge_factory(settings)
+
+    assert judge.vlm.name == "atlas"
+    assert judge.vlm.model_name == "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    # Pipeline settings are untouched.
+    assert settings.atlascloud_vlm_model == "qwen/qwen3-vl-30b-a3b-instruct"
+
+
+def test_judge_factory_uses_judge_provider_override():
+    settings = _atlas_settings(
+        judge_vlm_provider="openai",
+        judge_vlm_model="gpt-5.2",
+        openai_api_key="test-openai-key",
+        openai_vlm_model=None,
+    )
+    runner = BenchmarkRunner(settings)
+    judge = runner._default_judge_factory(settings)
+
+    assert judge.vlm.name == "openai"
+    assert judge.vlm.model_name == "gpt-5.2"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -761,6 +761,24 @@ def test_openai_vlm_falls_back_to_vlm_model():
     assert vlm.model_name == "gpt-5.2"
 
 
+def test_create_vlm_model_override_beats_provider_specific_model():
+    """create_vlm(model_override=...) wins over provider-specific model fields."""
+    from paperbanana.providers.registry import ProviderRegistry
+    from paperbanana.providers.vlm.atlas import AtlasVLM
+
+    settings = Settings(
+        vlm_provider="atlas",
+        atlascloud_api_key="test-atlas-key",
+        atlascloud_vlm_model="qwen/qwen3-vl-30b-a3b-instruct",
+    )
+    vlm = ProviderRegistry.create_vlm(settings, model_override="Qwen/Qwen3-VL-235B-A22B-Instruct")
+
+    assert isinstance(vlm, AtlasVLM)
+    assert vlm.model_name == "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    # The original settings object is not mutated.
+    assert settings.atlascloud_vlm_model == "qwen/qwen3-vl-30b-a3b-instruct"
+
+
 def test_openai_imagen_provider_creation():
     """Registry creates OpenAIImageGen with correct model and base_url."""
     from paperbanana.providers.image_gen.openai_imagen import OpenAIImageGen


### PR DESCRIPTION
## What

Adds the ability to run the benchmark judge on a **different model** than the generation pipeline:

- New CLI flags `--judge-provider` / `--judge-model` on `paperbanana benchmark`.
- New settings `judge_vlm_provider` / `judge_vlm_model` (env: `JUDGE_VLM_PROVIDER` / `JUDGE_VLM_MODEL`, plus `judge.*` YAML keys).
- `ProviderRegistry.create_vlm()` gains a `model_override` param that takes precedence over provider-specific and generic model fields, without mutating the passed settings.
- The benchmark judge factory swaps provider/model when configured; pipeline settings are untouched.

## Why

The judge and the generation pipeline previously shared one VLM, so `--vlm-provider` changed both. Separating them lets you pair a cheap pipeline model with a stronger, independent judge (and keeps the judge fixed when comparing pipeline variants).

## Tests

New coverage in `test_benchmark.py` (judge defaults to pipeline VLM; uses judge model/provider override; pipeline settings unchanged) and `test_features.py` (`model_override` precedence, no settings mutation). Full affected suites green (66 passed).

Backwards compatible: both new settings default to `None`, preserving existing behavior.