### PR TITLE
Link free visual cards and restore Typer test compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ An agentic framework for generating publication-quality academic diagrams and st
   <img src="assets/img/hero_image.png" alt="PaperBanana takes paper as input and provide diagram as output" style="max-width: 960px; width: 100%; height: auto;"/>
 </p>
 
+**Learning LLM concepts?** We also publish [211 free visual cards](https://github.com/llmsresearch/llm-flashcards)
+on attention, RAG, agents, and inference.
+[Read them online](https://llmsresearch.com/cards?utm_source=github&utm_medium=referral&utm_campaign=visual_library&utm_content=paperbanana-readme).
+
 ## Atlas Cloud
 
 <p align="center">

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -694,7 +694,7 @@ def test_ablate_retrieval_writes_report(monkeypatch):
         Path(report_path).unlink(missing_ok=True)
 
 
-def test_setup_official_api_flow_writes_key_and_clears_base_url(monkeypatch):
+def test_setup_official_api_flow_writes_key_and_clears_base_url(tmp_path, monkeypatch):
     """Official setup flow writes key and resets GOOGLE_BASE_URL to default."""
     answers = iter(
         [
@@ -705,15 +705,15 @@ def test_setup_official_api_flow_writes_key_and_clears_base_url(monkeypatch):
     )
     monkeypatch.setattr("paperbanana.cli.Prompt.ask", lambda *args, **kwargs: next(answers))
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(app, ["setup"])
-        assert result.exit_code == 0
-        env_text = Path(".env").read_text(encoding="utf-8")
-        assert "GOOGLE_API_KEY=test-gemini-key" in env_text
-        assert "GOOGLE_BASE_URL=" in env_text
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["setup"])
+    assert result.exit_code == 0
+    env_text = Path(".env").read_text(encoding="utf-8")
+    assert "GOOGLE_API_KEY=test-gemini-key" in env_text
+    assert "GOOGLE_BASE_URL=" in env_text
 
 
-def test_setup_updates_existing_env_without_overwrite(monkeypatch):
+def test_setup_updates_existing_env_without_overwrite(tmp_path, monkeypatch):
     """setup updates target keys while preserving unrelated existing env vars."""
     answers = iter(
         [
@@ -724,20 +724,20 @@ def test_setup_updates_existing_env_without_overwrite(monkeypatch):
     )
     monkeypatch.setattr("paperbanana.cli.Prompt.ask", lambda *args, **kwargs: next(answers))
 
-    with runner.isolated_filesystem():
-        Path(".env").write_text(
-            "OPENAI_API_KEY=existing-openai-key\nGOOGLE_API_KEY=old-key\n",
-            encoding="utf-8",
-        )
-        result = runner.invoke(app, ["setup"])
-        assert result.exit_code == 0
-        env_text = Path(".env").read_text(encoding="utf-8")
-        assert "OPENAI_API_KEY=existing-openai-key" in env_text
-        assert "GOOGLE_API_KEY=new-gemini-key" in env_text
-        assert "GOOGLE_BASE_URL=" in env_text
+    monkeypatch.chdir(tmp_path)
+    Path(".env").write_text(
+        "OPENAI_API_KEY=existing-openai-key\nGOOGLE_API_KEY=old-key\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["setup"])
+    assert result.exit_code == 0
+    env_text = Path(".env").read_text(encoding="utf-8")
+    assert "OPENAI_API_KEY=existing-openai-key" in env_text
+    assert "GOOGLE_API_KEY=new-gemini-key" in env_text
+    assert "GOOGLE_BASE_URL=" in env_text
 
 
-def test_setup_custom_endpoint_flow_writes_url_and_key(monkeypatch):
+def test_setup_custom_endpoint_flow_writes_url_and_key(tmp_path, monkeypatch):
     """Custom endpoint setup flow writes both GOOGLE_BASE_URL and GOOGLE_API_KEY."""
     answers = iter(
         [
@@ -748,15 +748,15 @@ def test_setup_custom_endpoint_flow_writes_url_and_key(monkeypatch):
     )
     monkeypatch.setattr("paperbanana.cli.Prompt.ask", lambda *args, **kwargs: next(answers))
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(app, ["setup"])
-        assert result.exit_code == 0
-        env_text = Path(".env").read_text(encoding="utf-8")
-        assert "GOOGLE_API_KEY=key-custom" in env_text
-        assert "GOOGLE_BASE_URL=https://gemini-proxy.example.com" in env_text
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["setup"])
+    assert result.exit_code == 0
+    env_text = Path(".env").read_text(encoding="utf-8")
+    assert "GOOGLE_API_KEY=key-custom" in env_text
+    assert "GOOGLE_BASE_URL=https://gemini-proxy.example.com" in env_text
 
 
-def test_setup_custom_endpoint_requires_non_empty_url(monkeypatch):
+def test_setup_custom_endpoint_requires_non_empty_url(tmp_path, monkeypatch):
     """Custom endpoint flow re-prompts when URL is empty."""
     answers = iter(
         [
@@ -768,12 +768,12 @@ def test_setup_custom_endpoint_requires_non_empty_url(monkeypatch):
     )
     monkeypatch.setattr("paperbanana.cli.Prompt.ask", lambda *args, **kwargs: next(answers))
 
-    with runner.isolated_filesystem():
-        result = runner.invoke(app, ["setup"])
-        assert result.exit_code == 0
-        assert "URL cannot be empty" in result.output
-        env_text = Path(".env").read_text(encoding="utf-8")
-        assert "GOOGLE_BASE_URL=https://gemini-proxy.example.com" in env_text
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["setup"])
+    assert result.exit_code == 0
+    assert "URL cannot be empty" in result.output
+    env_text = Path(".env").read_text(encoding="utf-8")
+    assert "GOOGLE_BASE_URL=https://gemini-proxy.example.com" in env_text
 
 
 def test_batch_resume_retry_failed(tmp_path, monkeypatch):

--- a/tests/test_pdf_dep_check.py
+++ b/tests/test_pdf_dep_check.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import builtins
 from pathlib import Path
 
-import click
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from paperbanana.cli import _check_pdf_dep, _require_pdf_dep, app
@@ -39,7 +39,7 @@ def block_gradio(monkeypatch):
 
 
 def test_require_pdf_dep_exits_when_fitz_missing(block_fitz):
-    with pytest.raises(click.exceptions.Exit) as exc_info:
+    with pytest.raises(typer.Exit) as exc_info:
         _require_pdf_dep()
     assert exc_info.value.exit_code == 1
 


### PR DESCRIPTION
Readers can now find LLMs Research's 211 free visual cards from the README introduction, with links to the public repository and online reader. The reader link has a distinct attribution tag so we can measure visits from this placement.

The existing CI tests also fail with Typer 0.27.2: four setup tests call the removed `CliRunner.isolated_filesystem()` helper, and the PDF dependency test expects Click's exception instead of the `typer.Exit` raised by the CLI. Use pytest's temporary-directory fixtures and assert the public Typer exception while preserving all existing behavioral assertions. Application code and dependencies are unchanged.

Validation: the reader link returns HTTP 200 with the correct canonical URL, and the card count matches the public collection. The existing CI matrix covers the test compatibility changes.
