### PR TITLE
fix: default Gemini VLM model errors out, override to gemini-flash-latest

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -4,7 +4,7 @@
 # Provider settings
 vlm:
   provider: gemini
-  model: gemini-2.5-flash
+  model: gemini-flash-latest
 
 image:
   provider: google_imagen

--- a/paperbanana/core/config.py
+++ b/paperbanana/core/config.py
@@ -23,7 +23,7 @@ class VLMConfig(BaseSettings):
     """VLM provider configuration."""
 
     provider: str = "gemini"
-    model: str = "gemini-2.5-flash"
+    model: str = "gemini-flash-latest"
 
 
 class ImageConfig(BaseSettings):
@@ -64,7 +64,7 @@ class Settings(BaseSettings):
 
     # Provider settings
     vlm_provider: str = Field(default="gemini", alias="VLM_PROVIDER")
-    vlm_model: str = Field(default="gemini-2.5-flash", alias="VLM_MODEL")
+    vlm_model: str = Field(default="gemini-flash-latest", alias="VLM_MODEL")
     image_provider: str = Field(default="google_imagen", alias="IMAGE_PROVIDER")
     image_model: str = Field(default="gemini-3-pro-image-preview", alias="IMAGE_MODEL")
 


### PR DESCRIPTION
## Summary
- `configs/config.yaml` defaults `vlm.model` to `gemini-2.5-flash`, which errors out when used as the VLM backend.
- Switches the default to `gemini-flash-latest`, which works.

## Test plan
- [x] Ran PaperBanana MCP locally with `gemini-2.5-flash` — reproduced the VLM error.
- [x] Switched to `gemini-flash-latest` — VLM calls succeed.