### PR TITLE
chore: gitignore wiki-temp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ env/
 .DS_Store
 Thumbs.db
 
+# Local clone of the GitHub wiki (https://github.com/llmsresearch/paperbanana.wiki.git)
+wiki-temp/
+
 # Outputs and generated images
 outputs/
 run_*/


### PR DESCRIPTION
Ignores `wiki-temp/`, a local clone of the GitHub wiki (`paperbanana.wiki.git`). It was showing as untracked and risked being committed by accident. No functional changes.